### PR TITLE
Occurrences counts in taxon pages

### DIFF
--- a/classes/TaxonProfile.php
+++ b/classes/TaxonProfile.php
@@ -704,7 +704,6 @@ class TaxonProfile extends Manager {
   {
     $count = -1;
     if ($taxonRank >= $limitRank) {
-      $sql = 'SELECT COUNT(occid) FROM omoccurrences WHERE tidinterpreted = '.$tid.'';
       $sql = 'SELECT COUNT(o.occid) FROM omoccurrences o JOIN (SELECT DISTINCT e.tid, t.sciname FROM taxaenumtree e JOIN taxa t ON e.tid = t.tid WHERE parenttid = '.$tid.' OR e.tid = '.$tid.') AS parentAndChildren ON o.tidinterpreted = parentAndChildren.tid;';
       if ($collids != "all") {
         $collidsStr = implode(",",$collids);

--- a/classes/TaxonProfile.php
+++ b/classes/TaxonProfile.php
@@ -693,9 +693,11 @@ class TaxonProfile extends Manager {
 	}
 
   //Gets occurrence counts of taxon in portal, to use in taxon profile
+  //Searches for taxon and all its children
   public function getOccTaxonInDbCnt($tid, $collids = "all")
   {
     $sql = 'SELECT COUNT(occid) FROM omoccurrences WHERE tidinterpreted = '.$tid.'';
+    $sql = 'SELECT COUNT(o.occid) FROM omoccurrences o JOIN (SELECT DISTINCT e.tid, t.sciname FROM taxaenumtree e JOIN taxa t ON e.tid = t.tid WHERE parenttid = '.$tid.' OR e.tid = '.$tid.') AS parentAndChildren ON o.tidinterpreted = parentAndChildren.tid;';
     if ($collids != "all") {
       $collidsStr = implode(",",$collids);
       $sql .= ' AND collid IN ('.$collidsStr.')';

--- a/classes/TaxonProfile.php
+++ b/classes/TaxonProfile.php
@@ -724,17 +724,18 @@ class TaxonProfile extends Manager {
    * Returns link for specimen search (by taxon) if number of occurrences
    * is within declared limit
    * $tid INTEGER taxon id
+   * $searchUrl STRING customizable in taxon profile page
    * $limitOccs INTEGER max number of occurrences in a search
    */
   public function getSearchByTaxon($numOccs, $searchUrl, $limitOccs = 200000)
   {
     $occMsg = '';
     if ((1 <= $numOccs) && ($numOccs <= $limitOccs)) {
-      $occMsg = '<p><a class="btn" href="'.$searchUrl.'" target="_blank">Explore '.$numOccs.' occurrences</a><p>';
+      $occMsg = '<a class="btn" href="'.$searchUrl.'" target="_blank">Explore '.$numOccs.' occurrences</a>';
     } elseif ($numOccs > $limitOccs) {
-      $occMsg = '<p>'.$numOccs.' occurrences</p>';
+      $occMsg = ''.$numOccs.' occurrences';
     } elseif ($numOccs == 0) {
-      $occMsg = '<p>No occurrences found</p>';
+      $occMsg = 'No occurrences found';
     } elseif ($numOccs == -1) {
       $occMsg = '';
     }

--- a/classes/TaxonProfile.php
+++ b/classes/TaxonProfile.php
@@ -698,14 +698,15 @@ class TaxonProfile extends Manager {
    * Checks taxon rank; counts turned off by default for anything above genus
    * $tid INTEGER taxon id
    * $taxonRank INTEGER taxon rank according to taxonunits table
-   * $limitRank INTEGER 
+   * $limitRank INTEGER
+   * $collids ARRAY of collids to include in search
    */
-  public function getOccTaxonInDbCnt($tid, $taxonRank, $limitRank = "170", $collids = "all")
+  public function getOccTaxonInDbCnt($tid, $taxonRank, $limitRank = 170, $collids = array("all"))
   {
     $count = -1;
     if ($taxonRank >= $limitRank) {
-      $sql = 'SELECT COUNT(o.occid) FROM omoccurrences o JOIN (SELECT DISTINCT e.tid, t.sciname FROM taxaenumtree e JOIN taxa t ON e.tid = t.tid WHERE parenttid = '.$tid.' OR e.tid = '.$tid.') AS parentAndChildren ON o.tidinterpreted = parentAndChildren.tid;';
-      if ($collids != "all") {
+      $sql = 'SELECT COUNT(o.occid) FROM omoccurrences o JOIN (SELECT DISTINCT e.tid, t.sciname FROM taxaenumtree e JOIN taxa t ON e.tid = t.tid WHERE parenttid = '.$tid.' OR e.tid = '.$tid.') AS parentAndChildren ON o.tidinterpreted = parentAndChildren.tid';
+      if ($collids[0] != "all") {
         $collidsStr = implode(",",$collids);
         $sql .= ' AND collid IN ('.$collidsStr.')';
       }

--- a/classes/TaxonProfile.php
+++ b/classes/TaxonProfile.php
@@ -692,6 +692,22 @@ class TaxonProfile extends Manager {
 		return $retArr;
 	}
 
+  //Gets occurrence counts of taxon in portal, to use in taxon profile
+  public function getOccTaxonInDbCnt($tid, $collids = "all")
+  {
+    $sql = 'SELECT COUNT(occid) FROM omoccurrences WHERE tidinterpreted = '.$tid.'';
+    if ($collids != "all") {
+      $collidsStr = implode(",",$collids);
+      $sql .= ' AND collid IN ('.$collidsStr.')';
+    }
+  $result = $this->conn->query($sql);
+  while ($row = $result->fetch_row()){
+    $count = $row;
+  }
+  $result->free();
+  return $count[0];
+  }
+
 	//Setters and getters
 	public function getTid(){
 		return $this->tid;

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -88,7 +88,6 @@ if($SYMB_UID){
 	<script src="../js/symb/taxa.editor.js?ver=202101" type="text/javascript"></script>
 </head>
 <body>
-  <?php echo $occs ?>
 <?php
 $displayLeftMenu = false;
 include($SERVER_ROOT.'/includes/header.php');

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -35,6 +35,10 @@ elseif($taxonValue){
 if($lang) $lang = $taxonManager->setLanguage($lang);
 if($pid === '' && isset($DEFAULT_PROJ_ID) && $DEFAULT_PROJ_ID) $pid = $DEFAULT_PROJ_ID;
 
+$occs = $taxonManager->getOccTaxonInDbCnt($tid);
+$scinameStr = $taxonManager->getTaxonName();
+$occSrcUrl = $CLIENT_ROOT.'/collections/list.php?db=all&includeothercatnum=1&taxa='.$scinameStr.'&usethes=1';
+
 $links = $taxonManager->getTaxaLinks();
 if($links){
 	foreach($links as $linkKey => $linkUrl){
@@ -80,6 +84,7 @@ if($SYMB_UID){
 	<script src="../js/symb/taxa.editor.js?ver=202101" type="text/javascript"></script>
 </head>
 <body>
+  <?php echo $occs ?>
 <?php
 $displayLeftMenu = false;
 include($SERVER_ROOT.'/includes/header.php');
@@ -111,6 +116,11 @@ include($SERVER_ROOT.'/includes/header.php');
 							<?php
 							$parentLink = 'index.php?tid='.$taxonManager->getParentTid().'&clid='.$clid.'&pid='.$pid.'&taxauthid='.$taxAuthId;
 							echo '&nbsp;<a href="'.$parentLink.'"><img class="navIcon" src="../images/toparent.png" title="Go to Parent" /></a>';
+              if($occs > 0){
+                echo '<p><a class="btn" href="'.$occSrcUrl.'">Explore '.$occs.' occurrences</a></p>';
+              } elseif($occs == 0){
+                echo '<p>No occurrences found</p>';
+              }
 							if($taxonManager->isForwarded()){
 						 		echo '<span id="redirectedfrom"> ('.(isset($LANG['REDIRECT'])?$LANG['REDIRECT']:'redirected from').': <i>'.$taxonManager->getSubmittedValue('sciname').'</i> '.$taxonManager->getSubmittedValue('author').')</span>';
 						 	}
@@ -268,6 +278,13 @@ include($SERVER_ROOT.'/includes/header.php');
 							}
 							echo '<div id="taxon">'.$displayName.'</div>';
 							?>
+              <?php 
+                if($occs > 0){
+                  echo '<p><a class="btn" href="'.$occSrcUrl.'">Explore '.$occs.' occurrences</a></p>';
+                } elseif($occs == 0){
+                  echo '<p>No occurrences found</p>';
+                }              
+              ?>
 						</div>
 					</td>
 				</tr>
@@ -434,6 +451,13 @@ include($SERVER_ROOT.'/includes/header.php');
 				}
 				?>
 				<div id="scinameDiv"><span id="taxon"><?php echo $taxonManager->getTaxonName(); ?></span></div>
+        <?php
+          if($occs > 0){
+            echo '<p><a class="btn" href="'.$occSrcUrl.'">Explore '.$occs.' occurrences</a></p>';
+          } elseif($occs == 0){
+            echo '<p>No occurrences found</p>';
+          }
+        ?>
 				<div>
 					<div id="leftPanel">
 						<fieldset style="clear:both">

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -117,7 +117,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							$parentLink = 'index.php?tid='.$taxonManager->getParentTid().'&clid='.$clid.'&pid='.$pid.'&taxauthid='.$taxAuthId;
 							echo '&nbsp;<a href="'.$parentLink.'"><img class="navIcon" src="../images/toparent.png" title="Go to Parent" /></a>';
               if($occs > 0){
-                echo '<p><a class="btn" href="'.$occSrcUrl.'">Explore '.$occs.' occurrences</a></p>';
+                echo '<p><a class="btn" href="'.$occSrcUrl.'" target="_blank">Explore '.$occs.' occurrences</a></p>';
               } elseif($occs == 0){
                 echo '<p>No occurrences found</p>';
               }
@@ -280,7 +280,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							?>
               <?php 
                 if($occs > 0){
-                  echo '<p><a class="btn" href="'.$occSrcUrl.'">Explore '.$occs.' occurrences</a></p>';
+                  echo '<p><a class="btn" href="'.$occSrcUrl.'" target="_blank">Explore '.$occs.' occurrences</a></p>';
                 } elseif($occs == 0){
                   echo '<p>No occurrences found</p>';
                 }              
@@ -453,7 +453,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				<div id="scinameDiv"><span id="taxon"><?php echo $taxonManager->getTaxonName(); ?></span></div>
         <?php
           if($occs > 0){
-            echo '<p><a class="btn" href="'.$occSrcUrl.'">Explore '.$occs.' occurrences</a></p>';
+            echo '<p><a class="btn" href="'.$occSrcUrl.'" target="_blank">Explore '.$occs.' occurrences</a></p>';
           } elseif($occs == 0){
             echo '<p>No occurrences found</p>';
           }

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -38,8 +38,7 @@ if($pid === '' && isset($DEFAULT_PROJ_ID) && $DEFAULT_PROJ_ID) $pid = $DEFAULT_P
 
 // Options to display occurrences counts and link by taxon
 $taxonRank = $taxonManager->getRankId();
-$occs = $taxonManager->getOccTaxonInDbCnt($tid, $taxonRank, 110);
-$limitOccs = 500000;
+$occs = $taxonManager->getOccTaxonInDbCnt($tid, $taxonRank);
 $scinameStr = $taxonManager->getTaxonName();
 $occSrcUrl = $CLIENT_ROOT.'/collections/list.php?db=all&includeothercatnum=1&taxa='.$scinameStr.'&usethes=1';
 
@@ -121,7 +120,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							<?php
 							$parentLink = 'index.php?tid='.$taxonManager->getParentTid().'&clid='.$clid.'&pid='.$pid.'&taxauthid='.$taxAuthId;
 							echo '&nbsp;<a href="'.$parentLink.'"><img class="navIcon" src="../images/toparent.png" title="Go to Parent" /></a>';
-              echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl, $limitOccs);
+              echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl);
 							if($taxonManager->isForwarded()){
 						 		echo '<span id="redirectedfrom"> ('.(isset($LANG['REDIRECT'])?$LANG['REDIRECT']:'redirected from').': <i>'.$taxonManager->getSubmittedValue('sciname').'</i> '.$taxonManager->getSubmittedValue('author').')</span>';
 						 	}
@@ -280,7 +279,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							echo '<div id="taxon">'.$displayName.'</div>';
 							?>
               <?php 
-                echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl, $limitOccs);         
+                echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl);         
               ?>
 						</div>
 					</td>
@@ -449,7 +448,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				?>
 				<div id="scinameDiv"><span id="taxon"><?php echo $taxonManager->getTaxonName(); ?></span></div>
         <?php
-          echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl, $limitOccs);
+          echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl);
         ?>
 				<div>
 					<div id="leftPanel">

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -32,12 +32,17 @@ elseif($taxonValue){
 	$tid = key($tidArr);
 	//Need to add code that allows user to select target taxon when more than one homonym is returned
 }
+
 if($lang) $lang = $taxonManager->setLanguage($lang);
 if($pid === '' && isset($DEFAULT_PROJ_ID) && $DEFAULT_PROJ_ID) $pid = $DEFAULT_PROJ_ID;
 
-$occs = $taxonManager->getOccTaxonInDbCnt($tid);
+// Options to display occurrences counts and link by taxon
+$taxonRank = $taxonManager->getRankId();
+$occs = $taxonManager->getOccTaxonInDbCnt($tid, $taxonRank, 110);
+$limitOccs = 500000;
 $scinameStr = $taxonManager->getTaxonName();
 $occSrcUrl = $CLIENT_ROOT.'/collections/list.php?db=all&includeothercatnum=1&taxa='.$scinameStr.'&usethes=1';
+
 
 $links = $taxonManager->getTaxaLinks();
 if($links){
@@ -116,11 +121,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							<?php
 							$parentLink = 'index.php?tid='.$taxonManager->getParentTid().'&clid='.$clid.'&pid='.$pid.'&taxauthid='.$taxAuthId;
 							echo '&nbsp;<a href="'.$parentLink.'"><img class="navIcon" src="../images/toparent.png" title="Go to Parent" /></a>';
-              if($occs > 0){
-                echo '<p><a class="btn" href="'.$occSrcUrl.'" target="_blank">Explore '.$occs.' occurrences</a></p>';
-              } elseif($occs == 0){
-                echo '<p>No occurrences found</p>';
-              }
+              echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl, $limitOccs);
 							if($taxonManager->isForwarded()){
 						 		echo '<span id="redirectedfrom"> ('.(isset($LANG['REDIRECT'])?$LANG['REDIRECT']:'redirected from').': <i>'.$taxonManager->getSubmittedValue('sciname').'</i> '.$taxonManager->getSubmittedValue('author').')</span>';
 						 	}
@@ -279,11 +280,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							echo '<div id="taxon">'.$displayName.'</div>';
 							?>
               <?php 
-                if($occs > 0){
-                  echo '<p><a class="btn" href="'.$occSrcUrl.'" target="_blank">Explore '.$occs.' occurrences</a></p>';
-                } elseif($occs == 0){
-                  echo '<p>No occurrences found</p>';
-                }              
+                echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl, $limitOccs);         
               ?>
 						</div>
 					</td>
@@ -452,11 +449,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				?>
 				<div id="scinameDiv"><span id="taxon"><?php echo $taxonManager->getTaxonName(); ?></span></div>
         <?php
-          if($occs > 0){
-            echo '<p><a class="btn" href="'.$occSrcUrl.'" target="_blank">Explore '.$occs.' occurrences</a></p>';
-          } elseif($occs == 0){
-            echo '<p>No occurrences found</p>';
-          }
+          echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl, $limitOccs);
         ?>
 				<div>
 					<div id="leftPanel">

--- a/taxa/index.php
+++ b/taxa/index.php
@@ -119,7 +119,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							<?php
 							$parentLink = 'index.php?tid='.$taxonManager->getParentTid().'&clid='.$clid.'&pid='.$pid.'&taxauthid='.$taxAuthId;
 							echo '&nbsp;<a href="'.$parentLink.'"><img class="navIcon" src="../images/toparent.png" title="Go to Parent" /></a>';
-              echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl);
+              echo '<p>'.$taxonManager->getSearchByTaxon($occs, $occSrcUrl).'</p>';
 							if($taxonManager->isForwarded()){
 						 		echo '<span id="redirectedfrom"> ('.(isset($LANG['REDIRECT'])?$LANG['REDIRECT']:'redirected from').': <i>'.$taxonManager->getSubmittedValue('sciname').'</i> '.$taxonManager->getSubmittedValue('author').')</span>';
 						 	}
@@ -278,7 +278,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							echo '<div id="taxon">'.$displayName.'</div>';
 							?>
               <?php 
-                echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl);         
+                echo '<p>'.$taxonManager->getSearchByTaxon($occs, $occSrcUrl).'</p>';       
               ?>
 						</div>
 					</td>
@@ -447,7 +447,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				?>
 				<div id="scinameDiv"><span id="taxon"><?php echo $taxonManager->getTaxonName(); ?></span></div>
         <?php
-          echo $taxonManager->getSearchByTaxon($occs, $occSrcUrl);
+          echo '<p>'.$taxonManager->getSearchByTaxon($occs, $occSrcUrl).'</p>';
         ?>
 				<div>
 					<div id="leftPanel">


### PR DESCRIPTION
Adds two methods to `TaxonProfile` class, with optional parameters to decide limits to taxon rank and record counts.

- Displays conditionally the occurrence counts per taxon (defaults to count only genera or below) in the taxon profile page
- Displays conditionally the occurrence search url (defaults to only include link in counts smaller than 200k records)

Values used in methods pulled from taxon profile page itself.