### PR TITLE
Change wording of edit common names

### DIFF
--- a/content/lang/sitemap.en.php
+++ b/content/lang/sitemap.en.php
@@ -118,11 +118,14 @@ $LANG['ABOUT'] = 'About Symbiota';
 $LANG['CODE'] = 'Code Version ';
 $LANG['SCHEMA'] = 'Schema Version ';
 $LANG['AUTHO'] = 'You are authorized to access the';
-$LANG['SYN_COM'] = 'Synonyms / Common Names';
-$LANG['TEXTDESC'] = 'Text Descriptions';
+$LANG['SYN_COM'] = 'Edit Synonyms / Common Names';
+$LANG['TEXTDESC'] = 'Edit Text Descriptions';
 $LANG['PERSONAL'] = 'Personal Specimen Management and Label Printing Features';
 $LANG['EDITIMG'] = 'Edit Images';
 $LANG['IMGSORTORD'] = 'Edit Image Sorting Order';
 $LANG['ADDNEWIMG'] = 'Add a new image';
 $LANG['DATASETS'] = 'Datasets';
+$LANG['ALLPUBDAT'] = 'All Publicly Viewable Datasets';
+$LANG['DATMANPAG'] = 'Dataset Management Page</a> - datasets you are authorized to edit';
+
 ?>

--- a/content/lang/sitemap.es.php
+++ b/content/lang/sitemap.es.php
@@ -118,11 +118,14 @@ $LANG['ABOUT'] = 'Acerca de Symbiota';
 $LANG['CODE'] = 'Versión del código';
 $LANG['SCHEMA'] = 'Versión del esquema';
 $LANG['AUTHO'] = 'Usted esta autorizado/a para el acceso a los siguientes paginas';
-$LANG['SYN_COM'] = 'Sinonimia / Nombres Comunes';
-$LANG['TEXTDESC'] = 'Descripciones textuales';
+$LANG['SYN_COM'] = 'Modificar Sinonimia / Nombres Comunes';
+$LANG['TEXTDESC'] = 'Modificar Descripciones Textuales';
 $LANG['PERSONAL'] = 'Gesti&oacute;n del manejo personal de especimenes y imprimir etiquetas';
 $LANG['EDITIMG'] = 'Modificar Im&aacute;genes';
 $LANG['IMGSORTORD'] = 'Modificar la secuencia de im&aacute;genes';
 $LANG['ADDNEWIMG'] = 'Añadir nuevo imagen';
 $LANG['DATASETS'] = 'Conjuntos de datos';
+$LANG['ALLPUBDAT'] = 'Todos los conjuntos de datos visibles públicamente';
+$LANG['DATMANPAG'] = 'Página de Administración de Conjuntos de Datos</a> - conjuntos de datos que está autorizado a editar';
+
 ?>

--- a/content/lang/sitemap.fr.php
+++ b/content/lang/sitemap.fr.php
@@ -118,10 +118,12 @@ $LANG['ABOUT'] = 'À Propos de Symbiota';
 $LANG['CODE'] = 'Version du Dodes';
 $LANG['SCHEMA'] = 'Version du Schéma';
 $LANG['AUTHO'] = 'Vous êtes autorisé à accéder au';
-$LANG['SYN_COM'] = 'Synonymes / Noms Communs';
-$LANG['TEXTDESC'] = 'Descriptions Textuelles';
+$LANG['SYN_COM'] = 'Modifier Synonymes / Noms Communs';
+$LANG['TEXTDESC'] = 'Modifier Descriptions Textuelles';
 $LANG['EDITIMG'] = 'Modifier Images';
 $LANG['IMGSORTORD'] = "Modifier l'Ordre de Tri des Images";
 $LANG['ADDNEWIMG'] = 'Ajouter une nouvelle image';
+$LANG['ALLPUBDAT'] = 'Tous les Ensembles de Données Consultables Publiquement';
+$LANG['DATMANPAG'] = 'Page de Gestion des Ensembles de Données</a> - ensembles de données que vous êtes autorisé à modifier';
 
 ?>

--- a/sitemap.php
+++ b/sitemap.php
@@ -104,7 +104,7 @@ $smManager = new SiteMapManager();
 
 			<h2><?php echo (isset($LANG['DATASETS'])?$LANG['DATASETS']:'Datasets') ;?></h2>
 			<ul>
-				<li><a href="collections/datasets/publiclist.php">All Publicly Viewable Datasets</a></li>
+				<li><a href="collections/datasets/publiclist.php"><?php echo (isset($LANG['ALLPUBDAT'])?$LANG['ALLPUBDAT']:'All Publicly Viewable Datasets') ;?></a></li>
 			</ul>
 			<div style="margin-top:10px;"><h2><?php echo $LANG['DYNAMIC'];?></h2></div>
 			<ul>
@@ -273,7 +273,7 @@ $smManager = new SiteMapManager();
 
 					<h3><?php echo (isset($LANG['DATASETS'])?$LANG['DATASETS']:'Datasets') ;?></h3>
 					<ul>
-						<li><a href="collections/datasets/index.php">Dataset Management Page</a> - datasets you are authorized to edit</li>
+						<li><a href="collections/datasets/index.php"><?php echo (isset($LANG['DATMANPAG'])?$LANG['DATMANPAG']:'Dataset Management Page</a> - datasets you are authorized to edit') ;?></li>
 					</ul>
 					<h3><?php echo $LANG['TAXONPROF'];?></h3>
 					<?php

--- a/taxa/profile/tpeditor.php
+++ b/taxa/profile/tpeditor.php
@@ -117,6 +117,7 @@ if($isEditor && $action){
 <html>
 <head>
 	<title><?php echo $DEFAULT_TITLE.' Taxon Editor: '.$tEditor->getSciName(); ?></title>
+	<div class="innertext">
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET;?>" />
 	<?php
 	$activateJQuery = true;
@@ -412,7 +413,7 @@ if($isEditor && $action){
 			?>
 			<div style="margin:20px;">
 				<form name="gettidform" action="tpeditor.php" method="post" onsubmit="return checkGetTidForm(this);">
-					<b>Taxon search: </b><input id="taxa" name="taxon" value="<?php echo $taxon; ?>" size="40" />
+					<b>Scientific name: </b><input id="taxa" name="taxon" value="<?php echo $taxon; ?>" size="40" />
 					<input type="hidden" name="tabindex" value="<?php echo $tabIndex; ?>" />
 					<input type="submit" name="action" value="Edit Taxon" />
 				</form>


### PR DESCRIPTION
Due to confusion on what "Synonyms / Common Names" means in the sitemap, which was issued by Mary Barkworth and documented here: https://github.com/BioKIC/Symbiota/issues/171

I changed the wording on the sitemap and on tpeditor to emphasize that you can't search by common name here, just edit the common names of taxa.