### PR TITLE
Get institution data from GBIF GrSciColl API

### DIFF
--- a/collections/misc/institutioneditor.php
+++ b/collections/misc/institutioneditor.php
@@ -87,7 +87,7 @@ if($editorCode){
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET; ?>">
 	<title><?php echo $DEFAULT_TITLE; ?> Institution Editor</title>
   <?php
-      $activateJQuery = false;
+      $activateJQuery = true;
       if(file_exists($SERVER_ROOT.'/includes/head.php')){
         include_once($SERVER_ROOT.'/includes/head.php');
       }
@@ -97,6 +97,9 @@ if($editorCode){
         echo '<link href="'.$CLIENT_ROOT.'/css/main.css?ver=1" type="text/css" rel="stylesheet" />';
       }
   ?>
+  <script src="../../js/jquery.js?ver=140310" type="text/javascript"></script>
+  <script src="../../js/jquery-ui.js?ver=140310" type="text/javascript"></script>
+  <script src="../../js/symb/collections.grscicoll.js?ver=2" type="text/javascript"></script>
 	<script language=javascript>
 		
 		function toggle(target){
@@ -157,6 +160,11 @@ include($SERVER_ROOT.'/includes/header.php');
 </div>
 <!-- This is inner text! -->
 <div id="innertext">
+	<div id="dialog" title="" style="display: none;">
+		<div id="dialogmsg"></div>
+	  <select id="getresult">
+	  </select>
+	</div>
 	<?php
 	if($statusStr){
 		?>
@@ -185,7 +193,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				?>
 			</div>
 			<div style="clear:both;">
-				<form name="insteditform" action="institutioneditor.php" method="post">
+				<form id="insteditform" name="insteditform" action="institutioneditor.php" method="post">
 					<fieldset style="padding:20px;">
 						<legend><b>Address Details</b></legend>
 						<div style="position:relative;">
@@ -197,6 +205,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							</div>
 							<div class="editdiv" style="display:<?php echo $eMode?'block':'none'; ?>;">
 								<input name="institutioncode" type="text" value="<?php echo $instArr['institutioncode']; ?>" />
+								<input name="getgrscicoll" type="button" value="Update from GrSciColl" onClick="grscicoll('insteditform')"/>
 							</div>
 						</div>
 						<div style="position:relative;clear:both;">
@@ -353,7 +362,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				</form>
 				<div style="clear:both;">
 					<fieldset style="padding:20px;">
-						<legend><b>Collecitons Linked to Institution Address</b></legend>
+						<legend><b>Collections Linked to Institution Address</b></legend>
 						<div>
 							<?php 
 							if($collList){
@@ -431,7 +440,7 @@ include($SERVER_ROOT.'/includes/header.php');
 				</a>
 			</div>
 			<div id="instadddiv" style="display:<?php echo ($eMode?'block':'none'); ?>;margin-bottom:8px;">
-				<form name="instaddform" action="institutioneditor.php" method="post">
+				<form id="instaddform" name="instaddform" action="institutioneditor.php" method="post">
 					<fieldset style="padding:20px;">
 						<legend><b>Add New Institution</b></legend>
 						<div style="position:relative;">
@@ -440,6 +449,7 @@ include($SERVER_ROOT.'/includes/header.php');
 							</div>
 							<div>
 								<input name="institutioncode" type="text" value="<?php echo $instCodeDefault; ?>" />
+								<input name="getgrscicoll" type="button" value="Get data from GrSciColl" onClick="grscicoll('instaddform')"/>
 							</div>
 						</div>
 						<div style="position:relative;clear:both;">

--- a/config/schema-1.0/dev/db_schema_patch-dev.sql
+++ b/config/schema-1.0/dev/db_schema_patch-dev.sql
@@ -639,3 +639,11 @@ INSERT INTO ctcontrolvocabterm(cvID, term, resourceUrl, activeStatus) SELECT cvI
 INSERT INTO ctcontrolvocabterm(cvID, term, resourceUrl, activeStatus) SELECT cvID, "poolDnaExtracts", "http://gensc.org/ns/mixs/pool_dna_extracts", 1 FROM ctcontrolvocab WHERE tableName = "ommaterialsampleextended" AND fieldName = "fieldName";
 INSERT INTO ctcontrolvocabterm(cvID, term, resourceUrl, activeStatus) SELECT cvID, "sampleDesignation", "http://data.ggbn.org/schemas/ggbn/terms/sampleDesignation", 1 FROM ctcontrolvocab WHERE tableName = "ommaterialsampleextended" AND fieldName = "fieldName";
 
+# Modify the institutions table so that some fields can hold more data
+# This is to allow extra content from GrSciColl/Index Herbariorum (e.g., multiple contacts)
+ALTER TABLE `institutions` 
+  CHANGE COLUMN `InstitutionName2` `InstitutionName2` VARCHAR(255) NULL DEFAULT NULL,
+  CHANGE COLUMN `Phone` `Phone` VARCHAR(100) NULL DEFAULT NULL,
+  CHANGE COLUMN `Contact` `Contact` VARCHAR(255) NULL DEFAULT NULL,
+  CHANGE COLUMN `Email` `Email` VARCHAR(255) NULL DEFAULT NULL,
+  CHANGE COLUMN `Notes` `Notes` VARCHAR(19500) NULL DEFAULT NULL;

--- a/js/symb/collections.grscicoll.js
+++ b/js/symb/collections.grscicoll.js
@@ -1,0 +1,427 @@
+// Code to get institution data from the GBIF GrSciColl API and import it into Symbiota
+// In addition to filling out all the Symbiota institution fields, it adds additional info into the notes section:
+// incorporated collections, taxonomic focus, geography, links etc. 
+
+// Function to do some pre-checking before querying the API and bringing the data to Symbiota
+function grscicoll(form) {
+
+	// Get the form name to add data to
+	var form = document.getElementById(form);
+
+	// Get the institution code to look up
+	var code = form.elements["institutioncode"].value;
+
+	// Check if the code is filled in, and exit if not
+	if(!code) {
+		$('#getresult').hide();
+		$('#dialogmsg').text('Fill in a code first to get data from GrSciColl');
+		$("#dialog").show();
+		$("#dialog").dialog({
+			width: 'auto', 
+			title: 'No institution code provided.',
+			buttons: [{
+				text: "Ok",
+				click: function() {
+
+					// Close the dialog
+					$(this).dialog( "close" );
+        
+				}
+			}]
+		});
+
+		// Quit
+		return;
+	}
+
+	// If data already exists (editing an institution), warn the user before continuing
+	if(form.name == "insteditform") {
+		$('#getresult').hide();
+		$('#dialogmsg').text('This will overwrite the existing data. Ok to proceed?');
+		$("#dialog").show();
+		$("#dialog").dialog({
+			width: 'auto', 
+			title: 'Warning:',
+			buttons: [{
+				text: "Ok",
+				click: function() {
+
+					// Close the dialog
+					$(this).dialog( "close" );
+
+					// Ok to overwrite, get the data
+					getData(form, code);
+				}
+			}, 
+			{
+				text: "Cancel",
+				click: function() {
+
+					// Close the dialog
+					$(this).dialog( "close" );
+
+					// Quit
+					return;
+				}
+			}]
+		});
+
+	} else {
+
+		// Adding a new institution, so just get the data
+		getData(form, code);
+	}
+}
+
+// Function to query the API and return a collection dataset
+function getData(form, code){
+
+	// GrSciColl API Url	
+	var GrSciCollURL = 'https://api.gbif.org/v1/grscicoll/collection';
+
+	// Query the GrSciColl API with the code
+	$.ajax({
+		data: {code: code},
+		url: GrSciCollURL,
+		dataType: "json",
+
+		// Function to run on a successful API call
+		success: function (results, status, xhr) {
+
+			// Show full API result(s) for debugging
+			//console.log(results);
+
+			// Check if no hits are found
+			if(results.count == 0) {
+				alert("No institution found for code: " + code);
+				return;
+			}
+
+			// Check if more than one result is found. If so, ask the user to pick one
+			if(results.count > 1) {
+
+				// Show the result choices
+				results.results.forEach(function (result, index) {
+
+					// Get the source of the data
+					if (result.masterSource == "GRSCICOLL"){
+						source = "GrSciColl";
+					} else if(result.masterSourceMetadata.source) {
+						if (result.masterSourceMetadata.source == "IH_IRN") {
+							source = "Index Herbariorum";
+						} else {
+							source = result.masterSourceMetadata.source;
+						}
+					} else {
+						source = result.masterSource;
+					}
+					// Construct a <select> list for the dialog
+					$('#getresult').append($('<option>', {
+					    value: index,
+					    text: result.name + " | " + result.institutionName + " | Source: " + source
+					}));
+				});
+				
+				// Make a jQuery UI dialog for the user to pick
+				$('#dialogmsg').text('');
+				$('#getresult').show();
+				$("#dialog").show();
+				$("#dialog").dialog({
+					width: 'auto', 
+					title: 'Multiple results found for code: ' + code + '. Which would you like to use?',
+					buttons: [{
+						text: "Save",
+						click: function() {
+
+							// Close the diagog
+							$( this ).dialog( "close" );
+
+							// Populate institution with the result the user picked
+							grscicollPopulate(form, code, results.results[$( "#getresult" ).val()]);
+
+							// Remove the result choices
+							$('#getresult').children().remove().end()
+						}
+					}, 
+					{
+						text: "Cancel",
+						click: function() {
+
+							// Return without doing anything
+							$( this ).dialog( "close" );
+
+							// Remove the result choices
+							$('#getresult').children().remove().end()
+
+							// Quit
+							return;
+						}
+					}]
+				});
+			} else {
+
+				// Only one result, so use that
+				grscicollPopulate(form, code, results.results[0]);
+			}
+		}
+	});
+}
+
+// Function to populate the data in Symbiota from a GrSciColl dataset
+function grscicollPopulate (form, code, result) {
+
+	// Show full API result for debugging
+	//console.log(result);
+
+	// Check if the institution is inactive, and warn if so
+	if(!result.active && !confirm("Warning: " + result.institutionName + " " + 
+		result.name + " (" + code + ") is marked as inactive. Ok to proceed?")) return;
+
+	// Reset the form
+	form.reset();
+
+	// Set Institution Code
+	form.elements["institutioncode"].value = code;
+
+	// Check if it's an Index Herbariorum entry, and get the IRN code from machineTags array if so
+	if(result.indexHerbariorumRecord) {
+		result.irn = result.masterSourceMetadata.sourceId;
+	}
+
+	// Set Institution Name
+	if(result.institutionName || result.name) form.elements["institutionname"].value = 
+		result.institutionName + " " + result.name;
+
+	// Set Institution Name2:
+	// If both division and department are present, concatenate the two with a comma
+	if(result.division && result.department) {
+		form.elements["institutionname2"].value = result.division + ", " + result.department;
+
+	// Otherwise, if only one is present, just use that as institutionname2
+	} else if(result.division) {
+		form.elements["institutionname2"].value = result.division;
+	} else if(result.department) {
+		form.elements["institutionname2"].value = result.department;
+	}
+
+	// Set Mailing Address
+	if(result.mailingAddress.address){
+
+		// Check for multi-line addresses, and split if possible
+		// split by semicolon first (least likely to be spurious)
+		if(result.mailingAddress.address.includes(";")){
+
+			// Split the street address with semicolons. 
+			var addrArr = result.mailingAddress.address.split(";");
+
+			// Set Address 1 to the first part of the address before a semicolon
+			form.elements["address1"].value = addrArr[0];
+
+			// Set Address 2 to everything else:
+			addrArr.shift();
+			form.elements["address2"].value = addrArr.join(", ").trim();
+
+		// Otherwise, try splitting by commas
+		} else if(result.mailingAddress.address.includes(",")){
+
+			// Split the street address with commas. 
+			var addrArr = result.mailingAddress.address.split(",");
+
+			// Set Address 1 to the first part of the address before a comma
+			form.elements["address1"].value = addrArr[0];
+
+			// Set Address 2 to everything else:
+			addrArr.shift();
+			form.elements["address2"].value = addrArr.join(", ").trim();
+
+		} else {
+
+			// Set Address:
+			if(result.mailingAddress.address) form.elements["address1"].value = result.mailingAddress.address;
+		}
+	}
+
+	// Set City:
+	if(result.mailingAddress.city) form.elements["city"].value = result.mailingAddress.city;
+
+	// Set State/Province to its abbreviation, if supported
+	if(result.mailingAddress.province) form.elements["stateprovince"].value = abbrState(result.mailingAddress.province);
+
+	// Set Postal Code:
+	if(result.mailingAddress.postalCode) form.elements["postalcode"].value = result.mailingAddress.postalCode;
+
+	// Set Country:
+	if(result.mailingAddress.country) form.elements["country"].value = result.mailingAddress.country;
+	
+	// Set Phone, separating multiple phone numbers by commas
+	if(result.phone) form.elements["phone"].value = result.phone.join(", ");
+
+	// Compile the contact persons into a list
+	if(result.contactPersons) {
+		var contacts = "";
+		result.contactPersons.forEach(element => {
+			// Account for possibility of missing fields
+			if(element.firstName) contacts += element.firstName;
+			if(element.firstName && element.lastName) contacts += ' '; 
+			if(element.lastName) contacts += element.lastName;
+			if(element.position){
+				contacts += " (" + element.position +"), ";
+			} else {
+				contacts += ", ";
+			}
+	 	});
+
+		// Remove trailing comma from the last contact
+		contacts = contacts.substring(0, contacts.length - 2)
+
+		// Set Contact
+		if(contacts) form.elements["contact"].value = contacts;
+	}
+
+	// Set Email, preferring the email field, falling back to the first contactPerson
+	if(result.email) {
+		if(result.email.length > 0) {
+			form.elements["email"].value = result.email.join(", ");
+		} else if (result.contactPersons[0].email){
+			form.elements["email"].value = result.contactPersons[0].email.join(", ");
+		}
+	}
+	
+	// Set URL:
+	if(result.homepage) form.elements["url"].value = result.homepage;
+
+	// Set Notes (this includes a number of fields)
+	var notes = "";
+	if(result.notes) notes += result.notes;
+
+	// Add taxonomic coverage to notes, if included
+	if(result.taxonomicCoverage) notes += "<br/><br/><strong>Taxonomic Coverage:</strong> " + result.taxonomicCoverage;
+
+	// Add geography to notes, if included
+	if(result.geography) notes += "<br/><br/><strong>Geography:</strong> " + result.geography;
+
+	// Add incorporated herbaria to notes, if included
+	if(result.incorporatedCollections && result.incorporatedCollections.length > 0) notes += "<br/><br/><strong>Incorporated Collections:</strong> " + result.incorporatedCollections.join("; ");
+
+	// Add specimen total, if included
+	if(result.numberSpecimens) notes += "<br/><br/><strong>Total Specimens:</strong> " + result.numberSpecimens;
+
+	// Add a link to GrSciColl to the notes
+	notes += "<br/><br/><strong><a href=https://www.gbif.org/grscicoll/collection/" + result.key + " target=_blank>GrSciColl Link</a></strong>";
+
+	// Add a link to Index Herbariorum to the notes
+	if(result.irn) notes += "<br/><br/><strong><a href=http://sweetgum.nybg.org/science/ih/herbarium-details/?irn=" + result.irn + " target=_blank>Index Herbariorum Link</a></strong>";
+
+	// iDigBio Link?
+
+	// Last Modified note?
+
+	// Add notes field
+	form.elements["notes"].value = notes;
+
+	// Finiosh
+	return;
+}
+
+// Function to convert a full state/province name to an abbreviation
+// https://gist.github.com/calebgrove/c285a9510948b633aa47
+function abbrState(state){
+
+    // United States
+    var states = [
+        ['Alabama', 'AL'],
+        ['Alaska', 'AK'],
+        ['American Samoa', 'AS'],
+        ['Arizona', 'AZ'],
+        ['Arkansas', 'AR'],
+        ['Armed Forces Americas', 'AA'],
+        ['Armed Forces Europe', 'AE'],
+        ['Armed Forces Pacific', 'AP'],
+        ['California', 'CA'],
+        ['Colorado', 'CO'],
+        ['Connecticut', 'CT'],
+        ['Delaware', 'DE'],
+        ['District Of Columbia', 'DC'],
+        ['Florida', 'FL'],
+        ['Georgia', 'GA'],
+        ['Guam', 'GU'],
+        ['Hawaii', 'HI'],
+        ['Idaho', 'ID'],
+        ['Illinois', 'IL'],
+        ['Indiana', 'IN'],
+        ['Iowa', 'IA'],
+        ['Kansas', 'KS'],
+        ['Kentucky', 'KY'],
+        ['Louisiana', 'LA'],
+        ['Maine', 'ME'],
+        ['Marshall Islands', 'MH'],
+        ['Maryland', 'MD'],
+        ['Massachusetts', 'MA'],
+        ['Michigan', 'MI'],
+        ['Minnesota', 'MN'],
+        ['Mississippi', 'MS'],
+        ['Missouri', 'MO'],
+        ['Montana', 'MT'],
+        ['Nebraska', 'NE'],
+        ['Nevada', 'NV'],
+        ['New Hampshire', 'NH'],
+        ['New Jersey', 'NJ'],
+        ['New Mexico', 'NM'],
+        ['New York', 'NY'],
+        ['North Carolina', 'NC'],
+        ['North Dakota', 'ND'],
+        ['Northern Mariana Islands', 'NP'],
+        ['Ohio', 'OH'],
+        ['Oklahoma', 'OK'],
+        ['Oregon', 'OR'],
+        ['Pennsylvania', 'PA'],
+        ['Puerto Rico', 'PR'],
+        ['Rhode Island', 'RI'],
+        ['South Carolina', 'SC'],
+        ['South Dakota', 'SD'],
+        ['Tennessee', 'TN'],
+        ['Texas', 'TX'],
+        ['US Virgin Islands', 'VI'],
+        ['Utah', 'UT'],
+        ['Vermont', 'VT'],
+        ['Virginia', 'VA'],
+        ['Washington', 'WA'],
+        ['West Virginia', 'WV'],
+        ['Wisconsin', 'WI'],
+        ['Wyoming', 'WY'],
+    ];
+
+    // Canada
+    var provinces = [
+        ['Alberta', 'AB'],
+        ['British Columbia', 'BC'],
+        ['Manitoba', 'MB'],
+        ['New Brunswick', 'NB'],
+        ['Newfoundland', 'NF'],
+        ['Northwest Territory', 'NT'],
+        ['Nova Scotia', 'NS'],
+        ['Nunavut', 'NU'],
+        ['Ontario', 'ON'],
+        ['Prince Edward Island', 'PE'],
+        ['Quebec', 'QC'],
+        ['Saskatchewan', 'SK'],
+        ['Yukon', 'YT'],
+    ];
+
+    // Combine states and provinces
+    var regions = states.concat(provinces);
+
+    // Check for a case insensitive match in states and provinces
+	const selectedState = regions.find(s =>
+		s.find(x => x.toLowerCase() === state.toLowerCase())
+	)
+
+	// Return the unabbreviated name if no match is found
+	if (!selectedState) return state;
+
+	// Return the abbreviation for the match
+	return selectedState
+		//.filter(s => s.toLowerCase() !== state.toLowerCase())
+		.filter(s => s.length == 2)
+		.join("");
+}


### PR DESCRIPTION
This adds a button to the Institution editor to pull in data for an institution code from GBIF's [GrSciColl API](https://www.gbif.org/developer/registry#collections), which includes all institutions in Index Herbariorum, as well as many from GBIF.

In addition to adding data to all of the institution fields in Symbiota, it adds additional information into the notes field that would be useful for collection managers: incorporated collections, taxonomic and geographic focus, number of specimens, and links to the collection page on GrSciColl and Index Herbariorum (if present).

In some cases there are multiple results (collections, institutions, different data sources) for an institution code. This allows the user to pick which result they would like to use (thanks Frank Bungartz).

I'd originally implemented this last fall using the Index Herbariorum API, but Frank realized we could do this with GrSciColl if they made a few changes, which they've just done. 