### PR TITLE
Update index.php

### DIFF
--- a/collections/index.php
+++ b/collections/index.php
@@ -41,6 +41,7 @@ $otherCatArr = $collManager->getOccurVoucherProjects();
 						$(ui.panel).html("<p>Loading...</p>");
 					}
 				});
+				sessionStorage.querystr = null;
 				//document.collections.onkeydown = checkKey;
 			});
 		</script>


### PR DESCRIPTION
reset sessionStorage.querystr on the collections\index.php page so that selecting new collections (after completing a previous search) will return the appropriate results.  Suspect the bug may be a result of no longer using the db=all query parameter,