### PR TITLE
Adds ability to edit loan/exchange shipping invoices

### DIFF
--- a/collections/loans/reports/defaultinvoice.php
+++ b/collections/loans/reports/defaultinvoice.php
@@ -399,10 +399,33 @@ else{
 				.message {width:100%;text-align:left;font:10pt arial,sans-serif;}
 				.saludos {width:100%;text-align:left;font:10pt arial,sans-serif;}
 				.return {width:100%;text-align:left;font:10pt arial,sans-serif;position:relative;bottom:0;margin-top:20%;}
+				/* Hide the edit button div when printing */
+				@media print {.controls {display: none;}}
 			</style>
+
+			<script language="javascript">
+
+				// Function to toggle editing of the invoice on or off
+				function toggleEdits() {
+					var invoice = document.getElementById('invoice');
+					let isEditable = invoice.contentEditable === 'true';
+					if (isEditable) {
+						invoice.contentEditable = 'false';
+						document.querySelector('#edit').innerText = 'Edit Invoice';
+						invoice.style.border = 'none';
+					} else {
+						invoice.contentEditable = 'true';
+						document.querySelector('#edit').innerText = 'Save';
+						invoice.style.border = '2px solid #03fc88';
+					}
+				}
+			</script>			
 		</head>
 		<body style="background-color:#ffffff;">
-			<table style="height:10in;">
+			<div class="controls">
+				<button id="edit" style="font-weight: bold;" onclick="toggleEdits();">Edit Invoice</button>
+			</div>
+			<table id="invoice" style="height:10in;">
 				<tr>
 					<td>
 						<div>


### PR DESCRIPTION
Adds an edit button to the shipping invoice form. Clicking it allows a user to edit the text, use bold and italics, paste in rich text or images, etc. The edited invoice can then be printed, but edits are not saved. Mostly, this is useful to add additional text to the shipping invoice beyond what is possible to auto-generate.

It uses the same nice solution that @arbolitoloco built for the label maker for editing labels before printing.