### PR TITLE
Materialsample bugfix

### DIFF
--- a/classes/OccurrenceEditorMaterialSample.php
+++ b/classes/OccurrenceEditorMaterialSample.php
@@ -19,11 +19,12 @@ class OccurrenceEditorMaterialSample extends Manager{
 		$sql = 'SELECT m.matSampleID, m.sampleType, m.catalogNumber, m.guid, m.sampleCondition, m.disposition, m.preservationType, m.preparationDetails, m.preparationDate,
 			m.preparedByUid, CONCAT_WS(", ",u.lastname,u.firstname) as preparedBy, m.individualCount, m.sampleSize, m.storageLocation, m.remarks, m.dynamicFields, m.recordID, m.initialTimestamp
 			FROM ommaterialsample m LEFT JOIN users u ON m.preparedByUid = u.uid WHERE m.occid = '.$this->occid;
-		$rs = $this->conn->query($sql);
-		while($r = $rs->fetch_assoc()){
-			$retArr[$r['matSampleID']] = $r;
+		if($rs = $this->conn->query($sql)){
+			while($r = $rs->fetch_assoc()){
+				$retArr[$r['matSampleID']] = $r;
+			}
+			$rs->free();
 		}
-		$rs->free();
 		return $retArr;
 	}
 

--- a/collections/editor/includes/materialsampleinclude.php
+++ b/collections/editor/includes/materialsampleinclude.php
@@ -19,7 +19,7 @@ $materialSampleManager->setOccid($occid);
 
 $isEditor = false;
 if($IS_ADMIN) $isEditor = true;
-elseif($collId && array_key_exists('CollAdmin',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollAdmin'])) $isEditor = true;
+elseif($collid && array_key_exists('CollAdmin',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollAdmin'])) $isEditor = true;
 elseif(array_key_exists('CollEditor',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollEditor'])) $isEditor = true;
 
 $materialSampleArr = $materialSampleManager->getMaterialSampleArr();


### PR DESCRIPTION
Resolves a bug that occurs when the material sample module is activated.  User would attempt to edit an occurrence record by selecting the Material sample tab. The "loading" message would appear, but the material sample fields would never load. 