### PR TITLE
Adds a binomial name field to label maker GUI, allows full name styling

### DIFF
--- a/js/symb/collections.labeljsongui.js
+++ b/js/symb/collections.labeljsongui.js
@@ -35,6 +35,12 @@ const fieldProps = [
     id: 'scientificname',
     group: 'taxon',
   },
+  {
+    block: 'labelBlock',
+    name: 'Binomial Name',
+    id: 'speciesname',
+    group: 'taxon',
+  },
   { block: 'labelBlock', name: 'Taxon Rank', id: 'taxonrank', group: 'taxon' },
   {
     block: 'labelBlock',


### PR DESCRIPTION
Previously, the visual interface had fields for scientific name, infraspecific epithet, taxon rank, scientific name authorship, and parent authorship, and would expose parent authorship to the labelmaker when the `Print species authors for infraspecific taxa` option was checked. However, this did not work in a case where both the parent authorship and the infrataxon authorship should be displayed, for example: 
_**Symphoricarpos albus**_ (L.) S.F. Blake **var.** _**laevigatus**_ (Fernald) S.F. Blake. 

In this example, since the scientific name was `Symphoricarpos albus var. laevigatus`, there was no way to insert the parent author correctly before the taxon rank. This format is a common one for plant labels.

This fix enables a new field `Binomial Name` to the label maker GUI that is just the genus and specific epithet, without the infrataxon. That allows each aspect of the name to be included in the proper order, and to be themed separately, e.g., the binomial name and the infraspecific epithet are typically italicized (and sometimes bolded as above), while the taxon rank and the authorships are not.

Some additional quirks
* For taxonomic names not in the thesaurus, there are no fields passed to the label maker by default for binomial name, taxon rank, and infraspecific epithet. The code detects this case and attempts to parse out those sections from the scientific name in the occurrence record (for ssp., var., f., and nothossp.). 
* For autonyms (where the infraspecific epithet matches the species epithet), the infraspecific author is typically not included, because it is the same as the species author by definition. The code detects this as well, and removes the infraspecific author if it is specified.

