### PR TITLE
Adds first and last buttons to the Occurrence Table View page

### DIFF
--- a/collections/editor/occurrencetabledisplay.php
+++ b/collections/editor/occurrencetabledisplay.php
@@ -100,14 +100,19 @@ if($SYMB_UID){
 	$recStart = floor($occIndex/$recLimit)*$recLimit;
 	$recArr = $occManager->getOccurMap($recStart, $recLimit);
 	$navStr = '<div class="navpath" style="float:right;">';
+
+
 	if($recStart >= $recLimit){
+		$navStr .= '<a href="#" onclick="return submitQueryForm(0);" title="'.(isset($LANG['FIRST'])?$LANG['FIRST']:'First').' '.$recLimit.' '.(isset($LANG['RECORDS'])?$LANG['RECORDS']:'records').'">|&lt;</a>&nbsp;&nbsp;&nbsp;&nbsp;';
 		$navStr .= '<a href="#" onclick="return submitQueryForm('.($recStart-$recLimit).');" title="'.(isset($LANG['PREVIOUS'])?$LANG['PREVIOUS']:'Previous').' '.$recLimit.' '.(isset($LANG['RECORDS'])?$LANG['RECORDS']:'records').'">&lt;&lt;</a>';
 	}
 	$navStr .= ' | ';
 	$navStr .= ($recStart+1).'-'.($qryCnt<$recLimit+$recStart?$qryCnt:$recLimit+$recStart).' '.(isset($LANG['OF'])?$LANG['OF']:'of').' '.$qryCnt.' '.(isset($LANG['RECORDS'])?$LANG['RECORDS']:'records');
 	$navStr .= ' | ';
 	if($qryCnt > ($recLimit+$recStart)){
-		$navStr .= '<a href="#" onclick="return submitQueryForm('.($recStart+$recLimit).');" title="'.(isset($LANG['NEXT'])?$LANG['NEXT']:'Next').' '.$recLimit.' '.(isset($LANG['RECORDS'])?$LANG['RECORDS']:'records').'">&gt;&gt;</a>';
+		$navStr .= '<a href="#" onclick="return submitQueryForm('.($recStart+$recLimit).');" title="'.(isset($LANG['NEXT'])?$LANG['NEXT']:'Next').' '.$recLimit.' '.(isset($LANG['RECORDS'])?$LANG['RECORDS']:'records').'">&gt;&gt;</a>&nbsp;&nbsp;&nbsp;&nbsp;';
+
+		$navStr .= '<a href="#" onclick="return submitQueryForm('.(floor($qryCnt/$recLimit) * $recLimit).');" title="'.(isset($LANG['LAST'])?$LANG['LAST']:'Last').' '.$recLimit.' '.(isset($LANG['RECORDS'])?$LANG['RECORDS']:'records').'">&gt;|</a>';	
 	}
 	$navStr .= '</div>';
 }

--- a/content/lang/collections/editor/occurrencetabledisplay.en.php
+++ b/content/lang/collections/editor/occurrencetabledisplay.en.php
@@ -5,10 +5,12 @@ Language: English
 ------------------
 */
 
+$LANG['FIRST'] = 'First';
 $LANG['PREVIOUS'] = 'Previous';
 $LANG['RECORDS'] = 'records';
 $LANG['OF'] = 'of';
 $LANG['NEXT'] = 'Next';
+$LANG['LAST'] = 'Last';
 $LANG['TABLE_VIEW'] = 'Occurrence Table View';
 $LANG['SEARCH_FILTER'] = 'Search / Filter';
 $LANG['BATCH_UPDATE'] = 'Batch Update';

--- a/content/lang/collections/editor/occurrencetabledisplay.es.php
+++ b/content/lang/collections/editor/occurrencetabledisplay.es.php
@@ -5,10 +5,12 @@ Language: Español
 ------------------
 */
 
+$LANG['FIRST'] = 'Primera';
 $LANG['PREVIOUS'] = 'Previo';
 $LANG['RECORDS'] = 'registro';
 $LANG['OF'] = 'de';
 $LANG['NEXT'] = 'Siguiente';
+$LANG['LAST'] = 'Última';
 $LANG['TABLE_VIEW'] = 'Ver Tabla de Ocurrencias';
 $LANG['SEARCH_FILTER'] = 'Buscar / Filtrar';
 $LANG['BATCH_UPDATE'] = 'Actualizar en Lote';

--- a/content/lang/collections/editor/occurrencetabledisplay.fr.php
+++ b/content/lang/collections/editor/occurrencetabledisplay.fr.php
@@ -5,10 +5,12 @@ Language: Français (French)
 ------------------
 */
 
+$LANG['FIRST'] = 'Première';
 $LANG['PREVIOUS'] = 'Précédents';
 $LANG['RECORDS'] = 'enregistrements';
 $LANG['OF'] = 'de';
 $LANG['NEXT'] = 'Suivants';
+$LANG['LAST'] = 'Dernière';
 $LANG['TABLE_VIEW'] = 'Vue du Tableau des Occurrences';
 $LANG['SEARCH_FILTER'] = 'Rechercher / Filtrer';
 $LANG['BATCH_UPDATE'] = 'Mise à Jour Par Lots';


### PR DESCRIPTION
These show the first 1000 or last 1000 (or other number of) records, allowing a user to quickly get to the beginning or end of a list of records. There are already buttons for "Next 1000 records" and "Previous 1000 records". 

The same functionality is in the editor view, and I used the same UI here. This was a request during the last Symbiota support group meeting. It was pretty simple to add.

@themerekat, I can't remember who it was who requested this. 