### PR TITLE
Autofill name, country & state for Personal Observations new records

### DIFF
--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -721,6 +721,17 @@ else{
 										<fieldset>
 											<legend><?php echo (isset($LANG['COLLECTOR_INFO'])?$LANG['COLLECTOR_INFO']:'Collector Info'); ?></legend>
 											<?php
+
+											// If it's a new record in a general observation collection, get the person info to autofill name, country & state
+											if($isGenObs && !$occId) {
+												$pHandler = new ProfileManager();
+												$pHandler->setUid($SYMB_UID);
+												$user = $pHandler->getPerson();
+												$occArr['recordedby'] = $user->getFirstName() . ' ' . $user->getLastName();
+												$occArr['country'] = $user->getCountry();
+												$occArr['stateprovince'] = $user->getState();
+											}
+
 											if($occId){
 												if($fragArr || $specImgArr){
 													?>

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -728,8 +728,12 @@ else{
 												$pHandler->setUid($SYMB_UID);
 												$user = $pHandler->getPerson();
 												$occArr['recordedby'] = $user->getFirstName() . ' ' . $user->getLastName();
-												$occArr['country'] = $user->getCountry();
-												$occArr['stateprovince'] = $user->getState();
+
+												// Don't add locality if carrying over locality information
+												if($goToMode != 2) {
+													$occArr['country'] = $user->getCountry();
+													$occArr['stateprovince'] = $user->getState();
+												}
 											}
 
 											if($occId){


### PR DESCRIPTION
This takes the first name, last name, state, and country from a user's User Profile and auto-fills them in new records initiated through a Personal Observations (GenObs) collection. This saves a collector entering data some time, since the majority of records are likely to be collected by them and in their home state. Collectors can also temporarily edit their User Profile with a different location to enter a batch of specimens from other locations. 

This was a request from our users here at Oregon State University.