### PR TITLE
Performance improvement to tabledisplay modifiedby

### DIFF
--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -698,7 +698,7 @@ class OccurrenceEditorManager {
 			$sqlFrag .= 'WHERE (o.occid = '.$this->occid.')';
 		}
 		elseif($this->sqlWhere){
-			$this->addTableJoins($sqlFrag, TRUE); // Add table joins, including one for lastmodified
+			$this->addTableJoins($sqlFrag, TRUE); // Add table joins, including one for recordmodifiedby
 			$sqlFrag .= $this->sqlWhere;
 			if($limit){
 				$this->setSqlOrderBy($sqlFrag);
@@ -717,7 +717,14 @@ class OccurrenceEditorManager {
 			}
 		}
 		if($sqlFrag){
-			$sql = 'SELECT DISTINCT o.occid, o.collid, lastuser.username as recordmodifiedby, o.'.implode(',o.',array_keys($this->fieldArr['omoccurrences'])).', datelastmodified FROM omoccurrences o '.$sqlFrag;
+
+			// Only add recordmodifiedby if the occurrence ID is not set (table display, not edit view)
+			if(!$this->occid) {
+				$sql = 'SELECT DISTINCT o.occid, o.collid, lastuser.username as recordmodifiedby, o.'.implode(',o.',array_keys($this->fieldArr['occurrence'])).', datelastmodified FROM omoccurrences o '.$sqlFrag;
+			} else {
+				$sql = 'SELECT DISTINCT o.occid, o.collid, o.'.implode(',o.',array_keys($this->fieldArr['occurrence'])).', datelastmodified FROM omoccurrences o '.$sqlFrag;
+			}
+
 			$previousOccid = 0;
 			$rs = $this->conn->query($sql);
 			$rsCnt = 0;


### PR DESCRIPTION
This turns off the table joins to get the last-modified-by user, unless the query is intended to show data in the occurrence table display. Previously, the joins were also being added to count queries and queries for the editor view, where they were not required, and the count queries in particular were causing performance issues under load. 

@egbot, an addendum to Pull Request https://github.com/BioKIC/Symbiota/pull/354. Sorry that I did not catch this sooner. 