### PR TITLE
OCR processing bug

### DIFF
--- a/classes/OccurrenceEditorImages.php
+++ b/classes/OccurrenceEditorImages.php
@@ -60,7 +60,7 @@ class OccurrenceEditorImages extends OccurrenceEditorManager {
 					}
 					if($rawStr){
 						if($ocrSource) $ocrSource .= ': '.date('Y-m-d');
-						$sql = 'INSERT INTO specprocessorrawlabels(imgid, rawstr, source) VALUES('.$this->activeImgId.',"'.$this->cleanInStr($rawStr).'","'.$this->cleanInStr($ocrSource).'")';
+						$sql = 'INSERT INTO specprocessorrawlabels(imgid, rawstr, source) VALUES('.$this->activeImgId.',"'.$this->cleanRawFragment($rawStr).'","'.$this->cleanInStr($ocrSource).'")';
 						if(!$this->conn->query($sql)){
 							$this->errorStr = $LANG['ERROR_LOAD_OCR'].': '.$this->conn->error;
 						}

--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -2544,7 +2544,7 @@ class OccurrenceEditorManager {
 		return $newStr;
 	}
 
-	private function cleanRawFragment($str){
+	protected function cleanRawFragment($str){
 		$newStr = trim($str);
 		$newStr = $this->encodeStr($newStr);
 		$newStr = $this->conn->real_escape_string($newStr);

--- a/classes/SpecProcessorOcr.php
+++ b/classes/SpecProcessorOcr.php
@@ -197,10 +197,11 @@ class SpecProcessorOcr extends Manager{
 
 	private function databaseRawStr($imgId,$rawStr,$notes,$source){
 		if(is_numeric($imgId) && $rawStr){
+			$rawStr = $this->cleanInStr($this->encodeString($rawStr));
 			$score = '';
 			if($rawStr == 'Failed OCR return') $score = 0;
 			$sql = 'INSERT INTO specprocessorrawlabels(imgid,rawstr,notes,source,score) '.
-				'VALUE ('.$imgId.',"'.$this->cleanInStr($rawStr).'",'.
+				'VALUE ('.$imgId.',"'.$rawStr.'",'.
 				($notes?'"'.$this->cleanInStr($notes).'"':'NULL').','.
 				($source?'"'.$this->cleanInStr($source).'"':'NULL').','.
 				($score?'"'.$this->cleanInStr($score).'"':'NULL').')';


### PR DESCRIPTION
- Ensure that the tesseract OCR output is in UTF-8 dataset prior to insert into database

Pull Request Checklist:

- [x] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
