### PR TITLE
Improve form accessibility 4

### DIFF
--- a/collections/editor/includes/determinationtab.php
+++ b/collections/editor/includes/determinationtab.php
@@ -155,50 +155,50 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 						}
 						?>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['ID_QUALIFIER']; ?>:</b>
-							<input type="text" name="identificationqualifier" title="e.g. cf, aff, etc" />
+							<label for="identificationqualifier"><b><?php echo $LANG['ID_QUALIFIER']; ?>:</b></label>
+							<input type="text" name="identificationqualifier" id="identificationqualifier" title="e.g. cf, aff, etc" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['SCI_NAME']; ?>:</b>
+							<label for="dafsciname"><b><?php echo $LANG['SCI_NAME']; ?>:</b></label>
 							<input type="text" id="dafsciname" name="sciname" style="background-color:lightyellow;width:350px;" onfocus="initDetAutocomplete(this.form)" />
 							<input type="hidden" id="daftidtoadd" name="tidtoadd" value="" />
 							<input type="hidden" name="family" value="" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['AUTHOR']; ?>:</b>
-							<input type="text" name="scientificnameauthorship" style="width:200px;" />
+							<label for="scientificnameauthorship"><b><?php echo $LANG['AUTHOR']; ?>:</b></label>
+							<input type="text" name="scientificnameauthorship" id="scientificnameauthorship" style="width:200px;" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['CONFIDENCE_IN_DET']; ?>:</b>
-							<select name="confidenceranking">
+							<label for="confidenceranking"><b><?php echo $LANG['CONFIDENCE_IN_DET']; ?>:</b></label>
+							<select name="confidenceranking" id="confidenceranking">
 								<option value="8"><?php echo $LANG['HIGH']; ?></option>
 								<option value="5" selected><?php echo $LANG['MEDIUM']; ?></option>
 								<option value="2"><?php echo $LANG['LOW']; ?></option>
 							</select>
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['DETERMINER']; ?>:</b>
-							<input type="text" name="identifiedby" style="background-color:lightyellow;width:200px;" />
+							<label for="identifiedby"><b><?php echo $LANG['DETERMINER']; ?>:</b></label>
+							<input type="text" name="identifiedby" id="identifiedby" style="background-color:lightyellow;width:200px;" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['DATE']; ?>:</b>
-							<input type="text" name="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
+							<label for="dateidentified"><b><?php echo $LANG['DATE']; ?>:</b></label>
+							<input type="text" name="dateidentified" id="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['REFERENCE']; ?>:</b>
-							<input type="text" name="identificationreferences" style="width:350px;" />
+							<label for="identificationreferences"><b><?php echo $LANG['REFERENCE']; ?>:</b></label>
+							<input type="text" name="identificationreferences" id="identificationreferences" style="width:350px;" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['NOTES']; ?>:</b>
-							<input type="text" name="identificationremarks" style="width:350px;" />
+							<label for="identificationremarks"><b><?php echo $LANG['NOTES']; ?>:</b></label>
+							<input type="text" name="identificationremarks" id="identificationremarks" style="width:350px;" />
 						</div>
 						<div style='margin:3px;'>
-							<input type="checkbox" name="makecurrent" value="1" /> <?php echo $LANG['MAKE_THIS_CURRENT']; ?>
+							<input type="checkbox" name="makecurrent" id="makecurrent" value="1" /><label for="makecurrent"> <?php echo $LANG['MAKE_THIS_CURRENT']; ?></label>
 						</div>
 						<div style='margin:3px;'>
-							<input type="checkbox" name="printqueue" value="1" /> <?php echo $LANG['ADD_TO_PRINT']; ?>
+							<input type="checkbox" name="printqueue" id="printqueue" value="1" /><label for="printqueue"> <?php echo $LANG['ADD_TO_PRINT']; ?></label>
 						</div>
-						<div style='margin:15px;'>
+						<div style='margin:3px; margin-top: 10px'>
 							<input type="hidden" name="occid" value="<?php echo $occId; ?>" />
 							<input type="hidden" name="occindex" value="<?php echo $occIndex; ?>" />
 							<input type="hidden" name="annotatorname" value="<?php echo $annotatorname; ?>" />
@@ -206,8 +206,8 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 							<input type="hidden" name="catalognumber" value="<?php echo $catalognumber; ?>" />
 							<input type="hidden" name="institutioncode" value="<?php echo $institutioncode; ?>" />
 							<input type="hidden" name="csmode" value="<?php echo $crowdSourceMode; ?>" />
-							<div style="float:left;">
-								<button type="submit" name="submitaction" value="submitDetermination" ><?php echo $LANG['SUBMIT_DET']; ?></button>
+							<div>
+								<button type="submit" name="submitaction" id="submitaction" value="submitDetermination" ><?php echo $LANG['SUBMIT_DET']; ?></button>
 							</div>
 						</div>
 					</fieldset>

--- a/collections/editor/includes/imagetab.php
+++ b/collections/editor/includes/imagetab.php
@@ -103,16 +103,16 @@ $photographerArr = $occManager->getPhotographerArr();
 						</div>
 					</div>
 					<div>
-						<input type="checkbox" name="nolgimage" value="1" /> <?php echo $LANG['DO_NOT_MAP_LARGE']; ?>
+						<input type="checkbox" name="nolgimage" id="nolgimage" value="1" /> <label for="nolgimage"><?php echo $LANG['DO_NOT_MAP_LARGE']; ?></label>
 					</div>
 				</div>
 				<div style="clear:both;margin:20px 0px 5px 10px;">
-					<b><?php echo $LANG['CAPTION']; ?>:</b>
-					<input name="caption" type="text" size="40" value="" />
+					<label for="caption"><b><?php echo $LANG['CAPTION']; ?>:</b></label>
+					<input name="caption" id="caption" type="text" size="40" value="" />
 				</div>
 				<div style='margin:0px 0px 5px 10px;'>
-					<b><?php echo $LANG['PHOTOGRAPHER']; ?>:</b>
-					<select name='photographeruid' name='photographeruid'>
+					<label for="photographeruid"><b><?php echo $LANG['PHOTOGRAPHER']; ?>:</b></label>
+					<select name='photographeruid' name='photographeruid' id="photographeruid">
 						<option value=""><?php echo $LANG['SEL_PHOTOG']; ?></option>
 						<option value="">---------------------------------------</option>
 						<?php
@@ -128,25 +128,25 @@ $photographerArr = $occManager->getPhotographerArr();
 					</a>
 				</div>
 				<div id="imgaddoverride" style="margin:0px 0px 5px 10px;display:none;">
-					<b><?php echo $LANG['PHOTOG_OVER']; ?>:</b>
-					<input name='photographer' type='text' style="width:300px;" maxlength='100' />
+					<label for="photographer"><b><?php echo $LANG['PHOTOG_OVER']; ?>:</b></label>
+					<input name='photographer' id="photographer" type='text' style="width:300px;" maxlength='100' />
 					* <?php echo $LANG['WILL_OVERRIDE']; ?>
 				</div>
 				<div style="margin:0px 0px 5px 10px;">
-					<b><?php echo $LANG['NOTES']; ?>:</b>
-					<input name="notes" type="text" size="40" value="" />
+					<label for="notes"><b><?php echo $LANG['NOTES']; ?>:</b></label>
+					<input name="notes" id="notes" type="text" size="40" value="" />
 				</div>
 				<div style="margin:0px 0px 5px 10px;">
-					<b><?php echo $LANG['COPYRIGHT']; ?>:</b>
-					<input name="copyright" type="text" size="40" value="" />
+					<label for="copyright"><b><?php echo $LANG['COPYRIGHT']; ?>:</b></label>
+					<input name="copyright" id="copyright" type="text" size="40" value="" />
 				</div>
 				<div style="margin:0px 0px 5px 10px;">
-					<b><?php echo $LANG['SOURCE_WEBPAGE']; ?>:</b>
-					<input name="sourceurl" type="text" size="40" value="" />
+					<label for="sourceurl"><b><?php echo $LANG['SOURCE_WEBPAGE']; ?>:</b></label>
+					<input name="sourceurl" id="sourceurl" type="text" size="40" value="" />
 				</div>
 				<div style="margin:0px 0px 5px 10px;">
-					<b><?php echo $LANG['SORT']; ?>:</b>
-					<input name="sortoccurrence" type="text" size="10" value="" />
+					<label for="sortoccurrence"><b><?php echo $LANG['SORT']; ?>:</b></label>
+					<input name="sortoccurrence" id="sortoccurrence" type="text" size="10" value="" />
 				</div>
 				<div style="margin:0px 0px 5px 10px;">
 					<b><?php echo $LANG['DESCRIBE_IMAGE']; ?></b>
@@ -155,7 +155,7 @@ $photographerArr = $occManager->getPhotographerArr();
 					$imageTagArr = $occManager->getImageTagArr();
 					foreach($imageTagArr as $key => $description) {
 						echo '<div style="margin-left:10px;">';
-						echo '<input name="ch_'.$key.'" type="checkbox" value="1" /> '.$description.'</br>';
+						echo '<input name="ch_' . $key . '" id="ch_' . $key . '" type="checkbox" value="1" /> <label for="ch_' . $key . '">' . $description . '</label></br>';
 						echo '</div>';
 					}
 					?>

--- a/collections/editor/includes/materialsampleinclude.php
+++ b/collections/editor/includes/materialsampleinclude.php
@@ -94,14 +94,14 @@ $controlTermArr = $materialSampleManager->getMSTypeControlValues();
 				?>
 				<form name="matSampleForm-<?php echo $matSampleID; ?>" action="occurrenceeditor.php" method="post" >
 					<div style="clear:both">
-						<div class="smSampleTypeDiv">
-							<label><?php echo $MS_LABEL_ARR['sampleType']; ?>: </label>
+						<section class="spaced">
+							<label for="ms_sampleType"><?php echo $MS_LABEL_ARR['sampleType']; ?>: </label>
 							<span class="edit-elem">
 								<?php
 								if(isset($controlTermArr['ommaterialsample']['sampleType'])){
 									$limitToList = $controlTermArr['ommaterialsample']['sampleType']['l'];
 									?>
-									<select name="ms_sampleType" required>
+									<select name="ms_sampleType" id="ms_sampleType" required>
 										<option value="">-------</option>
 										<?php
 										foreach($controlTermArr['ommaterialsample']['sampleType']['t'] as $t){
@@ -118,27 +118,27 @@ $controlTermArr = $materialSampleManager->getMSTypeControlValues();
 								}
 								?>
 							</span>
-						</div>
-						<div class="smCatalogNumberDiv">
-							<label><?php echo $MS_LABEL_ARR['catalogNumber']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_catalogNumber"><?php echo $MS_LABEL_ARR['catalogNumber']; ?>: </label>
 							<span class="edit-elem">
-								<input type="text" name="ms_catalogNumber" value="<?php echo isset($msArr['catalogNumber'])?$msArr['catalogNumber']:''; ?>" />
+								<input type="text" name="ms_catalogNumber" id="ms_catalogNumber" value="<?php echo isset($msArr['catalogNumber'])?$msArr['catalogNumber']:''; ?>" />
 							</span>
-						</div>
-						<div class="smGuidDiv">
-							<label><?php echo $MS_LABEL_ARR['guid']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_guid"><?php echo $MS_LABEL_ARR['guid']; ?>: </label>
 							<span class="edit-elem">
-								<input type="text" name="ms_guid" value="<?php echo isset($msArr['guid'])?$msArr['guid']:''; ?>" />
+								<input type="text" name="ms_guid" id="ms_guid" value="<?php echo isset($msArr['guid'])?$msArr['guid']:''; ?>" />
 							</span>
-						</div>
-						<div class="smSampleConditionDiv">
-							<label><?php echo $MS_LABEL_ARR['sampleCondition']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_sampleCondition"><?php echo $MS_LABEL_ARR['sampleCondition']; ?>: </label>
 							<span class="edit-elem">
 								<?php
 								if(isset($controlTermArr['ommaterialsample']['sampleCondition'])){
 									$limitToList = $controlTermArr['ommaterialsample']['sampleCondition']['l'];
 									?>
-									<select name="ms_sampleCondition">
+									<select name="ms_sampleCondition" id="ms_sampleCondition">
 										<option value="">-------</option>
 										<?php
 										foreach($controlTermArr['ommaterialsample']['sampleCondition']['t'] as $t){
@@ -155,15 +155,15 @@ $controlTermArr = $materialSampleManager->getMSTypeControlValues();
 								}
 								?>
 							</span>
-						</div>
-						<div class="smDispositionDiv">
-							<label><?php echo $MS_LABEL_ARR['disposition']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_disposition"><?php echo $MS_LABEL_ARR['disposition']; ?>: </label>
 							<span class="edit-elem">
 								<?php
 								if(isset($controlTermArr['ommaterialsample']['disposition'])){
 									$limitToList = $controlTermArr['ommaterialsample']['disposition']['l'];
 									?>
-									<select name="ms_disposition">
+									<select name="ms_disposition" id="ms_disposition">
 										<option value="">-------</option>
 										<?php
 										foreach($controlTermArr['ommaterialsample']['disposition']['t'] as $t){
@@ -180,15 +180,15 @@ $controlTermArr = $materialSampleManager->getMSTypeControlValues();
 								}
 								?>
 							</span>
-						</div>
-						<div class="smPreservationTypeDiv">
-							<label><?php echo $MS_LABEL_ARR['preservationType']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_preservationType"><?php echo $MS_LABEL_ARR['preservationType']; ?>: </label>
 							<span class="edit-elem">
 								<?php
 								if(isset($controlTermArr['ommaterialsample']['preservationType'])){
 									$limitToList = $controlTermArr['ommaterialsample']['preservationType']['l'];
 									?>
-									<select name="ms_preservationType">
+									<select name="ms_preservationType" id="ms_preservationType">
 										<option value="">-------</option>
 										<?php
 										foreach($controlTermArr['ommaterialsample']['preservationType']['t'] as $t){
@@ -205,46 +205,46 @@ $controlTermArr = $materialSampleManager->getMSTypeControlValues();
 								}
 								?>
 							</span>
-						</div>
-						<div class="smPreparationDateDiv">
-							<label><?php echo $MS_LABEL_ARR['preparationDate']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_preparationDate"><?php echo $MS_LABEL_ARR['preparationDate']; ?>: </label>
 							<span class="edit-elem">
-								<input type="date" name="ms_preparationDate" value="<?php echo isset($msArr['preparationDate'])?$msArr['preparationDate']:''; ?>" />
+								<input type="date" name="ms_preparationDate" id="ms_preparationDate" value="<?php echo isset($msArr['preparationDate'])?$msArr['preparationDate']:''; ?>" />
 							</span>
-						</div>
-						<div class="smPreparedByUidDiv">
-							<label><?php echo $MS_LABEL_ARR['preparedBy']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_preparedBy"><?php echo $MS_LABEL_ARR['preparedBy']; ?>: </label>
 							<span class="edit-elem">
-								<input class="ms_preparedBy" name="ms_preparedBy" type="text" value="<?php echo isset($msArr['preparedBy'])?$msArr['preparedBy']:''; ?>" />
+								<input class="ms_preparedBy" name="ms_preparedBy" id="ms_preparedBy" type="text" value="<?php echo isset($msArr['preparedBy'])?$msArr['preparedBy']:''; ?>" />
 								<input name="ms_preparedByUid" type="hidden" value="<?php echo isset($msArr['preparedByUid'])?$msArr['preparedByUid']:''; ?>" />
 							</span>
-						</div>
-						<div class="smPreparationDetailsDiv">
-							<label><?php echo $MS_LABEL_ARR['preparationDetails']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_preparationDetails"><?php echo $MS_LABEL_ARR['preparationDetails']; ?>: </label>
 							<span class="edit-elem">
-								<input type="text" name="ms_preparationDetails" value="<?php echo isset($msArr['preparationDetails'])?$msArr['preparationDetails']:''; ?>" />
+								<input type="text" name="ms_preparationDetails" id="ms_preparationDetails" value="<?php echo isset($msArr['preparationDetails'])?$msArr['preparationDetails']:''; ?>" />
 							</span>
-						</div>
-						<div class="smIndividualCountDiv">
-							<label><?php echo $MS_LABEL_ARR['individualCount']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_individualCount"><?php echo $MS_LABEL_ARR['individualCount']; ?>: </label>
 							<span class="edit-elem">
-								<input type="text" name="ms_individualCount" value="<?php echo isset($msArr['individualCount'])?$msArr['individualCount']:''; ?>" />
+								<input type="text" name="ms_individualCount" id="ms_individualCount" value="<?php echo isset($msArr['individualCount'])?$msArr['individualCount']:''; ?>" />
 							</span>
-						</div>
-						<div class="smSampleSizeDiv">
-							<label><?php echo $MS_LABEL_ARR['sampleSize']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_sampleSize"><?php echo $MS_LABEL_ARR['sampleSize']; ?>: </label>
 							<span class="edit-elem">
-								<input type="text" name="ms_sampleSize" value="<?php echo isset($msArr['sampleSize'])?$msArr['sampleSize']:''; ?>" />
+								<input type="text" name="ms_sampleSize" id="ms_sampleSize" value="<?php echo isset($msArr['sampleSize'])?$msArr['sampleSize']:''; ?>" />
 							</span>
-						</div>
-						<div class="smStorageLocationDiv">
-							<label><?php echo $MS_LABEL_ARR['storageLocation']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_storageLocation"><?php echo $MS_LABEL_ARR['storageLocation']; ?>: </label>
 							<span class="edit-elem">
 								<?php
 								if(isset($controlTermArr['ommaterialsample']['storageLocation'])){
 									$limitToList = $controlTermArr['ommaterialsample']['storageLocation']['l'];
 									?>
-									<select name="ms_storageLocation">
+									<select name="ms_storageLocation" id="ms_storageLocation">
 										<option value="">-------</option>
 										<?php
 										foreach($controlTermArr['ommaterialsample']['storageLocation']['t'] as $t){
@@ -261,13 +261,13 @@ $controlTermArr = $materialSampleManager->getMSTypeControlValues();
 								}
 								?>
 							</span>
-						</div>
-						<div class="smRemarksDiv">
-							<label><?php echo $MS_LABEL_ARR['remarks']; ?>: </label>
+						</section>
+						<section class="spaced">
+							<label for="ms_remarks"><?php echo $MS_LABEL_ARR['remarks']; ?>: </label>
 							<span class="edit-elem">
-								<input type="text" name="ms_remarks" value="<?php echo isset($msArr['remarks'])?$msArr['remarks']:''; ?>" />
+								<input type="text" name="ms_remarks" id="ms_remarks" value="<?php echo isset($msArr['remarks'])?$msArr['remarks']:''; ?>" />
 							</span>
-						</div>
+						</section>
 						<div style="clear:both;">
 							<input name="occid" type="hidden" value="<?php echo $occid; ?>" />
 							<input name="matSampleID" type="hidden" value="<?php echo $matSampleID; ?>" />

--- a/collections/editor/observationsubmit.php
+++ b/collections/editor/observationsubmit.php
@@ -208,7 +208,7 @@ $clArr = $obsManager->getChecklists();
 							</div>
 							<div>
 								<label for="eventdate"><?php echo $LANG['DATE']; ?>:</label>
-								<input type="text" id="eventdate" name="eventdate" style="width:120px;" onchange="verifyDate(this);" title="format: yyyy-mm-dd" required />
+								<input id="eventdate" name="eventdate" style="width:120px;" onchange="verifyDate(this);" title="format: yyyy-mm-dd" required placeholder="yyyy-mm-dd" />
 								<a style="margin:15px 0px 0px 5px;" onclick="toggle('obsextradiv');return false" title="Display additional fields">
 									<img src="../../images/editplus.png" style="width:15px;" />
 								</a>

--- a/collections/editor/rpc/dupelist.php
+++ b/collections/editor/rpc/dupelist.php
@@ -47,30 +47,30 @@ $dupArr = $dupeManager->getDupeList($recordedBy, $recordNumber, $eventDate, $cat
 		<fieldset style="padding:15px;">
 			<legend><b>Link New Specimen</b></legend>
 			<form name="adddupform" method="post" action="dupelist.php" onsubmit="return validateDupeForm(this)">
-				<div style="margin:3px;">
-					<b>Last Name:</b>
-					<input name="recordedby" type="text" value="<?php echo $recordedBy; ?>" />
-				</div>
-				<div style="margin:3px;">
-					<b>Number:</b>
-					<input name="recordnumber" type="text" value="<?php echo $recordNumber; ?>" />
-				</div>
-				<div style="margin:3px;">
-					<b>Date:</b>
-					<input name="eventdate" type="text" value="<?php echo $eventDate; ?>" />
-				</div>
-				<div style="margin:3px;">
-					<b>Catalog Number:</b>
-					<input name="catnum" type="text" value="" />
-				</div>
-				<div style="margin:3px;">
-					<b>occid:</b>
-					<input name="occid" type="text" value="" />
- 				</div>
-				<div style="margin:20px;">
+				<section style="margin-bottom: 10px;">
+					<label for="recordedby"><b>Last Name:</b></label>
+					<input name="recordedby" id="recordedby" type="text" value="<?php echo $recordedBy; ?>" />
+				</section>
+				<section style="margin-bottom: 10px;">
+					<label for="recordnumber"><b>Number:</b></label>
+					<input name="recordnumber" id="recordnumber" type="text" value="<?php echo $recordNumber; ?>" />
+				</section>
+				<section style="margin-bottom: 10px;">
+					<label for="eventdate"><b>Date:</b></label>
+					<input name="eventdate" id="eventdate" type="date" value="<?php echo $eventDate; ?>" />
+				</section>
+				<section style="margin-bottom: 10px;">
+					<label for="catnum"><b>Catalog Number:</b></label>
+					<input name="catnum" id="catnum" type="text" value="" />
+				</section>
+				<section style="margin-bottom: 10px;">
+					<label for="occid"><b>Occurrence ID:</b></label>
+					<input name="occid" id="occid" type="text" value="" />
+				</section>
+				<section style="margin-bottom: 10px;">
 					<input name="curoccid" type="hidden" value="<?php echo $currentOccid; ?>" />
 					<input name="" type="submit" value="Search for Duplicates" />
- 				</div>
+ 				</section>
 			</form>
 		</fieldset>
 		<fieldset>

--- a/collections/editor/tools/coordformatter.php
+++ b/collections/editor/tools/coordformatter.php
@@ -182,50 +182,70 @@ header("Content-Type: text/html; charset=".$CHARSET);
 	<style type="text/css">
 		body{ background-color: #ffffff; }
 		#coordAidDiv{  }
-		.toolDiv{ float: left; padding: 15px 10px; }
+		.toolDiv{ margin-bottom: 10px;}
 		#dmsAidDiv{ }
 		#utmAidDiv{  }
 		#trsAidDiv{  }
 		.fieldDiv{ padding: 3px 0px }
-		.labelSpan{  }
+		.labelSection{ font-weight: bold;  font-size: 14; margin-bottom: 10px;}
 		.buttonDiv{ margin-top: 5px }
 	</style>
 </head>
 <body>
 	<div id="coordAidDiv">
 		<form name="formatterForm" onsubmit="return false">
-			<div id="dmsAidDiv" class="toolDiv">
+			<div id="dmsAidDiv" class="toolDiv" style="margin-top: 10px;">
 				<fieldset>
 					<legend>DMS Converter</legend>
-					<div class="fieldDiv">
-						<span class="labelSpan">Lat:</span>
-						<input name="latdeg" style="width:35px;" title="Latitude Degree" />&deg;
-						<input name="latmin" style="width:50px;" title="Latitude Minutes" />'
-						<input name="latsec" style="width:50px;" title="Latitude Seconds" />&quot;
-						<select name="latns">
+					<section class="labelSection">Latitude</section>
+					<section>
+						<label for="latdeg">Latitude Degree: </label>
+						<input name="latdeg" id="latdeg" style="width:35px;" title="Latitude Degree" />
+					</section>
+					<section>
+						<label for="latmin">Latitude Minutes: </label>
+						<input name="latmin" id="latmin" style="width:50px;" title="Latitude Minutes" />
+					</section>
+					<section>
+						<label for="latsec">Latitude Seconds: </label>
+						<input name="latsec" id="latsec" style="width:50px;" title="Latitude Seconds" />
+					</section>
+					<section>
+						<label for="latns">Direction: </label>
+						<select name="latns" id="latns">
 							<option>N</option>
 							<option>S</option>
 						</select>
-					</div>
-					<div class="fieldDiv">
-						<span class="labelSpan">Long:</span>
-						<input name="lngdeg" style="width:35px;" title="Longitude Degree" />&deg;
-						<input name="lngmin" style="width:50px;" title="Longitude Minutes" />'
-						<input name="lngsec" style="width:50px;" title="Longitude Seconds" />&quot;
-						<select name="lngew">
+					</section>
+					<section class="labelSection">Longitude</section>
+					<section>
+						<label for="lngdeg">Longitude Degree: </label>
+						<input name="lngdeg" id="lngdeg" style="width:35px;" title="Longitude Degree" />
+					</section>
+					<section>
+						<label for="lngmin">Longitude Minutes: </label>
+						<input name="lngmin" id="lngmin' style="width:50px;" title="Longitude Minutes" />
+					</section>
+					<section>
+						<label for="lngsec">Longitude Seconds: </label>
+						<input name="lngsec" id="lngsec" style="width:50px;" title="Longitude Seconds" />
+					</section>
+					<section>
+						<label for="lngew">Direction: </label>
+						<select name="lngew" id="lngew">
 							<option>E</option>
 							<option SELECTED>W</option>
 						</select>
-					</div>
-					<div class="fieldDiv">
-						<span class="labelSpan">Datum:</span>
-						<select name="lldatum">
+					</section>
+					<section>
+						<label for="lldatum">Datum: </label>
+						<select name="lldatum" id="lldatum">
 							<option value="WGS84" selected>WGS84</option>
 							<option value="NAD27">NAD27</option>
 							<option value="NAD83">NAD83</option>
 						</select>
-					</div>
-					<div style="margin:5px;">
+					</section>
+					<div>
 						<button type="button" onclick="fomatDWS(this.form)">Insert Lat/Long Values</button>
 					</div>
 				</fieldset>
@@ -233,94 +253,109 @@ header("Content-Type: text/html; charset=".$CHARSET);
 			<div id="utmAidDiv" class="toolDiv">
 				<fieldset>
 					<legend>UTM Converter</legend>
-					<div class="fieldDiv">
-						<span class="labelSpan">Zone:</span>
-						<input name="utmzone" style="width:40px;" />
-					</div>
-					<div class="fieldDiv">
-						<span class="labelSpan">East:</span>
-						<input name="utmeast" type="text" style="width:100px;" />
-					</div>
-					<div class="fieldDiv">
-						<span class="labelSpan">North:</span>
-						<input name="utmnorth" type="text" style="width:100px;" />
-					</div>
-					<div class="fieldDiv">
-						<span class="labelSpan">Hemisphere:</span>
-						<select name="hemisphere" title="Use hemisphere designator (e.g. 12N) rather than grid zone ">
+					<section>
+						<label for="utmzone">Zone:</label>
+						<input name="utmzone" id="utmzone" style="width:40px;" />
+					</section>
+					<section>
+						<label for="utmeast">East:</label>
+						<input name="utmeast" id="utmeast" type="text" style="width:100px;" />
+					</section>
+					<section>
+						<label for="utmnorth">North:</label>
+						<input name="utmnorth" id="utmnorth" type="text" style="width:100px;" />
+					</section>
+					<section>
+						<label for="hemisphere">Hemisphere:</label>
+						<select name="hemisphere" id="hemisphere" title="Use hemisphere designator (e.g. 12N) rather than grid zone ">
 							<option value="N">North</option>
 							<option value="S">South</option>
 						</select>
-					</div>
-					<div class="fieldDiv">
-						<span class="labelSpan">Datum:</span>
-						<select name="utmdatum">
+					</section>
+					<section>
+						<label for="utmdatum">Datum:</label>
+						<select name="utmdatum" id="utmdatum">
 							<option value="WGS84" selected>WGS84</option>
 							<option value="NAD27">NAD27</option>
 							<option value="NAD83">NAD83</option>
 						</select>
-					</div>
-					<div class="buttonDiv">
+					</section>
+					<div>
 						<button type="button" onclick="formatUTM(this.form)">Insert UTM Values</button>
 					</div>
 				</fieldset>
 			</div>
 			<div id="trsAidDiv" class="toolDiv">
 				<fieldset>
-					<legend>TRS Converter</legend>
-					<div class="fieldDiv">
-						T<input name="township" style="width:30px;" title="Township" />
-						<select name="townshipNS">
+					<legend>Township Range Section Converter</legend>
+					<section>
+						<label for="township">Township:</label>
+						<input name="township" id="township" style="width:30px;" title="Township" />
+					</section>
+					<section>
+						<label for="townshipNS">Township (N/S):</label>
+						<select name="townshipNS" id="townshipNS">
 							<option>N</option>
 							<option>S</option>
 						</select>
-						R<input name="range" style="width:30px;" title="Range" />
-						<select name="rangeEW">
+					</section>
+					<section>
+						<label for="range">Range:</label>
+						<input name="range" id="range" style="width:30px;" title="Range" />
+					</section>
+					<section>
+						<label for="rangeEW">Range (E/W):</label>
+						<select name="rangeEW" id="rangeEW">
 							<option>E</option>
 							<option>W</option>
 						</select>
-					</div>
-					<div class="fieldDiv">
-						Sec:
-						<input name="section" type="input" style="width:30px;" title="Section" />
-						Details:
-						<input name="secdetails" type="input" style="width:90px;" title="Section Details" />
-					</div>
-					<select name="meridian" title="Meridian">
-						<option value="">Meridian Selection</option>
-						<option value="">----------------------------------</option>
-						<option value="G-AZ">Arizona, Gila &amp; Salt River</option>
-						<option value="NAAZ">Arizona, Navajo</option>
-						<option value="F-AR">Arkansas, Fifth Principal</option>
-						<option value="H-CA">California, Humboldt</option>
-						<option value="M-CA">California, Mt. Diablo</option>
-						<option value="S-CA">California, San Bernardino</option>
-						<option value="NMCO">Colorado, New Mexico</option>
-						<option value="SPCO">Colorado, Sixth Principal</option>
-						<option value="UTCO">Colorado, Ute</option>
-						<option value="B-ID">Idaho, Boise</option>
-						<option value="SPKS">Kansas, Sixth Principal</option>
-						<option value="F-MO">Missouri, Fifth Principal</option>
-						<option value="P-MT">Montana, Principal</option>
-						<option value="SPNE">Nebraska, Sixth Principal</option>
-						<option value="M-NV">Nevada, Mt. Diablo</option>
-						<option value="NMNM">New Mexico, New Mexico</option>
-						<option value="F-ND">North Dakota, Fifth Principal</option>
-						<option value="C-OK">Oklahoma, Cimarron</option>
-						<option value="I-OK">Oklahoma, Indian</option>
-						<option value="W-OR">Oregon, Willamette</option>
-						<option value="BHSD">South Dakota, Black Hills</option>
-						<option value="F-SD">South Dakota, Fifth Principal</option>
-						<option value="SPSD">South Dakota, Sixth Principal</option>
-						<option value="SLUT">Utah, Salt Lake</option>
-						<option value="U-UT">Utah, Uinta</option>
-						<option value="W-WA">Washington, Willamette</option>
-						<option value="SPWY">Wyoming, Sixth Principal</option>
-						<option value="WRWY">Wyoming, Wind River</option>
-					</select>
-					<div class="buttonDiv">
+					</section>
+					<section>
+						<label for="section">Sec:</label>
+						<input name="section" id="section" type="input" style="width:30px;" title="Section" />
+					</section>
+					<section>
+						<label for="secdetails">Details:</label>
+						<input name="secdetails" id="secdetails" type="input" style="width:90px;" title="Section Details" />
+					</section>
+					<section>
+						<label for="meridian">Meridian: </label>
+						<select name="meridian" title="Meridian" id="meridian">
+							<option value="">Meridian Selection</option>
+							<option value="">----------------------------------</option>
+							<option value="G-AZ">Arizona, Gila &amp; Salt River</option>
+							<option value="NAAZ">Arizona, Navajo</option>
+							<option value="F-AR">Arkansas, Fifth Principal</option>
+							<option value="H-CA">California, Humboldt</option>
+							<option value="M-CA">California, Mt. Diablo</option>
+							<option value="S-CA">California, San Bernardino</option>
+							<option value="NMCO">Colorado, New Mexico</option>
+							<option value="SPCO">Colorado, Sixth Principal</option>
+							<option value="UTCO">Colorado, Ute</option>
+							<option value="B-ID">Idaho, Boise</option>
+							<option value="SPKS">Kansas, Sixth Principal</option>
+							<option value="F-MO">Missouri, Fifth Principal</option>
+							<option value="P-MT">Montana, Principal</option>
+							<option value="SPNE">Nebraska, Sixth Principal</option>
+							<option value="M-NV">Nevada, Mt. Diablo</option>
+							<option value="NMNM">New Mexico, New Mexico</option>
+							<option value="F-ND">North Dakota, Fifth Principal</option>
+							<option value="C-OK">Oklahoma, Cimarron</option>
+							<option value="I-OK">Oklahoma, Indian</option>
+							<option value="W-OR">Oregon, Willamette</option>
+							<option value="BHSD">South Dakota, Black Hills</option>
+							<option value="F-SD">South Dakota, Fifth Principal</option>
+							<option value="SPSD">South Dakota, Sixth Principal</option>
+							<option value="SLUT">Utah, Salt Lake</option>
+							<option value="U-UT">Utah, Uinta</option>
+							<option value="W-WA">Washington, Willamette</option>
+							<option value="SPWY">Wyoming, Sixth Principal</option>
+							<option value="WRWY">Wyoming, Wind River</option>
+						</select>
+					</section>
+					<section class="buttonDiv">
 						<button type="button" onclick="formatTRS(this.form)">Insert TRS Values</button>
-					</div>
+					</section>
 				</fieldset>
 			</div>
 		</form>

--- a/css/v202209/symbiota/collections/editor/occureditormaterialsample.css
+++ b/css/v202209/symbiota/collections/editor/occureditormaterialsample.css
@@ -168,3 +168,7 @@
 .smRemarksDiv input{
 	width: 90%;
 }
+
+.spaced{
+	margin-bottom: 10px;
+}


### PR DESCRIPTION
# Description

This PR places all of the form fields in collections/editor/includes/determinationtab.php, collections/editor/includes/imagetab.php, collections/editor/includes/materialsampleinclude.php, collections/editor/rpc/dupelist.php, and collections/editor/tools/coordformatter.php on their own lines in order to be more accessible for screen readers and people with attention-related disabilities. Note that this entailed purging a lot of "float" styles on the <input> elements.

It also provides labels (and a few placeholders) for each form field in order to be more accessible for screen readers.

Added and changed a few css classes, but nothing global.

**Note especially that a few of the form field inputs are of `type="date"` now. PLEASE DON'T APPROVE THE PR IF THESE ARE ERRONEOUS FIXES.**

**Note also that most of this work was completed before Ed suggested that I try to make the forms have a 508 "mode". That work will be featured in the next PR.**

## collections/editor/includes/determinationtab.php

### Before

I can't seem to see this one anymore. See image below.

### After

Weird. I can no longer see this one!
<img width="1552" alt="Screen Shot 2023-05-09 at 3 45 48 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/37e35a74-31d2-4ea9-9051-939624083686">


## collections/editor/includes/imagetab.php

### Before

<img width="1552" alt="Screen Shot 2023-05-09 at 3 48 15 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/da3fa26d-0a32-4ca6-8924-5bf66e7b34d5">


### After

<img width="1552" alt="Screen Shot 2023-05-09 at 3 46 11 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/80f5f853-e95e-455e-9bab-98ed58e55004">

## collections/editor/tools/coordformatter.php

### Before

<img width="1552" alt="Screen Shot 2023-05-09 at 3 47 54 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/e95b11de-2c34-4f30-8cc7-95377df58906">


### After

<img width="1552" alt="Screen Shot 2023-05-09 at 3 27 40 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/d49eedae-0df9-4951-aedf-bf522a0aef59">

## collections/editor/includes/materialsampleinclude.php

### Before

<img width="1552" alt="Screen Shot 2023-05-09 at 3 47 35 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/757f4c19-2e6d-4f33-ad6a-3745f88abce6">


### After

<img width="1552" alt="Screen Shot 2023-05-09 at 3 49 08 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/fa3fd752-d402-4c23-b0dd-a92586f485ab">


## collections/editor/rpc/dupelist.php

### Before

<img width="1552" alt="Screen Shot 2023-05-09 at 3 47 14 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/8d7741b7-dcea-4121-8770-1dacfbbeecc9">


### After

<img width="1552" alt="Screen Shot 2023-05-09 at 3 46 34 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/6d19317c-53ac-4a72-8ca6-3b4ecb11b718">


## 

# Pull Request Checklist:

- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    - NA
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
    - The php files targeted in this PR did not have pre-existing translation files. There was some new text, but not much. I made the call to not make the effort to internationalize in these cases.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - NA
- [ ] Comment which GitHub issue(s), if any does this PR address
    - NA
    
# TODO
- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
