### PR TITLE
Occurrence Upload basisOfRecord bug

### DIFF
--- a/classes/ChecklistVoucherAdmin.php
+++ b/classes/ChecklistVoucherAdmin.php
@@ -651,7 +651,7 @@ class ChecklistVoucherAdmin extends Manager {
 				}
 				$rs->free();
 			}
-			if($retArr){
+			if($retArr && $this->clid){
 				//Tag collection most likely to be target
 				$sql = 'SELECT o.collid, COUNT(v.occid) as cnt
 					FROM fmvouchers v INNER JOIN omoccurrences o ON v.occid = o.occid


### PR DESCRIPTION
Resolves GitHub issue: https://github.com/BioKIC/Symbiota/issues/382

- Fix issue with setting basisOfRecord default value when data is not supplied within input file. Default value applied depends on collType value set within omcollections table
- basisOfRecord now set at time of loading data into uploadspectemp table to make it possible for user to preview value before final activation/transfer of data

Pull Request Checklist:

- [x] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [x] There are no linter errors
- [x] Comment which GitHub issue(s), if any does this PR address
