### PR TITLE
adjust PR protocol in the case of hotfixes. Make explicit that hotfix…

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,7 @@
 Pull Request Checklist:
 
+- [ ] Hotfixes should be branched off of the `master` branch and merged back into the `master` branch. Subsequently, a PR from `master` into Development should be made.
 - [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
-- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
 - [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
 - [ ] There are no linter errors
 - [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,6 +1,6 @@
 Pull Request Checklist:
 
-- [ ] Hotfixes should be branched off of the `master` branch and merged back into the `master` branch. Subsequently, a PR from `master` into Development should be made.
+- [ ] Hotfixes should be branched off of the `master` branch and merged back into the `master` branch. Subsequently, a PR from `master` into `Development` should be made.
 - [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
 - [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
 - [ ] There are no linter errors


### PR DESCRIPTION
… work should deal with the master branch directly and then should be PRed into Development subsequently

# Description

This PR is in response to decisions reached during the [dev team meeting on 8 May, 2023](https://docs.google.com/document/d/19T367SS9q5opYW84Y44_m3QXyDcTEmLkWa7Dvxsl3OU/edit).

# Pull Request Checklist:

- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    -N/A
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
    -N/A
- [ ] There are no linter errors
    -N/A
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    -N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    -N/A
- [ ] Comment which GitHub issue(s), if any does this PR address
    -N/A

# TODO
- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
