### PR TITLE
make it impossible for null to be passed to str_replace and relevant …

### DIFF
--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -775,17 +775,17 @@ class OccurrenceEditorManager {
 			//Iterate through occurrences and merge addtional identifiers and otherCatalogNumbers field values
 			foreach($occurrenceArr as $occid => $occurArr){
 				$otherCatNumArr = array();
-				$trimableOccurArr = $occurArr['othercatalognumbers'] ?? "";
-				if($ocnStr = trim($trimableOccurArr,',;| ')){
+				$trimmableOccurArr = $occurArr['othercatalognumbers'] ?? "";
+				if($ocnStr = trim($trimmableOccurArr,',;| ')){
 					$ocnStr = str_replace(array(',',';'),'|',$ocnStr);
 					$ocnArr = explode('|',$ocnStr);
 					foreach($ocnArr as $identUnit){
-						$trimableIdentUnit = $identUnit ?? "";
-						$unitArr = explode(':',trim($trimableIdentUnit,': '));
+						$trimmableIdentUnit = $identUnit ?? "";
+						$unitArr = explode(':',trim($trimmableIdentUnit,': '));
 						$safeUnitArr = $unitArr ?? array();
 						$tag = '';
-						$trimableShiftedUnitArr = array_shift($safeUnitArr) ?? "";
-						if(count($safeUnitArr) > 1) $tag = trim($trimableShiftedUnitArr);
+						$trimmableShiftedUnitArr = array_shift($safeUnitArr) ?? "";
+						if(count($safeUnitArr) > 1) $tag = trim($trimmableShiftedUnitArr);
 						$value = trim(implode(', ',$safeUnitArr));
 						$otherCatNumArr[$value] = $tag;
 					}

--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -775,14 +775,18 @@ class OccurrenceEditorManager {
 			//Iterate through occurrences and merge addtional identifiers and otherCatalogNumbers field values
 			foreach($occurrenceArr as $occid => $occurArr){
 				$otherCatNumArr = array();
-				if($ocnStr = trim($occurArr['othercatalognumbers'],',;| ')){
+				$trimableOccurArr = $occurArr['othercatalognumbers'] ?? "";
+				if($ocnStr = trim($trimableOccurArr,',;| ')){
 					$ocnStr = str_replace(array(',',';'),'|',$ocnStr);
 					$ocnArr = explode('|',$ocnStr);
 					foreach($ocnArr as $identUnit){
-						$unitArr = explode(':',trim($identUnit,': '));
+						$trimableIdentUnit = $identUnit ?? "";
+						$unitArr = explode(':',trim($trimableIdentUnit,': '));
+						$safeUnitArr = $unitArr ?? array();
 						$tag = '';
-						if(count($unitArr) > 1) $tag = trim(array_shift($unitArr));
-						$value = trim(implode(', ',$unitArr));
+						$trimableShiftedUnitArr = array_shift($safeUnitArr) ?? [];
+						if(count($safeUnitArr) > 1) $tag = trim($trimableShiftedUnitArr);
+						$value = trim(implode(', ',$safeUnitArr));
 						$otherCatNumArr[$value] = $tag;
 					}
 				}
@@ -2532,20 +2536,23 @@ class OccurrenceEditorManager {
 	}
 
 	protected function cleanOutStr($str){
-		$newStr = str_replace('"',"&quot;",$str);
+		$safeStr = $str ?? "";
+		$newStr = str_replace('"',"&quot;",$safeStr);
 		$newStr = str_replace("'","&apos;",$newStr);
 		return $newStr;
 	}
 
 	protected function cleanInStr($str){
-		$newStr = trim($str);
+		$safeStr = $str ?? "";
+		$newStr = trim($safeStr);
 		$newStr = preg_replace('/\s\s+/', ' ',$newStr);
 		$newStr = $this->conn->real_escape_string($newStr);
 		return $newStr;
 	}
 
 	protected function cleanRawFragment($str){
-		$newStr = trim($str);
+		$safeStr = $str ?? "";
+		$newStr = trim($safeStr);
 		$newStr = $this->encodeStr($newStr);
 		$newStr = $this->conn->real_escape_string($newStr);
 		return $newStr;

--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -784,7 +784,7 @@ class OccurrenceEditorManager {
 						$unitArr = explode(':',trim($trimableIdentUnit,': '));
 						$safeUnitArr = $unitArr ?? array();
 						$tag = '';
-						$trimableShiftedUnitArr = array_shift($safeUnitArr) ?? [];
+						$trimableShiftedUnitArr = array_shift($safeUnitArr) ?? "";
 						if(count($safeUnitArr) > 1) $tag = trim($trimableShiftedUnitArr);
 						$value = trim(implode(', ',$safeUnitArr));
 						$otherCatNumArr[$value] = $tag;


### PR DESCRIPTION
…trim()

# Description

My development environment is warning me that trim() and str_replace() with null arguments is deprecated in PHP 8.0 +.
It was causing http://localhost/Symbiota/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=70 to timeout.

It was easier to fix with a PR than it was to suppress warnings in my PHP.ini file lol. This seems like enough to have suppressed the warnings.

NOTE: * This is just a fix for occurrenceEditorManager.php *

## Before

![Screen Shot 2023-05-17 at 2 21 02 PM](https://github.com/BioKIC/Symbiota/assets/2775448/62e916d4-8b34-4bb9-b5f7-49e53d85e13e)

## After

![Screen Shot 2023-05-17 at 2 22 57 PM](https://github.com/BioKIC/Symbiota/assets/2775448/d41a7004-a00e-463d-85a3-cc8393757bcf)

# Pull Request Checklist:

- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    - N/A
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [ ] Comment which GitHub issue(s), if any does this PR address
    - N/A

# TODO
- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
