### PR TITLE
add delete branch item per team meeting discussion Jun 20, 2023 and a…

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,5 +1,6 @@
 Pull Request Checklist:
 
+- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
 - [ ] Hotfixes should be branched off of the `master` branch and merged back into the `master` branch. Subsequently, a PR from `master` into `Development` should be made.
 - [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
 - [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
@@ -12,5 +13,6 @@ Pull Request Checklist:
 - [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
 - [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
 - [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place
+- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.
 
 Thanks for contributing and keeping it clean!


### PR DESCRIPTION
…lso add PR description to checklist as a result of slack chatter

# Description

Adds two items to the PR checklist:

1. Feature branch deletion as part of the cleanup (as discussed in Dev. meeting on Jun 20, 2023).
2. Adding a description section (however brief) to PRs. This one was never formally discussed in the team meeting, but [came up in slack](https://symbiota-support.slack.com/archives/C04RLK7D5MK/p1688587999868019?thread_ts=1688582741.824719&cid=C04RLK7D5MK), so please feel free to push back on whether this should be added at all/whether the phrasing should change, etc.

This PR should likely be reviewed by the entire team.

# Pull Request Checklist:

- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    - N/A
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [ ] Comment which GitHub issue(s), if any does this PR address
    - N/A

# TODO
- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
