### PR TITLE
fix totalValidatorPro issues for includes/usagepolicy_template.php

### DIFF
--- a/includes/usagepolicy_template.php
+++ b/includes/usagepolicy_template.php
@@ -1,10 +1,11 @@
+<!DOCTYPE html>
 <?php
 include_once('../config/symbini.php');
 include_once ($SERVER_ROOT.'/classes/UtilityFunctions.php');
 header("Content-Type: text/html; charset=" . $CHARSET);
 $serverHost = UtilityFunctions::getDomain();
 ?>
-<html>
+<html lang="en">
 
 <head>
 	<title><?php echo $DEFAULT_TITLE; ?> Data Usage Guidelines</title>
@@ -78,8 +79,8 @@ $serverHost = UtilityFunctions::getDomain();
 					directed to the appropriate curators and/or collections managers.
 				</li>
 				<li>
-					<?php echo $DEFAULT_TITLE; ?> cannot assume responsibility for damages resulting from mis-use or
-					mis-interpretation of datasets or from errors or omissions that may exist in the data.
+					<?php echo $DEFAULT_TITLE; ?> cannot assume responsibility for damages resulting from misuse or
+					misinterpretation of datasets or from errors or omissions that may exist in the data.
 				</li>
 				<li>
 					It is considered a matter of professional ethics to cite and acknowledge the work of other scientists that
@@ -105,7 +106,7 @@ $serverHost = UtilityFunctions::getDomain();
 		<p>Specimens are used for scientific research and because of skilled preparation and careful use they may last for hundreds of years. Some collections have specimens that were
 		collected over 100 years ago that are no longer occur within the area. By making these specimens available on the web as images, their availability and value improves without
 		an increase in inadvertent damage caused by use. Note that if you are considering making specimens, remember collecting normally requires permission of the landowner and,
-		in the case of rare and endangered plants, additional permits may be required. It is best to coordinate such efforts with a regional institution that manages a publically
+		in the case of rare and endangered plants, additional permits may be required. It is best to coordinate such efforts with a regional institution that manages a publicly
 		accessible collection.
 		</p>
 


### PR DESCRIPTION
# Description

The totalValidatorPro run was surprisingly sparse on the usagepolicy page: it only identified DOCTYPE, a missing lang attribute in the `<html>` tag, and a few valid spelling mistakes. These have been fixed in this PR.

# Pull Request Checklist:

- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    - N/A
- [x] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
    - N/A

# TODO
- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
