### PR TITLE
Collections misc collprofiles

### DIFF
--- a/classes/OccurrenceCollectionProfile.php
+++ b/classes/OccurrenceCollectionProfile.php
@@ -93,8 +93,8 @@ class OccurrenceCollectionProfile extends OmCollections{
 				$title = (isset($LANG['HOMEPAGE'])?$LANG['HOMEPAGE']:'Homepage');
 				foreach($resourceArr as $rArr){
 					if(isset($rArr['title'][$LANG_TAG]) && $rArr['title'][$LANG_TAG]) $title = $rArr['title'][$LANG_TAG];
-					$outStr .= '<div class="field-div"><span class="label">'.$title.':</span> ';
-					$outStr .= '<a href="' . htmlspecialchars($rArr['url'], HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">' . htmlspecialchars($rArr['url'], HTML_SPECIAL_CHARS_FLAGS) . '</a>';
+					$outStr .= '<div class="field-div">';
+					$outStr .= '<a href="' . htmlspecialchars($rArr['url'], HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">' . $title . '</a>';
 					$outStr .= '</div>';
 				}
 			}
@@ -125,8 +125,7 @@ class OccurrenceCollectionProfile extends OmCollections{
 		if($this->collMeta[$this->collid]['dwcaurl']){
 			$dwcaUrl = $this->collMeta[$this->collid]['dwcaurl'];
 			$outStr .= '<div class="field-div">';
-			$outStr .= '<span class="label">'.(isset($LANG['DWCA_PUB'])?$LANG['DWCA_PUB']:'DwC-Archive Access Point').':</span> ';
-			$outStr .= '<a href="' . htmlspecialchars($dwcaUrl, HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($dwcaUrl, HTML_SPECIAL_CHARS_FLAGS) . '</a>';
+			$outStr .= '<a href="' . htmlspecialchars($dwcaUrl, HTML_SPECIAL_CHARS_FLAGS) . '">' . (isset($LANG['DWCA_PUB'])?$LANG['DWCA_PUB']:'DwC-Archive Access Point') . '</a>';
 			$outStr .= '</div>';
 		}
 		$outStr .= '<div class="field-div">';
@@ -149,7 +148,8 @@ class OccurrenceCollectionProfile extends OmCollections{
 		}
 		$outStr .= '</div>';
 		$outStr .= '<div class="field-div"><span class="label">' . htmlspecialchars((isset($LANG['DIGITAL_METADATA'])?$LANG['DIGITAL_METADATA']:'Digital Metadata'), HTML_SPECIAL_CHARS_FLAGS) . ':</span> <a href="../datasets/emlhandler.php?collid=' . htmlspecialchars($this->collMeta[$this->collid]['collid'], HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">EML File</a></div>';
-		$outStr .= '<div class="field-div"><span class="label">'.$LANG['USAGE_RIGHTS'].':</span> ';
+		// $outStr .= '<div class="field-div"><span class="label">'.$LANG['USAGE_RIGHTS'].':</span> ';
+		$outStr .= '<div class="field-div">';
 		if($this->collMeta[$this->collid]['rights']){
 			$rights = $this->collMeta[$this->collid]['rights'];
 			$rightsUrl = '';
@@ -162,7 +162,8 @@ class OccurrenceCollectionProfile extends OmCollections{
 				}
 			}
 			if($rightsUrl) $outStr .= '<a href="' . htmlspecialchars($rightsUrl, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">';
-			$outStr .= $rights;
+			// $outStr .= $rights;
+			$outStr .= $LANG['USAGE_RIGHTS'];
 			if($rightsUrl) $outStr .= '</a>';
 		}
 		elseif(file_exists('../../includes/usagepolicy.php')){

--- a/classes/OccurrenceCollectionProfile.php
+++ b/classes/OccurrenceCollectionProfile.php
@@ -148,7 +148,6 @@ class OccurrenceCollectionProfile extends OmCollections{
 		}
 		$outStr .= '</div>';
 		$outStr .= '<div class="field-div"><span class="label">' . htmlspecialchars((isset($LANG['DIGITAL_METADATA'])?$LANG['DIGITAL_METADATA']:'Digital Metadata'), HTML_SPECIAL_CHARS_FLAGS) . ':</span> <a href="../datasets/emlhandler.php?collid=' . htmlspecialchars($this->collMeta[$this->collid]['collid'], HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">EML File</a></div>';
-		// $outStr .= '<div class="field-div"><span class="label">'.$LANG['USAGE_RIGHTS'].':</span> ';
 		$outStr .= '<div class="field-div">';
 		if($this->collMeta[$this->collid]['rights']){
 			$rights = $this->collMeta[$this->collid]['rights'];
@@ -162,7 +161,6 @@ class OccurrenceCollectionProfile extends OmCollections{
 				}
 			}
 			if($rightsUrl) $outStr .= '<a href="' . htmlspecialchars($rightsUrl, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">';
-			// $outStr .= $rights;
 			$outStr .= $LANG['USAGE_RIGHTS'];
 			if($rightsUrl) $outStr .= '</a>';
 		}

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -105,7 +105,7 @@ if ($SYMB_UID) {
 			// GBIF citations widget
 			if ($datasetKey) {
 				echo '<div style="margin-left: 10px; margin-bottom: 20px;">';
-				echo '<iframe src="https://www.gbif.org/api/widgets/literature/button?gbifDatasetKey=' . $datasetKey . '" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="false" style="width: 140px; height: 24px;"></iframe>';
+				echo '<iframe title="GBIF citations" src="https://www.gbif.org/api/widgets/literature/button?gbifDatasetKey=' . $datasetKey . '" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="false" style="width: 140px; height: 24px;"></iframe>';
 				// Check if the Bionomia badge has been created yet - typically lags ~2 weeks behind GBIF publication
 				$bionomiaUrl = 'https://api.bionomia.net/dataset/' . $datasetKey . '/badge.svg';
 				$ch = curl_init($bionomiaUrl);
@@ -548,7 +548,7 @@ if ($SYMB_UID) {
 								if (substr($iconStr, 0, 6) == 'images') $iconStr = '../../' . $iconStr;
 								?>
 								<div class="justify-center">
-									<img src='<?php echo $iconStr; ?>' class="col-profile-img" /><br />
+									<img src='<?php echo $iconStr; ?>' class="col-profile-img" alt="icon for collection" /><br />
 								</div>
 							<?php
 							} else{
@@ -583,10 +583,6 @@ if ($SYMB_UID) {
 							<div style='margin:5px 0px 15px 10px;'>
 								<a href='collprofiles.php?collid=<?php echo htmlspecialchars($cid, HTML_SPECIAL_CHARS_FLAGS); ?>'><?php echo htmlspecialchars((isset($LANG['MORE_INFO']) ? $LANG['MORE_INFO'] : 'More Information'), HTML_SPECIAL_CHARS_FLAGS); ?></a>
 							</div>
-						</div>
-					</section>
-					<section class="bottom-breathing-room gridlike-form-row">
-						<div colspan='2'>
 						</div>
 					</section>
 					<hr class="test" />

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <?php
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT . '/content/lang/collections/misc/collprofiles.' . $LANG_TAG . '.php');
@@ -32,11 +33,11 @@ if ($SYMB_UID) {
 	}
 }
 ?>
-<html>
+<html lang="<?php echo $LANG_TAG ?>">
 <head>
 	<title><?php echo $DEFAULT_TITLE . ' ' . ($collid && isset($collData[$collid])? $collData[$collid]['collectionname'] : ''); ?></title>
 	<meta name="keywords" content="Natural history collections,<?php echo ($collid ? $collData[$collid]['collectionname'] : ''); ?>" />
-	<meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
+	<meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
 	<meta http-equiv="Pragma" content="no-cache">
 	<link href="<?php echo htmlspecialchars($CSS_BASE_PATH, HTML_SPECIAL_CHARS_FLAGS); ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
@@ -57,7 +58,7 @@ if ($SYMB_UID) {
 			return false;
 		}
 	</script>
-	<style type="text/css">
+	<style>
 		.field-div {
 			margin: 10px 0px;
 			clear: both
@@ -532,9 +533,7 @@ if ($SYMB_UID) {
 			?>
 			<h2><?php echo $DEFAULT_TITLE . ' ' . (isset($LANG['COLLECTION_PROJECTS']) ? $LANG['COLLECTION_PROJECTS'] : 'Natural History Collections and Observation Projects'); ?></h2>
 			<div style='margin:10px;clear:both;'>
-				<?php
-				echo (isset($LANG['RSS_FEED']) ? $LANG['RSS_FEED'] : 'RSS feed') . ': <a href="../datasets/rsshandler.php" target="_blank">' . htmlspecialchars($collManager->getDomain(), HTML_SPECIAL_CHARS_FLAGS) . htmlspecialchars($CLIENT_ROOT, HTML_SPECIAL_CHARS_FLAGS) . 'collections/datasets/rsshandler.php</a>';
-				?>
+				<a href="../datasets/rsshandler.php" target="_blank"><?php echo (isset($LANG['RSS_FEED']) ? $LANG['RSS_FEED'] : 'RSS feed'); ?></a>
 				<hr />
 			</div>
 			<table style='margin:10px;'>

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -530,7 +530,7 @@ if ($SYMB_UID) {
 		} elseif($collData) {
 			?>
 			<h2><?php echo $DEFAULT_TITLE . ' ' . (isset($LANG['COLLECTION_PROJECTS']) ? $LANG['COLLECTION_PROJECTS'] : 'Natural History Collections and Observation Projects'); ?></h2>
-			<div style='margin:10px;clear:both;'>
+			<div>
 				<a href="../datasets/rsshandler.php" target="_blank"><?php echo (isset($LANG['RSS_FEED']) ? $LANG['RSS_FEED'] : 'RSS feed'); ?></a>
 				<hr />
 			</div>

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -37,8 +37,6 @@ if ($SYMB_UID) {
 <head>
 	<title><?php echo $DEFAULT_TITLE . ' ' . ($collid && isset($collData[$collid])? $collData[$collid]['collectionname'] : ''); ?></title>
 	<meta name="keywords" content="Natural history collections,<?php echo ($collid ? $collData[$collid]['collectionname'] : ''); ?>" />
-	<meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
-	<meta http-equiv="Pragma" content="no-cache">
 	<link href="<?php echo htmlspecialchars($CSS_BASE_PATH, HTML_SPECIAL_CHARS_FLAGS); ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
 	include_once($SERVER_ROOT . '/includes/head.php');
@@ -105,7 +103,7 @@ if ($SYMB_UID) {
 			// GBIF citations widget
 			if ($datasetKey) {
 				echo '<div style="margin-left: 10px; margin-bottom: 20px;">';
-				echo '<iframe title="GBIF citations" src="https://www.gbif.org/api/widgets/literature/button?gbifDatasetKey=' . $datasetKey . '" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="false" style="width: 140px; height: 24px;"></iframe>';
+				echo '<iframe title="GBIF citation" src="https://www.gbif.org/api/widgets/literature/button?gbifDatasetKey=' . $datasetKey . '" frameborder="0" allowtransparency="true" style="width: 140px; height: 24px;"></iframe>';
 				// Check if the Bionomia badge has been created yet - typically lags ~2 weeks behind GBIF publication
 				$bionomiaUrl = 'https://api.bionomia.net/dataset/' . $datasetKey . '/badge.svg';
 				$ch = curl_init($bionomiaUrl);
@@ -551,7 +549,7 @@ if ($SYMB_UID) {
 									<img src='<?php echo $iconStr; ?>' class="col-profile-img" alt="icon for collection" /><br />
 								</div>
 							<?php
-							} else{
+							} else{ // placeholder for missing icon
 								?>
 								<div class="justify-center">
 									<p class="col-profile-img"></p><br />

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -536,27 +536,31 @@ if ($SYMB_UID) {
 				<a href="../datasets/rsshandler.php" target="_blank"><?php echo (isset($LANG['RSS_FEED']) ? $LANG['RSS_FEED'] : 'RSS feed'); ?></a>
 				<hr />
 			</div>
-			<table style='margin:10px;'>
+			<div class="gridlike-form">
 				<?php
 				foreach ($collData as $cid => $collArr) {
 					?>
-					<tr>
-						<td style='text-align:center;vertical-align:top;'>
+					<section class="bottom-breathing-room gridlike-form-row">
+						<div style='text-align:center;vertical-align:top; max-width:50px;'>
 							<?php
 							$iconStr = $collArr['icon'];
 							if ($iconStr) {
 								if (substr($iconStr, 0, 6) == 'images') $iconStr = '../../' . $iconStr;
 								?>
-								<img src='<?php echo $iconStr; ?>' style='border-size:1px;height:30;width:30;' /><br />
-								<?php
-								echo $collArr['institutioncode'];
-								if ($collArr['collectioncode']) echo '-' . $collArr['collectioncode'];
+								<img src='<?php echo $iconStr; ?>' class="col-profile-img" /><br />
+								<div>
+									<?php
+									echo $collArr['institutioncode'];
+									if ($collArr['collectioncode']) echo '-' . $collArr['collectioncode'];
+									?>
+								</div>
+							<?php
 							}
 							?>
-						</td>
-						<td>
+						</div>
+						<div>
 							<h3>
-								<a href='collprofiles.php?collid=<?php echo htmlspecialchars($cid, HTML_SPECIAL_CHARS_FLAGS); ?>'>
+								<a class="col-profile-header" href='collprofiles.php?collid=<?php echo htmlspecialchars($cid, HTML_SPECIAL_CHARS_FLAGS); ?>'>
 									<?php echo $collArr['collectionname']; ?>
 								</a>
 							</h3>
@@ -569,17 +573,17 @@ if ($SYMB_UID) {
 							<div style='margin:5px 0px 15px 10px;'>
 								<a href='collprofiles.php?collid=<?php echo htmlspecialchars($cid, HTML_SPECIAL_CHARS_FLAGS); ?>'><?php echo htmlspecialchars((isset($LANG['MORE_INFO']) ? $LANG['MORE_INFO'] : 'More Information'), HTML_SPECIAL_CHARS_FLAGS); ?></a>
 							</div>
-						</td>
-					</tr>
-					<tr>
-						<td colspan='2'>
-							<hr />
-						</td>
-					</tr>
+						</div>
+					</section>
+					<section class="bottom-breathing-room gridlike-form-row">
+						<div colspan='2'>
+						</div>
+					</section>
+					<hr class="test" />
 					<?php
 				}
 				?>
-			</table>
+			</div>
 			<?php
 		}
 		?>

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -541,22 +541,32 @@ if ($SYMB_UID) {
 				foreach ($collData as $cid => $collArr) {
 					?>
 					<section class="bottom-breathing-room gridlike-form-row">
-						<div style='text-align:center;vertical-align:top; max-width:50px;'>
+						<div class="gridlike-form">
 							<?php
 							$iconStr = $collArr['icon'];
 							if ($iconStr) {
 								if (substr($iconStr, 0, 6) == 'images') $iconStr = '../../' . $iconStr;
 								?>
-								<img src='<?php echo $iconStr; ?>' class="col-profile-img" /><br />
-								<div>
-									<?php
-									echo $collArr['institutioncode'];
-									if ($collArr['collectioncode']) echo '-' . $collArr['collectioncode'];
-									?>
+								<div class="justify-center">
+									<img src='<?php echo $iconStr; ?>' class="col-profile-img" /><br />
 								</div>
 							<?php
+							} else{
+								?>
+								<div class="justify-center">
+									<p class="col-profile-img"></p><br />
+								</div>
+								<?php
 							}
 							?>
+							<div class="gridlike-form-row col-profile-inst-code justify-center">
+									<p>
+										<?php
+										echo $collArr['institutioncode'] ?? '';
+										if ($collArr['collectioncode']) echo '-' . $collArr['collectioncode'];
+										?>
+									</p>
+								</div>
 						</div>
 						<div>
 							<h3>

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -431,3 +431,17 @@ table.styledtable tr.alt td {
 .gridlike-form-row-input {
   width: 40%;
 }
+
+.col-profile-img {
+  border: 1px;
+  height: 30px;
+  width: 30px;
+}
+
+.col-profile-header {
+  margin-left: 0.5em;
+}
+
+.test {
+  background-color: black;
+}

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -442,10 +442,6 @@ table.styledtable tr.alt td {
   margin-left: 0.5em;
 }
 
-.test {
-  background-color: black;
-}
-
 .col-profile-inst-code {
   min-width: 9rem;
   max-width: 9rem;

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -434,8 +434,8 @@ table.styledtable tr.alt td {
 
 .col-profile-img {
   border: 1px;
-  height: 30px;
-  width: 30px;
+  height: 6.4rem;
+  width: 6.4rem;
 }
 
 .col-profile-header {
@@ -444,4 +444,14 @@ table.styledtable tr.alt td {
 
 .test {
   background-color: black;
+}
+
+.col-profile-inst-code {
+  min-width: 9rem;
+  max-width: 9rem;
+}
+
+.justify-center {
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
# Description

This PR fixes as many of the 508-compliance issues highlighted by TotalValidatorPro as possible for collections/misc/collprofiles.php.

## Errors highlighted before these fixes:

<img width="1552" alt="Screen Shot 2023-07-26 at 11 15 46 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/ab9542fe-5ae1-4620-9222-7e9dc466d7bb">

## Errors highlighted after these fixes:

<img width="1552" alt="Screen Shot 2023-07-26 at 11 05 46 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/14bf09c8-0544-4b20-adc7-df964346e4cc">


## Aesthetic changes

Screen readers have a lot of trouble navigating nested tables, so I removed the tables on this page, which were present only for aesthetic reasons. I implemented styling that resulted in what I thought were comparable results or improvements, but I'm open to objections about this.

### Aesthetics Before:

<img width="1552" alt="Screen Shot 2023-07-26 at 11 13 16 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/12e79d22-0897-412b-8414-eb275060a2cf">

### Aesthetics After:

<img width="1552" alt="Screen Shot 2023-07-26 at 10 53 22 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/84de0f2b-cf61-4da2-bd1e-3fbeda273b4c">

## Addressing remaining errors highlighted by TotalValidatorPro.

All remaining issues I believe are specific to HTML that's coming from entries stored in the database. Specifically,

- The "Use relative rather than absolute units. Using relative units helps the page to be rendered correctly at different resolutions and allows people with sight difficulties to 'zoom in' to pages to read them." errors come from code like 

`<p style="font-family: Arial, Helvetica, sans-serif; font-size: 12px; background-color: #ffffff;">`

which is not found directly in collections/misc/collprofiles.php, but rather from within a call to OccurrenceCollectionProfile.php via `$collManager->getMetadataHtml()`. Within this method, the code is being pulled from the "full description" of the collection metadata: `collMeta[$this->collid]["fulldescription"]`. In other words, I suspect that the problematic HTML is coming from the database directly and not our codebase.

- The same is true for the, "Add a 'title' attribute to facilitate identification and navigation `<iframe style="width: 140px; height: 24px;" src="https://www.gbif.org/api/widgets...`" errors; these are coming from the the same `$collManager->getMetadataHtml()` call.

- The same is true for the, "Duplicate 'id' value found. `<menu id="fcltHTML5Menu1"...`" error.

- The same is true for the , "Unrecognised element. This error is often raised when an old element has been used when testing against a newer HTML specification...
`<menu id="fcltHTML5Menu1...`" error.

- The same is true for the, " The 'scrolling' attribute is not allowed here" error.

- The same is true for the, "The 'allowfullscreen' attribute does not have a valid value" error.

- All dead links are Collection-specific and have been escalated to the SSH core: https://symbiota-support.slack.com/archives/C05K9KXNCEM/p1690392803131579

- The "Problem with link: Internal Server Error" has also been reported to the SSH core team: https://symbiota-support.slack.com/archives/C05K9KXNCEM/p1690394021301919

- All remaining, "Do not use the URL as link text" errors come from internal content stored in the database.

- The, "Heading mark-up should be used if this is a heading `<strong>`" errors also come from CCH2 database-specific content.



Pull Request Checklist:

- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    - N/A
- [x] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=31321457

# TODO

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
