### PR TITLE
508 accessibility mode imagelib/search.php

### DIFF
--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -98,7 +98,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 			<form name="imagesearchform" id="imagesearchform" action="search.php" method="post">
 				<div id="criteriadiv">
 					<div class="flex-form">
-						<div>
+						<div style="margin-top: 1.5px">
 							<label for="taxontype"><?php echo htmlspecialchars($LANG['TAXON_TYPE'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
 							<select id="taxontype" name="taxontype">
 								<?php
@@ -109,7 +109,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 							</select>
 						</div>
 						<div>
-							<label for="taxa"  > <?php echo htmlspecialchars($LANG['TAXON'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
+							<label for="taxa"><?php echo htmlspecialchars($LANG['TAXON'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
 							<input id="taxa" name="taxa" type="text" style="width:450px;" value="<?php echo $imgLibManager->getTaxaStr(); ?>" title="Separate multiple names w/ commas" autocomplete="off" />
 						</div>
 						<div>
@@ -179,7 +179,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 							</select>
 						</div>
 					</div>
-					<div >
+					<div>
 						<div class="flex-form">
 							<div>
 								<label for="imagetype"><?php echo htmlspecialchars($LANG['IMG_TYPE'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -183,21 +183,12 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 						<div class="flex-form">
 							<div>
 								<label for="imagetype"><?php echo htmlspecialchars($LANG['IMG_TYPE'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
-								<select id="imagetype" name="imagetypes">
+								<select id="imagetype" name="imagetypes" onchange="imageTypeChanged(this)">>
 									<option value="0">All Images</option>
 									<option value="1" <?php echo ($imgLibManager->getImageType() == 1?'SELECTED':''); ?>>Specimen Images</option>
 									<option value="2" <?php echo ($imgLibManager->getImageType() == 2?'SELECTED':''); ?>>Image Vouchered Observations</option>
 									<option value="3" <?php echo ($imgLibManager->getImageType() == 3?'SELECTED':''); ?>>Field Images (lacking specific locality details)</option>
 								</select>
-								<script src="../imagelib/selectUtilities.js?v=2"></script>
-								<script>
-									const select = document.getElementById("imagetype");
-									
-									select.addEventListener("blur", function() {
-										if (isSelectionMade(select))
-											imageTypeChanged(this);
-									});
-								</script>
 							</div>
 						</div>
 						<div class="flex-form">

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -45,7 +45,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 	<title><?php echo $DEFAULT_TITLE; ?> Image Library</title>
 	<meta name='keywords' content='Search, Images, Taxon' />
 	<?php
-	include_once($SERVER_ROOT.'/includes/head.php');
+	include_once($SERVER_ROOT.'/includes/head_template.php');
 	include_once($SERVER_ROOT.'/includes/googleanalytics.php');
 	?>
 	<link href="<?php echo htmlspecialchars($CSS_BASE_PATH, HTML_SPECIAL_CHARS_FLAGS); ?>/symbiota/collections/listdisplay.css" type="text/css" rel="stylesheet" />
@@ -75,7 +75,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 <body>
 	<?php
 	$displayLeftMenu = (isset($imagelib_searchMenu)?$imagelib_searchMenu:false);
-	include($SERVER_ROOT.'/includes/header.php');
+	include($SERVER_ROOT.'/includes/header_template.php');
 	?>
 	<div class="navpath">
 		<a href="../index.php">Home</a> &gt;&gt;
@@ -97,8 +97,8 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 			</ul>
 			<form name="imagesearchform" id="imagesearchform" action="search.php" method="post">
 				<div id="criteriadiv">
-					<div style="clear:both;height:50px">
-						<div style="float:left;margin-top:3px">
+					<div class="flex-form">
+						<div>
 							<label for="taxontype"><?php echo htmlspecialchars($LANG['TAXON_TYPE'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
 							<select id="taxontype" name="taxontype">
 								<?php
@@ -108,42 +108,46 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 								?>
 							</select>
 						</div>
-						<div style="float:left;">
+						<div>
 							<label for="taxa"  > <?php echo htmlspecialchars($LANG['TAXON'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
 							<input id="taxa" name="taxa" type="text" style="width:450px;" value="<?php echo $imgLibManager->getTaxaStr(); ?>" title="Separate multiple names w/ commas" autocomplete="off" />
 						</div>
-						<div style="float:left;margin-left:10px;" >
+						<div>
 							<input id ="usethes" name="usethes" type="checkbox" value="1" <?php if(!$action || $imgLibManager->getUseThes()) echo 'CHECKED'; ?> >
 							<label for="usethes"><?php echo htmlspecialchars($LANG['USE_THES'], HTML_SPECIAL_CHARS_FLAGS) ?> </label>
 						</div>
 					</div>
-					<div style="clear:both;margin-bottom:5px;">
-						<label for="phuid"><?php echo htmlspecialchars($LANG['PHU_ID'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
-						<select id="phuid" name="phuid">
-							<option value="">All Image Contributors</option>
-							<option value="">-----------------------------</option>
-							<?php
-							$uidList = $imgLibManager->getPhotographerUidArr();
-							foreach($uidList as $uid => $name){
-								echo '<option value="'.$uid.'" '.($imgLibManager->getPhotographerUid()==$uid?'SELECTED':'').'>'.$name.'</option>';
-							}
-							?>
-						</select>
+					<div class="flex-form">
+						<div>
+							<label for="phuid"><?php echo htmlspecialchars($LANG['PHU_ID'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
+							<select id="phuid" name="phuid">
+								<option value="">All Image Contributors</option>
+								<option value="">-----------------------------</option>
+								<?php
+								$uidList = $imgLibManager->getPhotographerUidArr();
+								foreach($uidList as $uid => $name){
+									echo '<option value="'.$uid.'" '.($imgLibManager->getPhotographerUid()==$uid?'SELECTED':'').'>'.$name.'</option>';
+								}
+								?>
+							</select>
+						</div>
 					</div>
 					<?php
 					if($tagArr = $imgLibManager->getTagArr()){
 						?>
-						<div style="margin-bottom:5px;">
-							<label for="tags"><?php echo htmlspecialchars($LANG['IMG_TAGS'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
-							<select id="tags" name="tags" >
-								<option value="">Select Tag</option>
-								<option value="">--------------</option>
-								<?php
-								foreach($tagArr as $k){
-									echo '<option value="'.$k.'" '.($imgLibManager->getTags()==$k?'SELECTED ':'').'>'.$k.'</option>';
-								}
-								?>
-							</select>
+						<div class="flex-form">
+							<div>
+								<label for="tags"><?php echo htmlspecialchars($LANG['IMG_TAGS'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
+								<select id="tags" name="tags" >
+									<option value="">Select Tag</option>
+									<option value="">--------------</option>
+									<?php
+									foreach($tagArr as $k){
+										echo '<option value="'.$k.'" '.($imgLibManager->getTags()==$k?'SELECTED ':'').'>'.$k.'</option>';
+									}
+									?>
+								</select>
+							</div>	
 						</div>
 						<?php
 					}
@@ -159,32 +163,47 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 					$specArr = (isset($collList['spec'])?$collList['spec']:null);
 					$obsArr = (isset($collList['obs'])?$collList['obs']:null);
 					?>
-					<div style="margin-bottom:5px;">
-						<label for="imagecount"><?php echo htmlspecialchars($LANG['IMG_COUNT'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
-						<select id="imagecount" name="imagecount">
-							<option value="all" <?php echo ($imgLibManager->getImageCount()=='all'?'SELECTED ':''); ?>>All images</option>
-							<option value="taxon" <?php echo ($imgLibManager->getImageCount()=='taxon'?'SELECTED ':''); ?>>One per taxon</option>
-							<?php
-							if($specArr){
-								?>
-								<option value="specimen" <?php echo ($imgLibManager->getImageCount()=='specimen'?'SELECTED ':''); ?>>One per specimen</option>
+					<div class="flex-form">
+						<div>
+							<label for="imagecount"><?php echo htmlspecialchars($LANG['IMG_COUNT'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
+							<select id="imagecount" name="imagecount">
+								<option value="all" <?php echo ($imgLibManager->getImageCount()=='all'?'SELECTED ':''); ?>>All images</option>
+								<option value="taxon" <?php echo ($imgLibManager->getImageCount()=='taxon'?'SELECTED ':''); ?>>One per taxon</option>
 								<?php
-							}
-							?>
-						</select>
-					</div>
-					<div style="height: 40px">
-						<div style="margin-bottom:5px;float:left;">
-							<label for="imagetype"><?php echo htmlspecialchars($LANG['IMG_TYPE'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
-							<select id="imagetype" name="imagetypes" onchange="imageTypeChanged(this)" onkeypress="imageTypeChanged(this)">
-								<option value="0">All Images</option>
-								<option value="1" <?php echo ($imgLibManager->getImageType() == 1?'SELECTED':''); ?>>Specimen Images</option>
-								<option value="2" <?php echo ($imgLibManager->getImageType() == 2?'SELECTED':''); ?>>Image Vouchered Observations</option>
-								<option value="3" <?php echo ($imgLibManager->getImageType() == 3?'SELECTED':''); ?>>Field Images (lacking specific locality details)</option>
+								if($specArr){
+									?>
+									<option value="specimen" <?php echo ($imgLibManager->getImageCount()=='specimen'?'SELECTED ':''); ?>>One per specimen</option>
+									<?php
+								}
+								?>
 							</select>
 						</div>
-						<div style="margin:0px 40px;float:left">
-							<button name="submitaction" type="submit" value="search">Load Images</button>
+					</div>
+					<div >
+						<div class="flex-form">
+							<div>
+								<label for="imagetype"><?php echo htmlspecialchars($LANG['IMG_TYPE'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
+								<select id="imagetype" name="imagetypes">
+									<option value="0">All Images</option>
+									<option value="1" <?php echo ($imgLibManager->getImageType() == 1?'SELECTED':''); ?>>Specimen Images</option>
+									<option value="2" <?php echo ($imgLibManager->getImageType() == 2?'SELECTED':''); ?>>Image Vouchered Observations</option>
+									<option value="3" <?php echo ($imgLibManager->getImageType() == 3?'SELECTED':''); ?>>Field Images (lacking specific locality details)</option>
+								</select>
+								<script src="../imagelib/selectUtilities.js?v=2"></script>
+								<script>
+									const select = document.getElementById("imagetype");
+									
+									select.addEventListener("blur", function() {
+										if (isSelectionMade(select))
+											imageTypeChanged(this);
+									});
+								</script>
+							</div>
+						</div>
+						<div class="flex-form">
+							<div>
+								<button name="submitaction" type="submit" value="search">Load Images</button>
+							</div>
 						</div>
 					</div>
 					<?php

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -45,7 +45,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 	<title><?php echo $DEFAULT_TITLE; ?> Image Library</title>
 	<meta name='keywords' content='Search, Images, Taxon' />
 	<?php
-	include_once($SERVER_ROOT.'/includes/head_template.php');
+	include_once($SERVER_ROOT.'/includes/head.php');
 	include_once($SERVER_ROOT.'/includes/googleanalytics.php');
 	?>
 	<link href="<?php echo htmlspecialchars($CSS_BASE_PATH, HTML_SPECIAL_CHARS_FLAGS); ?>/symbiota/collections/listdisplay.css" type="text/css" rel="stylesheet" />
@@ -75,7 +75,7 @@ if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 <body>
 	<?php
 	$displayLeftMenu = (isset($imagelib_searchMenu)?$imagelib_searchMenu:false);
-	include($SERVER_ROOT.'/includes/header_template.php');
+	include($SERVER_ROOT.'/includes/header.php');
 	?>
 	<div class="navpath">
 		<a href="../index.php">Home</a> &gt;&gt;

--- a/includes/header_template.php
+++ b/includes/header_template.php
@@ -1,5 +1,5 @@
 <?php
-if($LANG_TAG == 'en' || !file_exists($SERVER_ROOT.'/content/lang/header.'.$LANG_TAG.'.php')) include_once($SERVER_ROOT.'/content/lang/header.en_template.php');
+if($LANG_TAG == 'en' || !file_exists($SERVER_ROOT.'/content/lang/header.'.$LANG_TAG.'.php')) include_once($SERVER_ROOT.'/content/lang/header.en.php');
 else include_once($SERVER_ROOT.'/content/lang/header.'.$LANG_TAG.'.php');
 
 include_once($SERVER_ROOT.'/classes/ProfileManager.php');

--- a/includes/header_template.php
+++ b/includes/header_template.php
@@ -1,5 +1,5 @@
 <?php
-if($LANG_TAG == 'en' || !file_exists($SERVER_ROOT.'/content/lang/header.'.$LANG_TAG.'.php')) include_once($SERVER_ROOT.'/content/lang/header.en.php');
+if($LANG_TAG == 'en' || !file_exists($SERVER_ROOT.'/content/lang/header.'.$LANG_TAG.'.php')) include_once($SERVER_ROOT.'/content/lang/header.en_template.php');
 else include_once($SERVER_ROOT.'/content/lang/header.'.$LANG_TAG.'.php');
 
 include_once($SERVER_ROOT.'/classes/ProfileManager.php');


### PR DESCRIPTION
## Before Changes:
<img width="1506" alt="Screen Shot 2023-08-04 at 2 32 58 PM" src="https://github.com/BioKIC/Symbiota/assets/86389284/a9c1fc86-9e20-495e-ab55-3212d2dba14e">

## After Changes (Condensed Mode):
<img width="1506" alt="Screen Shot 2023-08-04 at 3 34 53 PM" src="https://github.com/BioKIC/Symbiota/assets/86389284/c384a888-c98e-4044-a9ae-0fd85757e051">

## After Changes (Accessibility Mode):
<img width="1506" alt="Screen Shot 2023-08-04 at 2 33 13 PM" src="https://github.com/BioKIC/Symbiota/assets/86389284/0c2108d1-91bc-450b-9cad-2c1bc0845e7e">

## Changes Made:
Changed the included .php files to *_template.php with the accessibility button functionality in imagelib/search.php and includes/header_template.php.  

Removed styles and added flex-form to the select, input, and button elements in imagelib/search.php.

## Potential Styling Issues:

- The "Load images" button moved to the left. I applied flex-form to this button for consistency, but it might have damaged the original aesthetics.
- "Taxon Type" and "Taxon" elements' allignment might not look properly on all screen sizes.
- (Not related to this code) The text wrapping in top right corner buttons is not consistent in Accessibility and Condensed Modes.

## Random Found issues: 

- In css/v202209/symbiota/main.css line 156 padding value is missing. 

## Pull Request Checklist:

- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [X] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [N/A] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [X] There are no linter errors
- [?] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [N/A] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address
- [X] It is the code author's responsibility to merge their own pull request after it has been approved
- [X] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [N/A] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [N/A] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
