### PR TITLE
508 taxa/taxonomy/taxonomydisplay.php

### DIFF
--- a/classes/TaxonomyDisplayManager.php
+++ b/classes/TaxonomyDisplayManager.php
@@ -275,7 +275,7 @@ class TaxonomyDisplayManager extends Manager{
 				}
 				$indent = $taxonRankId;
 				if($indent > 230) $indent -= 10;
-				echo "<div>".str_repeat('&nbsp;',$indent/5);
+				echo "<div>".str_repeat('&nbsp;',intval($indent/5));
 				if($taxonRankId > 139) echo '<a href="../index.php?taxon=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">' . htmlspecialchars($sciName, HTML_SPECIAL_CHARS_FLAGS) . '</a>';
 				else echo $sciName;
 				if($this->isEditor) echo ' <a href="taxoneditor.php?tid=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank"><img src="../../images/edit.png" style="width:11px" /></a>';

--- a/classes/TaxonomyDisplayManager.php
+++ b/classes/TaxonomyDisplayManager.php
@@ -278,11 +278,11 @@ class TaxonomyDisplayManager extends Manager{
 				echo "<div>".str_repeat('&nbsp;',intval($indent/5));
 				if($taxonRankId > 139) echo '<a href="../index.php?taxon=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">' . htmlspecialchars($sciName, HTML_SPECIAL_CHARS_FLAGS) . '</a>';
 				else echo $sciName;
-				if($this->isEditor) echo ' <a href="taxoneditor.php?tid=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank"><img src="../../images/edit.png" style="width:11px" /></a>';
+				if($this->isEditor) echo ' <a href="taxoneditor.php?tid=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank"><img src="../../images/edit.png" style="width:11px" alt="Edit" /></a>';
 				if(!$this->displayFullTree){
 					if(($this->targetRankId < 140 && $taxonRankId == 140) || !$this->targetStr && $taxonRankId == 10){
 						echo ' <a href="taxonomydisplay.php?target=' . htmlspecialchars($sciName, HTML_SPECIAL_CHARS_FLAGS) . '">';
-						echo '<img src="../../images/tochild.png" style="width:9px;" />';
+						echo '<img src="../../images/tochild.png" style="width:9px;" alt="Go to child" />';
 						echo '</a>';
 					}
 				}

--- a/content/lang/taxa/taxonomy/taxonomydisplay.fr.php
+++ b/content/lang/taxa/taxonomy/taxonomydisplay.fr.php
@@ -1,0 +1,29 @@
+<?php
+/*
+------------------
+Language: Français (French)
+------------------
+*/
+
+$LANG['TAX_DISPLAY'] = 'Affichage de la taxonomie';
+$LANG['HOME'] = 'Accueil';
+$LANG['TAX_TREE_VIEWER'] = 'Visionneuse d\'arbre taxonomique';
+$LANG['ADD_NEW_TAXON'] = 'Ajouter un nouveau taxon';
+$LANG['DESCRIPTION'] = 'Description';
+$LANG['EDITORS'] = 'Editeurs';
+$LANG['CONTACT'] = 'Contact';
+$LANG['EMAIL'] = 'E-mail';
+$LANG['NOTES'] = 'Notes';
+$LANG['TAX_SEARCH'] = 'Recherche de taxons';
+$LANG['TAXON'] = 'Taxon';
+$LANG['DISP_TAX_TREE'] = 'Afficher l\'arbre des taxons';
+$LANG['DISP_AUTHORS'] = 'Afficher les auteurs';
+$LANG['MATCH_WHOLE_WORDS'] = 'Recherche sur des mots entiers';
+$LANG['DISP_FULL_TREE'] = 'Afficher l\'arborescence complète sous la famille';
+$LANG['DISP_SUBGENERA'] = 'Afficher les espèces avec les sous-genres';
+
+//Affichage dynamique
+$LANG['TAX_EXPLORE'] = 'Explorateur de taxonomie';
+$LANG['EDITOR_MODE'] = 'Mode éditeur';
+
+?>

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -482,3 +482,7 @@ table.styledtable tr.alt td {
 .bottom-breathing-room-sm-rel {
   margin-bottom: 0.5rem;
 }
+
+.taxon-search-bar {
+  width: 25rem;
+}

--- a/taxa/taxonomy/taxonomydisplay.php
+++ b/taxa/taxonomy/taxonomydisplay.php
@@ -1,16 +1,18 @@
+<!DOCTYPE html>
+
 <?php
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/TaxonomyDisplayManager.php');
 header("Content-Type: text/html; charset=".$CHARSET);
 include_once($SERVER_ROOT.'/content/lang/taxa/taxonomy/taxonomydisplay.'.$LANG_TAG.'.php');
 
-$target = array_key_exists('target', $_REQUEST) ? filter_var($_REQUEST['target'], FILTER_SANITIZE_STRING) : '';
+$target = array_key_exists('target', $_REQUEST) ? htmlspecialchars($_REQUEST['target'], HTML_SPECIAL_CHARS_FLAGS) : '';
 $displayAuthor = array_key_exists('displayauthor', $_REQUEST) ? filter_var($_REQUEST['displayauthor'], FILTER_SANITIZE_NUMBER_INT): 0;
 $matchOnWords = array_key_exists('matchonwords', $_POST) ? filter_var($_POST['matchonwords'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $displayFullTree = array_key_exists('displayfulltree', $_REQUEST) ? filter_var($_REQUEST['displayfulltree'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $displaySubGenera = array_key_exists('displaysubgenera', $_REQUEST) ? filter_var($_REQUEST['displaysubgenera'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $taxAuthId = array_key_exists('taxauthid', $_REQUEST) ? filter_var($_REQUEST['taxauthid'], FILTER_SANITIZE_NUMBER_INT) : 1;
-$statusStr = array_key_exists('statusstr', $_REQUEST) ? filter_var($_REQUEST['statusstr'], FILTER_SANITIZE_STRING) : '';
+$statusStr = array_key_exists('statusstr', $_REQUEST) ? htmlspecialchars($_REQUEST['statusstr'], HTML_SPECIAL_CHARS_FLAGS) : '';
 
 if(!$target) $matchOnWords = 1;
 $taxonDisplayObj = new TaxonomyDisplayManager();
@@ -26,7 +28,7 @@ if($IS_ADMIN || array_key_exists("Taxonomy",$USER_RIGHTS)){
 	$isEditor = true;
 }
 ?>
-<html>
+<html lang="<?php echo $LANG_TAG ?>">
 <head>
 	<title><?php echo $DEFAULT_TITLE." ".(isset($LANG['TAX_DISPLAY'])?$LANG['TAX_DISPLAY']:'Taxonomy Display').": ".$taxonDisplayObj->getTargetStr(); ?></title>
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET; ?>"/>
@@ -79,7 +81,7 @@ if($IS_ADMIN || array_key_exists("Taxonomy",$USER_RIGHTS)){
 			?>
 			<div style="float:right;" title="<?php echo (isset($LANG['ADD_NEW_TAXON'])?$LANG['ADD_NEW_TAXON']:'Add a New Taxon'); ?>">
 				<a href="taxonomyloader.php">
-					<img style='border:0px;width:15px;' src='../../images/add.png'/>
+					<img style='border:0px;width:15px;' src='../../images/add.png' alt="Plus sign">
 				</a>
 			</div>
 			<?php
@@ -107,8 +109,8 @@ if($IS_ADMIN || array_key_exists("Taxonomy",$USER_RIGHTS)){
 				<fieldset style="padding:10px;max-width:850px;">
 					<legend><b><?php echo (isset($LANG['TAX_SEARCH'])?$LANG['TAX_SEARCH']:'Taxon Search'); ?></b></legend>
 					<div style="float:left;">
-						<b><?php echo (isset($LANG['TAXON'])?$LANG['TAXON']:'Taxon'); ?>:</b>
-						<input id="taxontarget" name="target" type="text" style="width:400px;" value="<?php echo $taxonDisplayObj->getTargetStr(); ?>" />
+						<label for="taxontarget"> <?php echo htmlspecialchars($LANG['TAXON'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
+						<input id="taxontarget" class="taxon-search-bar" name="target" type="text" value="<?php echo $taxonDisplayObj->getTargetStr(); ?>" />
 					</div>
 					<div style="float:left;margin-left:15px;">
 						<button name="tdsubmit" type="submit" value="displayTaxonTree"><?php echo (isset($LANG['DISP_TAX_TREE'])?$LANG['DISP_TAX_TREE']:'Display Taxon Tree'); ?></button>
@@ -116,16 +118,20 @@ if($IS_ADMIN || array_key_exists("Taxonomy",$USER_RIGHTS)){
 					</div>
 					<div style="clear:both;padding-top:15px; margin-left:60px;">
 						<div style="margin:3px;">
-							<input name="displayauthor" type="checkbox" value="1" <?php echo ($displayAuthor?'checked':''); ?> /> <?php echo (isset($LANG['DISP_AUTHORS'])?$LANG['DISP_AUTHORS']:'Display authors'); ?>
+							<input name="displayauthor" type="checkbox" value="1" <?php echo ($displayAuthor?'checked':''); ?> />
+							<label> <?php echo (isset($LANG['DISP_AUTHORS'])?$LANG['DISP_AUTHORS']:'Display authors'); ?> </label>
 						</div>
 						<div style="margin:3px;">
-							<input name="matchonwords" type="checkbox" value="1" <?php echo ($matchOnWords?'checked':''); ?> /> <?php echo (isset($LANG['MATCH_WHOLE_WORDS'])?$LANG['MATCH_WHOLE_WORDS']:'Match on whole words'); ?>
+							<input name="matchonwords" type="checkbox" value="1" <?php echo ($matchOnWords?'checked':''); ?> /> 
+							<label> <?php echo (isset($LANG['MATCH_WHOLE_WORDS'])?$LANG['MATCH_WHOLE_WORDS']:'Match on whole words'); ?> </label>
 						</div>
 						<div style="margin:3px">
-							<input name="displayfulltree" type="checkbox" value="1" <?php echo ($displayFullTree?'checked':''); ?> /> <?php echo (isset($LANG['DISP_FULL_TREE'])?$LANG['DISP_FULL_TREE']:'Display full tree below family'); ?>
+							<input name="displayfulltree" type="checkbox" value="1" <?php echo ($displayFullTree?'checked':''); ?> /> 
+							<label> <?php echo (isset($LANG['DISP_FULL_TREE'])?$LANG['DISP_FULL_TREE']:'Display full tree below family'); ?> </label>
 						</div>
 						<div style="margin:3px;">
-							<input name="displaysubgenera" type="checkbox" value="1" <?php echo ($displaySubGenera?'checked':''); ?> /> <?php echo (isset($LANG['DISP_SUBGENERA'])?$LANG['DISP_SUBGENERA']:'Display species with subgenera'); ?>
+							<input name="displaysubgenera" type="checkbox" value="1" <?php echo ($displaySubGenera?'checked':''); ?> /> 
+							<label> <?php echo (isset($LANG['DISP_SUBGENERA'])?$LANG['DISP_SUBGENERA']:'Display species with subgenera'); ?> </label>
 						</div>
 					</div>
 				</fieldset>

--- a/taxa/taxonomy/taxonomydisplay.php
+++ b/taxa/taxonomy/taxonomydisplay.php
@@ -106,32 +106,35 @@ if($IS_ADMIN || array_key_exists("Taxonomy",$USER_RIGHTS)){
 		</div>
 		<div style="clear:both;">
 			<form id="tdform" name="tdform" action="taxonomydisplay.php" method='POST'>
-				<fieldset style="padding:10px;max-width:850px;">
+				<fieldset style="padding:10px;max-width:850px;" class="flex-form">
 					<legend><b><?php echo (isset($LANG['TAX_SEARCH'])?$LANG['TAX_SEARCH']:'Taxon Search'); ?></b></legend>
-					<div style="float:left;">
+					<div>
 						<label for="taxontarget"> <?php echo htmlspecialchars($LANG['TAXON'], HTML_SPECIAL_CHARS_FLAGS) ?>: </label>
 						<input id="taxontarget" class="taxon-search-bar" name="target" type="text" value="<?php echo $taxonDisplayObj->getTargetStr(); ?>" />
+					
+						<div>
+							<input id="displayauthor" name="displayauthor" type="checkbox" value="1" <?php echo ($displayAuthor?'checked':''); ?> />
+							<label for="displayauthor" > <?php echo (isset($LANG['DISP_AUTHORS'])?$LANG['DISP_AUTHORS']:'Display authors'); ?> </label>
+						</div>
+						<div>
+							<input id="matchonwords" name="matchonwords" type="checkbox" value="1" <?php echo ($matchOnWords?'checked':''); ?> /> 
+							<label for="matchonwords" > <?php echo (isset($LANG['MATCH_WHOLE_WORDS'])?$LANG['MATCH_WHOLE_WORDS']:'Match on whole words'); ?> </label>
+						</div>
+						<div>
+							<input id="displayfulltree" name="displayfulltree" type="checkbox" value="1" <?php echo ($displayFullTree?'checked':''); ?> /> 
+							<label for="displayfulltree" > <?php echo (isset($LANG['DISP_FULL_TREE'])?$LANG['DISP_FULL_TREE']:'Display full tree below family'); ?> </label>
+						</div>
+						<div>
+							<input id="displaysubgenera" name="displaysubgenera" type="checkbox" value="1" <?php echo ($displaySubGenera?'checked':''); ?> /> 
+							<label for="displaysubgenera"> <?php echo (isset($LANG['DISP_SUBGENERA'])?$LANG['DISP_SUBGENERA']:'Display species with subgenera'); ?> </label>
+						</div>
+
 					</div>
-					<div style="float:left;margin-left:15px;">
-						<button name="tdsubmit" type="submit" value="displayTaxonTree"><?php echo (isset($LANG['DISP_TAX_TREE'])?$LANG['DISP_TAX_TREE']:'Display Taxon Tree'); ?></button>
-						<input name="taxauthid" type="hidden" value="<?php echo $taxAuthId; ?>" />
-					</div>
-					<div style="clear:both;padding-top:15px; margin-left:60px;">
-						<div style="margin:3px;">
-							<input name="displayauthor" type="checkbox" value="1" <?php echo ($displayAuthor?'checked':''); ?> />
-							<label> <?php echo (isset($LANG['DISP_AUTHORS'])?$LANG['DISP_AUTHORS']:'Display authors'); ?> </label>
-						</div>
-						<div style="margin:3px;">
-							<input name="matchonwords" type="checkbox" value="1" <?php echo ($matchOnWords?'checked':''); ?> /> 
-							<label> <?php echo (isset($LANG['MATCH_WHOLE_WORDS'])?$LANG['MATCH_WHOLE_WORDS']:'Match on whole words'); ?> </label>
-						</div>
-						<div style="margin:3px">
-							<input name="displayfulltree" type="checkbox" value="1" <?php echo ($displayFullTree?'checked':''); ?> /> 
-							<label> <?php echo (isset($LANG['DISP_FULL_TREE'])?$LANG['DISP_FULL_TREE']:'Display full tree below family'); ?> </label>
-						</div>
-						<div style="margin:3px;">
-							<input name="displaysubgenera" type="checkbox" value="1" <?php echo ($displaySubGenera?'checked':''); ?> /> 
-							<label> <?php echo (isset($LANG['DISP_SUBGENERA'])?$LANG['DISP_SUBGENERA']:'Display species with subgenera'); ?> </label>
+
+					<div class="flex-form">
+						<div>
+							<button name="tdsubmit" type="submit" value="displayTaxonTree"><?php echo (isset($LANG['DISP_TAX_TREE'])?$LANG['DISP_TAX_TREE']:'Display Taxon Tree'); ?></button>
+							<input name="taxauthid" type="hidden" value="<?php echo $taxAuthId; ?>" />
 						</div>
 					</div>
 				</fieldset>


### PR DESCRIPTION
## Before Changes:
<img width="1507" alt="Screen Shot 2023-08-18 at 2 29 09 PM" src="https://github.com/egbot/Symbiota/assets/86389284/1da534b7-c8a5-4e71-8d28-f4d1546ddea9">

## After Changes:

<img width="1507" alt="Screen Shot 2023-08-18 at 2 22 56 PM" src="https://github.com/egbot/Symbiota/assets/86389284/ff2fbd24-5ca1-416b-882b-4914043f2ae9">

<img width="757" alt="Screen Shot 2023-08-18 at 2 32 01 PM" src="https://github.com/egbot/Symbiota/assets/86389284/8ac6b824-ad15-4e88-abd3-278fca853e3f">

## Mobile version (Old --> New) :
<img width="408" alt="Screen Shot 2023-08-18 at 2 31 28 PM" src="https://github.com/egbot/Symbiota/assets/86389284/c6922797-b74d-420e-9fa0-2204c8c5242b">

<img width="410" alt="Screen Shot 2023-08-18 at 2 33 31 PM" src="https://github.com/egbot/Symbiota/assets/86389284/09324085-792d-4453-abe8-7d7848abda2d">

## Changes Made:

- 508 Compliance (There are still errors connected to table and font size)
- Internationalized navigation and checkbox options. Added French language in content/lang/taxa/taxonomy/taxonomydisplay.fr.php
- Repositioned the Checkboxes and Load Button for better accessibility (First - search bar and options, last - load button)
- Added flex-form for accessibility/condensed modes switch. 

## Pull Request Checklist:

- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [N/A] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [X] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [X] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [N/A] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address
- [X] It is the code author's responsibility to merge their own pull request after it has been approved
- [X] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [N/A] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [X] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
