### PR TITLE
508 compliance for geothesaurus/index.php

### DIFF
--- a/content/lang/geothesaurus/index.en.php
+++ b/content/lang/geothesaurus/index.en.php
@@ -1,0 +1,42 @@
+<?php
+/*
+------------------
+Language: English
+------------------
+*/
+
+$LANG['GEO_THES_MNGR'] = 'Geographic Thesaurus Manager';
+$LANG['GEO_THES_BLIST'] = 'Geographic Thesaurus Base List';
+$LANG['EDIT_GEO'] = 'Edit Geographic';
+$LANG['UNIT'] = 'UNIT';
+$LANG['GEO_UNIT'] = 'GeoUnit Name';
+$LANG['ABBR'] = 'Abbreviation';
+$LANG['ISO2'] = 'ISO2 Code';
+$LANG['ISO3'] = 'ISO3 Code';
+$LANG['NUM_CODE'] = 'Numeric Code';
+$LANG['GEO_RANK'] = 'Geography Rank';
+$LANG['SELECT_RANK'] = 'Select Rank';
+$LANG['NOTES'] = 'Notes';
+$LANG['PARENT_TERM'] = 'Parent term';
+$LANG['IS_ROOT_TERM'] = 'Is a Root Term (e.g. no parent)';
+$LANG['ACCEPTED_TERM'] = 'Accepted term';
+$LANG['IS_ACCEPTED'] = 'Term is Accepted';
+$LANG['SAVE_EDITS'] = 'Save Edits';
+$LANG['DEL_GEO_UNIT'] = 'Delete Geographic Unit';
+$LANG['CONFIRM_DELETE'] = 'Are you sure you want to delete this record?';
+$LANG['CANT_DELETE'] = '* Record can not be deleted until all child records are deleted';
+$LANG['SHOW'] = 'Show';
+$LANG['TERMS'] = 'terms';
+$LANG['SHOW_CHILDREN'] = 'Show children';
+$LANG['ADD_GEO_UNIT'] = 'Add Geographic Unit';
+$LANG['SELECT_PARENT'] = 'Select Parent Term';
+$LANG['SELECT_ACCEPTED'] = 'Select Accepted Term';
+$LANG['ADD_UNIT'] = 'Add Unit';
+$LANG['TERMS_WITHIN'] = 'geographic terms within';
+$LANG['ROOT_TERMS'] = 'Root Terms (terms without parents)';
+$LANG['CHILDREN'] = 'children';
+$LANG['SHOW_LIST'] = 'Show Parent list';
+$LANG['NO_RECORDS'] = 'No records returned';
+$LANG['DISABLED'] = 'disabled';
+
+?>

--- a/content/lang/geothesaurus/index.en.php
+++ b/content/lang/geothesaurus/index.en.php
@@ -18,7 +18,7 @@ $LANG['GEO_RANK'] = 'Geography Rank';
 $LANG['SELECT_RANK'] = 'Select Rank';
 $LANG['NOTES'] = 'Notes';
 $LANG['PARENT_TERM'] = 'Parent term';
-$LANG['IS_ROOT_TERM'] = 'Is a Root Term (e.g. no parent)';
+$LANG['IS_ROOT_TERM'] = 'Is a Root Term (i.e. no parent)';
 $LANG['ACCEPTED_TERM'] = 'Accepted term';
 $LANG['IS_ACCEPTED'] = 'Term is Accepted';
 $LANG['SAVE_EDITS'] = 'Save Edits';
@@ -37,6 +37,6 @@ $LANG['ROOT_TERMS'] = 'Root Terms (terms without parents)';
 $LANG['CHILDREN'] = 'children';
 $LANG['SHOW_LIST'] = 'Show Parent list';
 $LANG['NO_RECORDS'] = 'No records returned';
-$LANG['DISABLED'] = 'disabled';
+$LANG['EDIT'] = 'Edit';
 
 ?>

--- a/content/lang/geothesaurus/index.es.php
+++ b/content/lang/geothesaurus/index.es.php
@@ -18,7 +18,7 @@ $LANG['GEO_RANK'] = 'Clasificación geográfica';
 $LANG['SELECT_RANK'] = 'Seleccionar rango';
 $LANG['NOTES'] = 'Notas';
 $LANG['PARENT_TERM'] = 'Término principal';
-$LANG['IS_ROOT_TERM'] = 'Es un término raíz (por ejemplo, sin padre)';
+$LANG['IS_ROOT_TERM'] = 'Es un término raíz (es decir, sin padre)';
 $LANG['ACCEPTED_TERM'] = 'Término aceptado';
 $LANG['IS_ACCEPTED'] = 'Se acepta el plazo';
 $LANG['SAVE_EDITS'] = 'Guardar ediciones';
@@ -38,5 +38,6 @@ $LANG['CHILDREN'] = 'niños';
 $LANG['SHOW_LIST'] = 'Mostrar lista de padres';
 $LANG['NO_RECORDS'] = 'No se devolvieron registros';
 $LANG['DISABLED'] = 'deshabilitado';
+$LANG['EDITAR'] = 'Editar';
 
 ?>

--- a/content/lang/geothesaurus/index.es.php
+++ b/content/lang/geothesaurus/index.es.php
@@ -1,0 +1,42 @@
+<?php
+/*
+------------------
+Language: Español (Spanish)
+------------------
+*/
+
+$LANG['GEO_THES_MNGR'] = 'Administrador de tesauro geográfico';
+$LANG['GEO_THES_BLIST'] = 'Lista base de tesauros geográficos';
+$LANG['EDIT_GEO'] = 'Editar Geográfico';
+$LANG['UNIT'] = 'UNIDAD';
+$LANG['GEO_UNIT'] = 'Nombre de la GeoUnidad';
+$LANG['ABBR'] = 'Abreviatura';
+$LANG['ISO2'] = 'Código ISO2';
+$LANG['ISO3'] = 'Código ISO3';
+$LANG['NUM_CODE'] = 'Código numérico';
+$LANG['GEO_RANK'] = 'Clasificación geográfica';
+$LANG['SELECT_RANK'] = 'Seleccionar rango';
+$LANG['NOTES'] = 'Notas';
+$LANG['PARENT_TERM'] = 'Término principal';
+$LANG['IS_ROOT_TERM'] = 'Es un término raíz (por ejemplo, sin padre)';
+$LANG['ACCEPTED_TERM'] = 'Término aceptado';
+$LANG['IS_ACCEPTED'] = 'Se acepta el plazo';
+$LANG['SAVE_EDITS'] = 'Guardar ediciones';
+$LANG['DEL_GEO_UNIT'] = 'Eliminar unidad geográfica';
+$LANG['CONFIRM_DELETE'] = '¿Está seguro de que desea eliminar este registro?';
+$LANG['CANT_DELETE'] = '* El registro no se puede eliminar hasta que se eliminen todos los registros secundarios';
+$LANG['SHOW'] = 'Mostrar';
+$LANG['TERMS'] = 'términos';
+$LANG['SHOW_CHILDREN'] = 'Mostrar niños';
+$LANG['ADD_GEO_UNIT'] = 'Agregar unidad geográfica';
+$LANG['SELECT_PARENT'] = 'Seleccionar término principal';
+$LANG['SELECT_ACCEPTED'] = 'Seleccionar término aceptado';
+$LANG['ADD_UNIT'] = 'Agregar unidad';
+$LANG['TERMS_WITHIN'] = 'términos geográficos dentro';
+$LANG['ROOT_TERMS'] = 'Términos raíz (términos sin padres)';
+$LANG['CHILDREN'] = 'niños';
+$LANG['SHOW_LIST'] = 'Mostrar lista de padres';
+$LANG['NO_RECORDS'] = 'No se devolvieron registros';
+$LANG['DISABLED'] = 'deshabilitado';
+
+?>

--- a/content/lang/geothesaurus/index.fr.php
+++ b/content/lang/geothesaurus/index.fr.php
@@ -18,7 +18,7 @@ $LANG['GEO_RANK'] = 'Rang géographique';
 $LANG['SELECT_RANK'] = 'Sélectionner le rang';
 $LANG['NOTES'] = 'Notes';
 $LANG['PARENT_TERM'] = 'Terme parent';
-$LANG['IS_ROOT_TERM'] = 'Est un terme racine (par exemple, pas de parent)';
+$LANG['IS_ROOT_TERM'] = 'Est un terme racine (c\'est-à-dire aucun parent)';
 $LANG['ACCEPTED_TERM'] = 'Terme accepté';
 $LANG['IS_ACCEPTED'] = 'Le terme est accepté';
 $LANG['SAVE_EDITS'] = 'Enregistrer les modifications';
@@ -38,5 +38,6 @@ $LANG['CHILDREN'] = 'enfants';
 $LANG['SHOW_LIST'] = 'Mostrar lista de padres';
 $LANG['NO_RECORDS'] = 'Aucun enregistrement renvoyé';
 $LANG['DISABLED'] = 'désactivé';
+$LANG['EDIT'] = 'Modifier';
 
 ?>

--- a/content/lang/geothesaurus/index.fr.php
+++ b/content/lang/geothesaurus/index.fr.php
@@ -1,0 +1,42 @@
+<?php
+/*
+------------------
+Language: Français (French)
+------------------
+*/
+
+$LANG['GEO_THES_MNGR'] = 'Gestionnaire de thésaurus géographique';
+$LANG['GEO_THES_BLIST'] = 'Liste de base du thésaurus géographique';
+$LANG['EDIT_GEO'] = 'Modifier géographique';
+$LANG['UNIT'] = 'UNITÉ';
+$LANG['GEO_UNIT'] = 'Nom de la géounité';
+$LANG['ABBR'] = 'Abréviation';
+$LANG['ISO2'] = 'Code ISO2';
+$LANG['ISO3'] = 'Code ISO3';
+$LANG['NUM_CODE'] = 'Code numérique';
+$LANG['GEO_RANK'] = 'Rang géographique';
+$LANG['SELECT_RANK'] = 'Sélectionner le rang';
+$LANG['NOTES'] = 'Notes';
+$LANG['PARENT_TERM'] = 'Terme parent';
+$LANG['IS_ROOT_TERM'] = 'Est un terme racine (par exemple, pas de parent)';
+$LANG['ACCEPTED_TERM'] = 'Terme accepté';
+$LANG['IS_ACCEPTED'] = 'Le terme est accepté';
+$LANG['SAVE_EDITS'] = 'Enregistrer les modifications';
+$LANG['DEL_GEO_UNIT'] = 'Supprimer l\'unité géographique';
+$LANG['CONFIRM_DELETE'] = 'Êtes-vous sûr de vouloir supprimer cet enregistrement ?';
+$LANG['CANT_DELETE'] = '* L\'enregistrement ne peut pas être supprimé tant que tous les enregistrements enfants ne sont pas supprimés';
+$LANG['SHOW'] = 'Afficher';
+$LANG['TERMS'] = 'termes';
+$LANG['SHOW_CHILDREN'] = 'Afficher les enfants';
+$LANG['ADD_GEO_UNIT'] = 'Ajouter une unité géographique';
+$LANG['SELECT_PARENT'] = 'Sélectionner le terme parent';
+$LANG['SELECT_ACCEPTED'] = 'Sélectionner un terme accepté';
+$LANG['ADD_UNIT'] = 'Ajouter une unité';
+$LANG['TERMS_WITHIN'] = 'termes géographiques au sein';
+$LANG['ROOT_TERMS'] = 'Termes racines (termes sans parents)';
+$LANG['CHILDREN'] = 'enfants';
+$LANG['SHOW_LIST'] = 'Mostrar lista de padres';
+$LANG['NO_RECORDS'] = 'Aucun enregistrement renvoyé';
+$LANG['DISABLED'] = 'désactivé';
+
+?>

--- a/geothesaurus/index.php
+++ b/geothesaurus/index.php
@@ -1,6 +1,9 @@
+<!DOCTYPE html>
+
 <?php
 include_once ('../config/symbini.php');
 include_once ($SERVER_ROOT . '/classes/GeographicThesaurus.php');
+include_once($SERVER_ROOT.'/content/lang/geothesaurus/index.'.$LANG_TAG.'.php');
 header("Content-Type: text/html; charset=".$CHARSET);
 
 $geoThesID = array_key_exists('geoThesID', $_REQUEST) ? $_REQUEST['geoThesID'] : '';
@@ -38,9 +41,9 @@ if($isEditor && $submitAction) {
 $geoArr = $geoManager->getGeograpicList($parentID);
 
 ?>
-<html>
+<html lang="<?php echo $LANG_TAG ?>">
 <head>
-	<title><?php echo $DEFAULT_TITLE; ?> - Geographic Thesaurus Manager</title>
+	<title><?php echo $DEFAULT_TITLE; ?> - <?php echo (isset($LANG['GEO_THES_MNGR']) ? $LANG['GEO_THES_MNGR'] : 'Geographic Thesaurus Manager'); ?></title>
 	<link href="<?php echo htmlspecialchars($CSS_BASE_PATH, HTML_SPECIAL_CHARS_FLAGS); ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
 	include_once ($SERVER_ROOT.'/includes/head.php');
@@ -56,7 +59,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 			$("#unitDel-div").toggle();
 		}
 	</script>
-	<style type="text/css">
+	<style>
 		fieldset{ margin: 10px; padding: 15px; width: 800px }
 		legend{ font-weight: bold; }
 		label{ text-decoration: underline; }
@@ -78,8 +81,8 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 	include($SERVER_ROOT.'/includes/header.php');
 	?>
 	<div class="navpath">
-		<a href="../index.php">Home</a> &gt;&gt;
-		<b><a href="index.php">Geographic Thesaurus Base List</a></b>
+	<a href="../index.php"> <?php echo htmlspecialchars($LANG['HOME'], HTML_SPECIAL_CHARS_FLAGS) ?> </a> &gt;&gt;
+		<b> <?php echo htmlspecialchars($LANG['GEO_THES_BLIST'], HTML_SPECIAL_CHARS_FLAGS) ?> </b>
 	</div>
 	<div id='innertext'>
 		<?php
@@ -92,43 +95,43 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 			?>
 			<div id="updateGeoUnit-div" style="clear:both;margin-bottom:10px;">
 				<fieldset id="edit-fieldset">
-					<legend>Edit Geographic<span id="edit-legend"> Unit</span></legend>
+					<legend> <?php echo (isset($LANG['EDIT_GEO']) ? $LANG['EDIT_GEO'] : 'Edit Geographic') ?> <span id="edit-legend"> <?php echo (isset($LANG['UNIT']) ? $LANG['UNIT'] : 'Unit') ?> </span></legend>
 					<div style="float:right">
-						<span class="editIcon"><a href="#" onclick="toggleEditor()"><img class="editimg" src="../images/edit.png" /></a></span>
+						<span class="editIcon"><a href="#" onclick="toggleEditor()"><img class="editimg" src="../images/edit.png" alt="Edit"/></a></span>
 
 					</div>
 					<form name="unitEditForm" action="index.php" method="post">
 						<div class="field-div">
-							<label>GeoUnit Name</label>:
+							<label> <?php echo (isset($LANG['GEO_UNIT']) ? $LANG['GEO_UNIT'] : 'GeoUnit Name') ?> </label>:
 							<span class="editTerm"><?php echo $geoUnit['geoTerm']; ?></span>
 							<span class="editFormElem"><input type="text" name="geoTerm" value="<?php echo $geoUnit['geoTerm'] ?>" style="width:200px;" required /></span>
 						</div>
 						<div class="field-div">
-							<label>Abbreviation</label>:
+							<label> <?php echo (isset($LANG['ABBR']) ? $LANG['ABBR'] : 'Abbreviation') ?> </label>:
 							<span class="editTerm"><?php echo $geoUnit['abbreviation']; ?></span>
 							<span class="editFormElem"><input type="text" name="abbreviation" value="<?php echo $geoUnit['abbreviation'] ?>" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>ISO2 Code</label>:
+							<label> <?php echo (isset($LANG['ISO2']) ? $LANG['ISO2'] : 'ISO2 Code') ?> </label>:
 							<span class="editTerm"><?php echo $geoUnit['iso2']; ?></span>
 							<span class="editFormElem"><input type="text" name="iso2" value="<?php echo $geoUnit['iso2'] ?>" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>ISO3 Code</label>:
+							<label> <?php echo (isset($LANG['ISO3']) ? $LANG['ISO3'] : 'ISO3 Code') ?> </label>:
 							<span class="editTerm"><?php echo $geoUnit['iso3']; ?></span>
 							<span class="editFormElem"><input type="text" name="iso3" value="<?php echo $geoUnit['iso3'] ?>"style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>Numeric Code</label>:
+							<label> <?php echo (isset($LANG['NUM_CODE']) ? $LANG['NUM_CODE'] : 'Numeric Code') ?> </label>:
 							<span class="editTerm"><?php echo $geoUnit['numCode']; ?></span>
 							<span class="editFormElem"><input type="text" name="numCode" value="<?php echo $geoUnit['numCode'] ?>" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>Geography Rank</label>:
+							<label> <?php echo (isset($LANG['GEO_RANK']) ? $LANG['GEO_RANK'] : 'Geography Rank') ?> </label>:
 							<span class="editTerm"><?php echo ($geoUnit['geoLevel']?$rankArr[$geoUnit['geoLevel']].' ('.$geoUnit['geoLevel'].')':''); ?></span>
 							<span class="editFormElem">
 								<select name="geoLevel">
-									<option value="">Select Rank</option>
+									<option value=""> <?php echo (isset($LANG['SELECT_RANK']) ? $LANG['SELECT_RANK'] : 'Select Rank') ?> </option>
 									<option value="">----------------------</option>
 									<?php
 									foreach($rankArr as $rankID => $rankValue){
@@ -139,7 +142,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 							</span>
 						</div>
 						<div class="field-div">
-							<label>Notes</label>:
+							<label> <?php echo (isset($LANG['NOTES']) ? $LANG['NOTES'] : 'Notes') ?> </label>:
 							<span class="editTerm"><?php echo $geoUnit['notes']; ?></span>
 							<span class="editFormElem"><input type="text" name="notes" value="<?php echo $geoUnit['notes'] ?>" maxlength="250" style="width:650px;" /></span>
 						</div>
@@ -150,11 +153,11 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 								if($geoUnit['parentTerm']) $parentStr = '<a href="index.php?geoThesID=' . htmlspecialchars($geoUnit['parentID'], HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($geoUnit['parentTerm'], HTML_SPECIAL_CHARS_FLAGS) . '</a>';
 								?>
 								<div class="field-div">
-									<label>Parent term</label>:
+									<label> <?php echo (isset($LANG['PARENT_TERM']) ? $LANG['PARENT_TERM'] : 'Parent term') ?> </label>:
 									<span class="editTerm"><?php echo $parentStr; ?></span>
 									<span class="editFormElem">
 										<select name="parentID">
-											<option value="">Is a Root Term (e.g. no parent)</option>
+											<option value=""> <?php echo (isset($LANG['IS_ROOT_TERM']) ? $LANG['IS_ROOT_TERM'] : 'Is a Root Term (e.g. no parent)') ?> </option>
 											<?php
 											foreach($parentList as $id => $term){
 												echo '<option value="'.$id.'" '.($id==$geoUnit['parentID']?'selected':'').'>'.$term.'</option>';
@@ -170,11 +173,11 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 						if($geoUnit['acceptedTerm']) $acceptedStr = '<a href="index.php?geoThesID=' . htmlspecialchars($geoUnit['acceptedID'], HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($geoUnit['acceptedTerm'], HTML_SPECIAL_CHARS_FLAGS) . '</a>';
 						?>
 						<div class="field-div">
-							<label>Accepted term</label>:
+							<label> <?php echo (isset($LANG['ACCEPTED_TERM']) ? $LANG['ACCEPTED_TERM'] : 'Accepted term') ?> </label>:
 							<span class="editTerm"><?php echo $acceptedStr; ?></span>
 							<span class="editFormElem">
 								<select name="acceptedID">
-									<option value="">Term is Accepted</option>
+									<option value=""> <?php echo (isset($LANG['IS_ACCEPTED']) ? $LANG['IS_ACCEPTED'] : 'Term is Accepted') ?> </option>
 									<option value="">----------------------</option>
 									<?php
 									$acceptedList = $geoManager->getAcceptedGeoTermArr($geoUnit['geoLevel']);
@@ -187,7 +190,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 						</div>
 						<div id="editButton-div" class="button-div">
 							<input name="geoThesID" type="hidden" value="<?php echo $geoThesID; ?>" />
-							<button type="submit" name="submitaction" value="submitGeoEdits">Save Edits</button>
+							<button type="submit" name="submitaction" value="submitGeoEdits"> <?php echo (isset($LANG['SAVE_EDITS']) ? $LANG['SAVE_EDITS'] : 'Save Edits') ?> </button>
 						</div>
 					</form>
 				</fieldset>
@@ -195,62 +198,62 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 			<div id="unitDel-div">
 				<form name="unitDeleteForm" action="index.php" method="post">
 					<fieldset>
-						<legend>Delete Geographic Unit</legend>
+						<legend> <?php echo (isset($LANG['DEL_GEO_UNIT']) ? $LANG['DEL_GEO_UNIT'] : 'Delete Geographic Unit') ?> </legend>
 						<div class="button-div">
 							<input name="parentID" type="hidden" value="<?php echo $geoUnit['parentID']; ?>" />
 							<input name="delGeoThesID" type="hidden"  value="<?php echo $geoThesID; ?>" />
 
 							<!-- We need to decide if we want to allow folks to delete a term and all their children, or only can delete if no children or synonym exists. I'm thinking the later. -->
 
-							<button type="submit" name="submitaction" value="deleteGeoUnits" onclick="return confirm('Are you sure you want to delete this record?')" <?php echo ($geoUnit['childCnt']?'disabled':''); ?>>Delete Geographic Unit</button>
+							<button type="submit" name="submitaction" value="deleteGeoUnits" onclick="return confirm(<?php echo (isset($LANG['CONFIRM_DELETE']) ? $LANG['CONFIRM_DELETE'] : 'Are you sure you want to delete this record?') ?>)" <?php echo ($geoUnit['childCnt']?(isset($LANG['DISABLED']) ? $LANG['DISABLED'] : 'disabled'):''); ?>> <?php echo (isset($LANG['DEL_GEO_UNIT']) ? $LANG['DEL_GEO_UNIT'] : 'Delete Geographic Unit') ?> </button>
 						</div>
 						<?php
-						if($geoUnit['childCnt']) echo '<div>* Record can not be deleted until all child records are deleted</div>';
+						if($geoUnit['childCnt']) echo '<div></div>';
 						?>
 					</fieldset>
 				</form>
 			</div>
 			<?php
 			echo '<div class="link-div">';
-			echo '<div><a href="index.php?' . htmlspecialchars((isset($geoUnit['parentID'])?'parentID='.$geoUnit['parentID']:''), HTML_SPECIAL_CHARS_FLAGS) . '">Show ' . htmlspecialchars((isset($geoUnit['geoLevel'])?$rankArr[$geoUnit['geoLevel']]:''), HTML_SPECIAL_CHARS_FLAGS) . ' terms</a></div>';
-			if(isset($geoUnit['childCnt']) && $geoUnit['childCnt']) echo '<div><a href="index.php?parentID=' . htmlspecialchars($geoThesID, HTML_SPECIAL_CHARS_FLAGS) . '">Show children</a></div>';
+			echo '<div><a href="index.php?' . htmlspecialchars((isset($geoUnit['parentID'])?'parentID='.$geoUnit['parentID']:''), HTML_SPECIAL_CHARS_FLAGS) . '">' . (isset($LANG['SHOW']) ? $LANG['SHOW'] : 'Show') . ' ' . htmlspecialchars((isset($geoUnit['geoLevel'])?$rankArr[$geoUnit['geoLevel']]:''), HTML_SPECIAL_CHARS_FLAGS) . ' ' . (isset($LANG['TERMS']) ? $LANG['TERMS'] : 'terms') . '</a></div>';
+			if(isset($geoUnit['childCnt']) && $geoUnit['childCnt']) echo '<div><a href="index.php?parentID=' . htmlspecialchars($geoThesID, HTML_SPECIAL_CHARS_FLAGS) . '">' . (isset($LANG['SHOW_CHILDREN']) ? $LANG['SHOW_CHILDREN'] : 'Show children') . '</a></div>';
 			echo '</div>';
 		}
 		else{
 			?>
 			<div style="float:right">
-				<span class="editIcon"><a href="#" onclick="$('#addGeoUnit-div').toggle();"><img class="editimg" src="../images/add.png" /></a></span>
+				<span class="editIcon"><a href="#" onclick="$('#addGeoUnit-div').toggle();"><img class="editimg" src="../images/add.png" alt="Edit" /></a></span>
 			</div>
 			<div id="addGeoUnit-div" style="clear:both;margin-bottom:10px;display:none">
 				<!--This should also be visible when !$geoThesID -->
 				<fieldset id="new-fieldset">
-					<legend>Add Geographic Unit</legend>
+					<legend> <?php echo (isset($LANG['ADD_GEO_UNIT']) ? $LANG['ADD_GEO_UNIT'] : 'Add Geographic Unit') ?> </legend>
 					<form name="unitAddForm" action="index.php" method="post">
 						<div class="field-div">
-							<label>GeoUnit Name</label>:
+							<label> <?php echo (isset($LANG['GEO_UNIT']) ? $LANG['GEO_UNIT'] : 'GeoUnit Name') ?> </label>:
 							<span><input type="text" name="geoTerm" style="width:200px;" required /></span>
 						</div>
 						<div class="field-div">
-							<label>Abbreviation</label>:
+							<label> <?php echo (isset($LANG['ABBR']) ? $LANG['ABBR'] : 'Abbreviation') ?> </label>:
 							<span><input type="text" name="abbreviation" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>ISO2 Code</label>:
+							<label> <?php echo (isset($LANG['ISO2']) ? $LANG['ISO2'] : 'ISO2 Code') ?> </label>:
 							<span><input type="text" name="iso2" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>ISO3 Code</label>:
+							<label> <?php echo (isset($LANG['ISO3']) ? $LANG['ISO3'] : 'ISO3 Code') ?> </label>:
 							<span><input type="text" name="iso3" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>Numeric Code</label>:
+							<label> <?php echo (isset($LANG['NUM_CODE']) ? $LANG['NUM_CODE'] : 'Numeric Code') ?> </label>:
 							<span><input type="text" name="numCode" style="width:50px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>Geography Rank</label>:
+							<label> <?php echo (isset($LANG['GEO_RANK']) ? $LANG['GEO_RANK'] : 'Geography Rank') ?> </label>:
 							<span>
 								<select name="geoLevel">
-									<option value="">Select Rank</option>
+									<option value=""> <?php echo (isset($LANG['SELECT_RANK']) ? $LANG['SELECT_RANK'] : 'Select Rank') ?> </option>
 									<option value="">----------------------</option>
 									<?php
 									$defaultGeoLevel = 0;
@@ -264,16 +267,16 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 							</span>
 						</div>
 						<div class="field-div">
-							<label>Notes</label>:
+							<label> <?php echo (isset($LANG['NOTES']) ? $LANG['NOTES'] : 'Notes') ?> </label>:
 							<span><input type="text" name="notes" maxlength="250" style="width:200px;" /></span>
 						</div>
 						<div class="field-div">
-							<label>Parent term</label>:
+							<label> <?php echo (isset($LANG['PARENT_TERM']) ? $LANG['PARENT_TERM'] : 'Parent term') ?> </label>:
 							<span>
 								<select name="parentID">
-									<option value="">Select Parent Term</option>
+									<option value=""> <?php echo (isset($LANG['SELECT_PARENT']) ? $LANG['SELECT_PARENT'] : 'Select Parent Term') ?> </option>
 									<option value="">----------------------</option>
-									<option value="">Is a Root Term (e.g. no parent)</option>
+									<option value=""> <?php echo (isset($LANG['IS_ROOT_TERM']) ? $LANG['IS_ROOT_TERM'] : 'Is a Root Term (e.g. no parent)') ?> </option>
 									<?php
 									$parentList = $geoManager->getParentGeoTermArr();
 									foreach($parentList as $id => $term){
@@ -284,12 +287,12 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 							</span>
 						</div>
 						<div class="field-div">
-							<label>Accepted term</label>:
+							<label> <?php echo (isset($LANG['ACCEPTED_TERM']) ? $LANG['ACCEPTED_TERM'] : 'Accepted term') ?> </label>:
 							<span>
 								<select name="acceptedID">
-									<option value="">Select Accepted Term</option>
+									<option value=""> <?php echo (isset($LANG['SELECT_ACCEPTED']) ? $LANG['SELECT_ACCEPTED'] : 'Select Accepted Term') ?> </option>
 									<option value="">----------------------</option>
-									<option value="">Term is Accepted</option>
+									<option value=""> <?php echo (isset($LANG['IS_ACCEPTED']) ? $LANG['IS_ACCEPTED'] : 'Term is Accepted') ?> </option>
 									<?php
 									$acceptedList = $geoManager->getAcceptedGeoTermArr();
 									foreach($acceptedList as $id => $term){
@@ -300,7 +303,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 							</span>
 						</div>
 						<div id="addButton-div" class="button-div">
-							<button type="submit" name="submitaction" value="addGeoUnit">Add Unit</button>
+							<button type="submit" name="submitaction" value="addGeoUnit"> <?php echo (isset($LANG['ADD_UNIT']) ? $LANG['ADD_UNIT'] : 'Add Unit') ?> </button>
 						</div>
 					</form>
 				</fieldset>
@@ -311,10 +314,10 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 				$parentArr = $geoManager->getGeograpicUnit($parentID);
 				if($parentID){
 					$rankArr = $geoManager->getGeoRankArr();
-					$titleStr = '<b>'.$rankArr[$geoArr[key($geoArr)]['geoLevel']].'</b> geographic terms within <b>'.$parentArr['geoTerm'].'</b>';
+					$titleStr = '<b>'.$rankArr[$geoArr[key($geoArr)]['geoLevel']] . '</b>' . (isset($LANG['TERMS_WITHIN']) ? $LANG['TERMS_WITHIN'] : 'geographic terms within') . '<b>'.$parentArr['geoTerm'] . '</b>';
 				}
 				else{
-					$titleStr = '<b>Root Terms (terms without parents)</b>';
+					$titleStr = '<b>' . (isset($LANG['ROOT_TERMS']) ? $LANG['ROOT_TERMS'] : 'Root Terms (terms without parents)') . '</b>';
 				}
 				echo '<div style=";font-size:1.3em;margin: 10px 0px">'.$titleStr.'</div>';
 				echo '<ul>';
@@ -329,13 +332,13 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 						if($codeStr) $termDisplay .= ' ('.trim($codeStr,', ').') ';
 					}
 					if($unitArr['acceptedTerm']) $termDisplay .= ' => <a href="index.php?geoThesID=' . htmlspecialchars($unitArr['acceptedID'], HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($unitArr['acceptedTerm'], HTML_SPECIAL_CHARS_FLAGS) . '</a>';
-					elseif(isset($unitArr['childCnt']) && $unitArr['childCnt']) $termDisplay .= ' - <a href="index.php?parentID=' . htmlspecialchars($geoID, HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($unitArr['childCnt'], HTML_SPECIAL_CHARS_FLAGS) . ' children</a>';
+					elseif(isset($unitArr['childCnt']) && $unitArr['childCnt']) $termDisplay .= ' - <a href="index.php?parentID=' . htmlspecialchars($geoID, HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($unitArr['childCnt'], HTML_SPECIAL_CHARS_FLAGS) . (isset($LANG['CHILDREN']) ? $LANG['CHILDREN'] : 'children') . '</a>';
 					echo '<li>'.$termDisplay.'</li>';
 				}
 				echo '</ul>';
-				if($parentID) echo '<div class="link-div"><a href="index.php?parentID=' . htmlspecialchars($parentArr['parentID'], HTML_SPECIAL_CHARS_FLAGS) . '">Show Parent list</a></div>';
+				if($parentID) echo '<div class="link-div"><a href="index.php?parentID=' . htmlspecialchars($parentArr['parentID'], HTML_SPECIAL_CHARS_FLAGS) . '">' . (isset($LANG['SHOW_LIST']) ? $LANG['SHOW_LIST'] : 'Show Parent list') . '</a></div>';
 			}
-			else echo '<div>No records returned</div>';
+			else echo '<div>' . (isset($LANG['NO_RECORDS']) ? $LANG['NO_RECORDS'] : 'No records returned') . '</div>';
 			if($geoThesID || $parentID) echo '<div class="link-div"><a href="index.php">Show base list</a></div>';
 		}
 		?>

--- a/geothesaurus/index.php
+++ b/geothesaurus/index.php
@@ -97,7 +97,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 				<fieldset id="edit-fieldset">
 					<legend> <?php echo (isset($LANG['EDIT_GEO']) ? $LANG['EDIT_GEO'] : 'Edit Geographic') ?> <span id="edit-legend"> <?php echo (isset($LANG['UNIT']) ? $LANG['UNIT'] : 'Unit') ?> </span></legend>
 					<div style="float:right">
-						<span class="editIcon"><a href="#" onclick="toggleEditor()"><img class="editimg" src="../images/edit.png" alt="Edit"/></a></span>
+						<span class="editIcon"><a href="#" onclick="toggleEditor()"><img class="editimg" src="../images/edit.png" alt="<?php echo (isset($LANG['EDIT']) ? $LANG['EDIT'] : 'Edit'); ?>"/></a></span>
 
 					</div>
 					<form name="unitEditForm" action="index.php" method="post">
@@ -157,7 +157,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 									<span class="editTerm"><?php echo $parentStr; ?></span>
 									<span class="editFormElem">
 										<select name="parentID">
-											<option value=""> <?php echo (isset($LANG['IS_ROOT_TERM']) ? $LANG['IS_ROOT_TERM'] : 'Is a Root Term (e.g. no parent)') ?> </option>
+											<option value=""> <?php echo (isset($LANG['IS_ROOT_TERM']) ? $LANG['IS_ROOT_TERM'] : 'Is a Root Term (i.e. no parent)') ?> </option>
 											<?php
 											foreach($parentList as $id => $term){
 												echo '<option value="'.$id.'" '.($id==$geoUnit['parentID']?'selected':'').'>'.$term.'</option>';
@@ -208,7 +208,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 							<button type="submit" name="submitaction" value="deleteGeoUnits" onclick="return confirm(<?php echo (isset($LANG['CONFIRM_DELETE']) ? $LANG['CONFIRM_DELETE'] : 'Are you sure you want to delete this record?') ?>)" <?php echo ($geoUnit['childCnt']?(isset($LANG['DISABLED']) ? $LANG['DISABLED'] : 'disabled'):''); ?>> <?php echo (isset($LANG['DEL_GEO_UNIT']) ? $LANG['DEL_GEO_UNIT'] : 'Delete Geographic Unit') ?> </button>
 						</div>
 						<?php
-						if($geoUnit['childCnt']) echo '<div></div>';
+						if($geoUnit['childCnt']) echo '<div>' . (isset($LANG['CANT_DELETE']) ? $LANG['CANT_DELETE'] : '* Record can not be deleted until all child records are deleted') . '</div>';
 						?>
 					</fieldset>
 				</form>
@@ -222,7 +222,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 		else{
 			?>
 			<div style="float:right">
-				<span class="editIcon"><a href="#" onclick="$('#addGeoUnit-div').toggle();"><img class="editimg" src="../images/add.png" alt="Edit" /></a></span>
+				<span class="editIcon"><a href="#" onclick="$('#addGeoUnit-div').toggle();"><img class="editimg" src="../images/add.png" alt="<?php echo (isset($LANG['EDIT']) ? $LANG['EDIT'] : 'Edit'); ?>" /></a></span>
 			</div>
 			<div id="addGeoUnit-div" style="clear:both;margin-bottom:10px;display:none">
 				<!--This should also be visible when !$geoThesID -->
@@ -276,7 +276,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 								<select name="parentID">
 									<option value=""> <?php echo (isset($LANG['SELECT_PARENT']) ? $LANG['SELECT_PARENT'] : 'Select Parent Term') ?> </option>
 									<option value="">----------------------</option>
-									<option value=""> <?php echo (isset($LANG['IS_ROOT_TERM']) ? $LANG['IS_ROOT_TERM'] : 'Is a Root Term (e.g. no parent)') ?> </option>
+									<option value=""> <?php echo (isset($LANG['IS_ROOT_TERM']) ? $LANG['IS_ROOT_TERM'] : 'Is a Root Term (i.e. no parent)') ?> </option>
 									<?php
 									$parentList = $geoManager->getParentGeoTermArr();
 									foreach($parentList as $id => $term){
@@ -314,7 +314,7 @@ $geoArr = $geoManager->getGeograpicList($parentID);
 				$parentArr = $geoManager->getGeograpicUnit($parentID);
 				if($parentID){
 					$rankArr = $geoManager->getGeoRankArr();
-					$titleStr = '<b>'.$rankArr[$geoArr[key($geoArr)]['geoLevel']] . '</b>' . (isset($LANG['TERMS_WITHIN']) ? $LANG['TERMS_WITHIN'] : 'geographic terms within') . '<b>'.$parentArr['geoTerm'] . '</b>';
+					$titleStr = '<b>'. $rankArr[$geoArr[key($geoArr)]['geoLevel']] . '</b>' . (isset($LANG['TERMS_WITHIN']) ? $LANG['TERMS_WITHIN'] : 'geographic terms within') . '<b>' . $parentArr['geoTerm'] . '</b>';
 				}
 				else{
 					$titleStr = '<b>' . (isset($LANG['ROOT_TERMS']) ? $LANG['ROOT_TERMS'] : 'Root Terms (terms without parents)') . '</b>';

--- a/geothesaurus/index.php
+++ b/geothesaurus/index.php
@@ -15,7 +15,7 @@ $submitAction = array_key_exists('submitaction', $_POST) ? $_POST['submitaction'
 if(!is_numeric($geoThesID)) $geoThesID = 0;
 if(!is_numeric($parentID)) $parentID = 0;
 if(!is_numeric($geoLevel)) $geoLevel = 0;
-$submitAction = filter_var($submitAction, FILTER_SANITIZE_STRING);
+$submitAction = htmlspecialchars($submitAction, HTML_SPECIAL_CHARS_FLAGS);
 
 $geoManager = new GeographicThesaurus();
 


### PR DESCRIPTION
## Changes Made:

- added Doctype and lang attribute
- deleted css style type (deprecated) 
- added alt to images
- Internationalized text, added lang files to lang/geothesaurus/

## Pull Request Checklist:

- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [N/A] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [X] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address
- [X] It is the code author's responsibility to merge their own pull request after it has been approved
- [X] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [N/A] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [N/A] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
