### PR TITLE
508 compliance for collections/admin/guidmapper.php

### DIFF
--- a/collections/admin/guidmapper.php
+++ b/collections/admin/guidmapper.php
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <?php
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/UuidFactory.php');
@@ -17,7 +19,7 @@ if($IS_ADMIN || array_key_exists("CollAdmin",$USER_RIGHTS) && in_array($collId,$
 
 $uuidManager = new UuidFactory();
 ?>
-<html>
+<html lang="<?php echo $LANG_TAG ?>">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET; ?>">
 	<title><?php echo (isset($LANG['UID_MAP'])?$LANG['UID_MAP']:'GUID (UUID) Mapper'); ?></title>
@@ -109,7 +111,7 @@ include($SERVER_ROOT.'/includes/header.php');
 					<legend><b><?php echo (isset($LANG['UID_MAP'])?$LANG['UID_MAP']:'GUID (UUID) Mapper'); ?></b></legend>
 					<div style="clear:both;">
 						<input type="hidden" name="collid" value="<?php echo $collId; ?>" />
-						<input type="submit" name="formsubmit" value="Populate Collection GUIDs" />
+						<input type="submit" name="formsubmit" value="<?php echo (isset($LANG['POP_COLL_GUID'])?$LANG['POP_COLL_GUID']:'Populate Collection GUIDs'); ?>" />
 					</div>
 				</fieldset>
 			</form>
@@ -123,7 +125,7 @@ include($SERVER_ROOT.'/includes/header.php');
 						<legend><b><?php echo (isset($LANG['UID_MAP'])?$LANG['UID_MAP']:'GUID (UUID) Mapper'); ?></b></legend>
 						<div style="clear:both;margin:10px;">
 							<input type="hidden" name="collid" value="<?php echo $collId; ?>" />
-							<input type="submit" name="formsubmit" value="Populate GUIDs" />
+							<input type="submit" name="formsubmit" value="<?php echo (isset($LANG['POP_GUID'])?$LANG['POP_GUID']:'Populate GUIDs'); ?>" />
 						</div>
 					</fieldset>
 				</form>

--- a/content/lang/collections/admin/guidmapper.en.php
+++ b/content/lang/collections/admin/guidmapper.en.php
@@ -13,4 +13,7 @@ $LANG['DETS'] = 'Determinations';
 $LANG['IMGS'] = 'Images';
 $LANG['NOT_AUTH'] = 'You are not authorized to access this page';
 
+$LANG['POP_COLL_GUID'] = 'Populate Collection GUIDs';
+$LANG['POP_GUID'] = 'Populate GUIDs';
+
 ?>

--- a/content/lang/collections/admin/guidmapper.es.php
+++ b/content/lang/collections/admin/guidmapper.es.php
@@ -13,4 +13,7 @@ $LANG['DETS'] = 'Determinaciones';
 $LANG['IMGS'] = 'Imágenes';
 $LANG['NOT_AUTH'] = 'No está autorizado para ingresar en esta página';
 
+$LANG['POP_COLL_GUID'] = 'Rellenar GUID de colección';
+$LANG['POP_GUID'] = 'Rellenar GUID';
+
 ?>

--- a/content/lang/collections/admin/guidmapper.fr.php
+++ b/content/lang/collections/admin/guidmapper.fr.php
@@ -1,0 +1,19 @@
+<?php
+/*
+------------------
+Language: French
+------------------
+*/
+
+$LANG['UID_MAP'] = 'Mappeur de GUID (UUID)';
+$LANG['GUID_CP'] = 'Panneau de configuration de maintenance GUID';
+$LANG['REC_WO_GUIDS'] = 'Enregistrements sans GUID (UUID)';
+$LANG['OCCS'] = 'Occurrences';
+$LANG['DETS'] = 'Déterminations';
+$LANG['IMGS'] = 'Images';
+$LANG['NOT_AUTH'] = 'Vous n\'êtes pas autorisé à accéder à cette page';
+
+$LANG['POP_COLL_GUID'] = 'Remplir les GUID de la collection';
+$LANG['POP_GUID'] = 'Remplir les GUID';
+
+?>


### PR DESCRIPTION
## Changes made:

- added Doctype and lang attribute
- internationalized "populate" button text and added french language file to lang/collections/admin/guidmapper.en.php

## Pull Request Checklist:

- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [N/A] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [X] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [X] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [N/A] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address
- [X] It is the code author's responsibility to merge their own pull request after it has been approved
- [X] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [N/A] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [N/A] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
