### PR TITLE
Add cumulative changes in docs/pull_request_template.md to master bra…

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,16 +1,24 @@
-Pull Request Checklist:
+# Pull Request Checklist:
 
+# Pre-Approval
+
+- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
+- [ ] Hotfixes should be branched off of the `master` branch and merged back into the `master` branch. Subsequently, a PR from `master` into `Development` should be made.
 - [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
-- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
 - [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
 - [ ] There are no linter errors
 - [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
 - [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
 - [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
 - [ ] Comment which GitHub issue(s), if any does this PR address
+- [ ] If this PR makes any changes that would require addional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
+
+# Post-Approval
+
 - [ ] It is the code author's responsibility to merge their own pull request after it has been approved
 - [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
 - [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
 - [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place
+- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.
 
 Thanks for contributing and keeping it clean!


### PR DESCRIPTION
…nch because github will only enact them in the PR checklist if they are on the master branch

Pull Request Checklist:

- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
    - N/A
- [x] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
    - These changes are already in the Development branch.
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [ ] Comment which GitHub issue(s), if any does this PR address
    - N/A

# TODO

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
