### PR TITLE
Fix deprecated warnings

### DIFF
--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -25,7 +25,6 @@ class TaxonomyUpload{
  		$this->setUploadTargetPath();
  		set_time_limit(3000);
 		ini_set("max_input_time",120);
-  		ini_set('auto_detect_line_endings', true);
 	}
 
 	function __destruct(){
@@ -50,7 +49,7 @@ class TaxonomyUpload{
 			$this->uploadFileName = $_FILES['uploadfile']['name'];
 			move_uploaded_file($_FILES['uploadfile']['tmp_name'], $this->uploadTargetPath.$this->uploadFileName);
 		}
-		if(file_exists($this->uploadTargetPath.$this->uploadFileName) && substr($this->uploadFileName,-4) == ".zip"){
+		if(file_exists($this->uploadTargetPath.$this->uploadFileName) && substr($this->uploadFileName ?? '',-4) == ".zip"){
 			$zip = new ZipArchive;
 			$zip->open($this->uploadTargetPath.$this->uploadFileName);
 			$zipFile = $this->uploadTargetPath.$this->uploadFileName;


### PR DESCRIPTION
#Changes made:

- for /taxa/taxonomy/batchloader.php: TaxonomyUpload: line 28 - removed deprecated auto_detect_line_endings, seems like new versions automatically detect common line endings: (\n and \r\n). line 53 - added null coalescing to substr to escape passing null.
- for taxa/profile/eolmapper.php: Don't see warnings on my end.

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [N/A] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [N/A] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [X] There are no linter errors
- [N/A] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [N/A] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address
- [N/A] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
