### PR TITLE
Collection name in harvestparams

### DIFF
--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -35,7 +35,7 @@ if (curl_errno($curlSession)) {
     }
 }
 curl_close($curlSession);
-// var_dump($collectionNameError); // for easy troubleshooting... right now, I think silent failure is ok; it will just default to not displaying.
+// var_dump($collectionNameError); // Leaving this in for easy future troubleshooting... right now, I think silent failure is ok; it will just default to not displaying the collection name if the api call fails.
 //------- End fetch the collection name from the api --------- //
 
 ?>
@@ -101,7 +101,7 @@ curl_close($curlSession);
 	<div id="innertext">
 		<?php if(isset($collectionName)){ ?>
 			<h1 class="emphatic-header">
-				<?php echo htmlspecialchars((isset($LANG['SEARCH_COLLECTION']) ? $LANG['SEARCH_COLLECTION'] : 'Search Collection'), HTML_SPECIAL_CHARS_FLAGS) . ": " . $collectionName; ?>	
+				<?php echo htmlspecialchars((isset($LANG['SEARCH_COLLECTION']) ? $LANG['SEARCH_COLLECTION'] : 'Searching Collection'), HTML_SPECIAL_CHARS_FLAGS) . ": " . $collectionName; ?>	
 			</h1>
 		<?php } ?>
 		<form name="harvestparams" id="harvestparams" action="list.php" method="post" onsubmit="return checkHarvestParamsForm(this)">

--- a/collections/harvestparams.php
+++ b/collections/harvestparams.php
@@ -11,9 +11,9 @@ $searchVar = $collManager->getQueryTermStr();
 
 //------- Fetch the collection name from the api --------- //
 $collId = array_key_exists('db', $_REQUEST) ? htmlspecialchars($_REQUEST['db'], HTML_SPECIAL_CHARS_FLAGS) : null;
-$reffererUrl = $_SERVER['HTTP_REFERER'];
-$baseUrl = strstr($reffererUrl, $CLIENT_ROOT, true); // @TODO this feels janky, but I couldn't find a better way to get the beginning of the URL... does this work in /portal/ projects?
-$apiUrl = $baseUrl . $CLIENT_ROOT . "/api/v2/collection/" . $collId;
+$protocol = array_key_exists('REQUEST_SCHEME', $_SERVER) ? $_SERVER['REQUEST_SCHEME'] : "https";
+$baseUrl = $protocol . "://" . $SERVER_HOST . $CLIENT_ROOT; // @TODO this feels janky; is it reliable?
+$apiUrl = $baseUrl . "/api/v2/collection/" . $collId;
 $curlSession = curl_init($apiUrl);
 curl_setopt($curlSession, CURLOPT_RETURNTRANSFER, true);
 $response = curl_exec($curlSession);
@@ -35,6 +35,7 @@ if (curl_errno($curlSession)) {
     }
 }
 curl_close($curlSession);
+// var_dump($collectionNameError); // for easy troubleshooting... right now, I think silent failure is ok; it will just default to not displaying.
 //------- End fetch the collection name from the api --------- //
 
 ?>
@@ -98,13 +99,17 @@ curl_close($curlSession);
 	}
 	?>
 	<div id="innertext">
+		<?php if(isset($collectionName)){ ?>
+			<h1 class="emphatic-header">
+				<?php echo htmlspecialchars((isset($LANG['SEARCH_COLLECTION']) ? $LANG['SEARCH_COLLECTION'] : 'Search Collection'), HTML_SPECIAL_CHARS_FLAGS) . ": " . $collectionName; ?>	
+			</h1>
+		<?php } ?>
 		<form name="harvestparams" id="harvestparams" action="list.php" method="post" onsubmit="return checkHarvestParamsForm(this)">
 			<hr/>
 			<div>
 				<div style="float:left">
 					<div>
-						<p><?php echo $collectionName ?></p>
-						<p><?php echo $collectionNameError ?></p>
+						
 						<div class="catHeaderDiv"><?php echo $LANG['TAXON_HEADER']; ?></div>
 						<div style="margin:10px 0px 0px 5px;"><input type='checkbox' name='usethes' id='usethes' value='1' CHECKED />
 						<label for="usethes"><?php echo $LANG['INCLUDE_SYNONYMS']; ?></div></label>

--- a/content/lang/collections/harvestparams.en.php
+++ b/content/lang/collections/harvestparams.en.php
@@ -65,4 +65,5 @@ $LANG['TYPE_TAXON'] = 'Type taxon';
 $LANG['SELECT_TAXON_TYPE'] = 'Select taxon type';
 $LANG['DIRECTION'] = 'Direction';
 $LANG['DISTANCE_UNIT'] = 'Unit of distance';
+$LANG['SEARCH_COLLECTION'] = 'Searching Collection';
 ?>

--- a/content/lang/collections/harvestparams.es.php
+++ b/content/lang/collections/harvestparams.es.php
@@ -65,4 +65,5 @@ $LANG['TYPE_TAXON'] = 'Escriba el taxón';
 $LANG['SELECT_TAXON_TYPE'] = 'Seleccionar tipo de taxón';
 $LANG['DIRECTION'] = 'Dirección';
 $LANG['DISTANCE_UNIT'] = 'Unidad de distancia';
+$LANG['SEARCH_COLLECTION'] = 'Buscando en la Colección';
 ?>

--- a/content/lang/collections/harvestparams.fr.php
+++ b/content/lang/collections/harvestparams.fr.php
@@ -65,4 +65,5 @@ $LANG['TYPE_TAXON'] = 'Tapez le taxon';
 $LANG['SELECT_TAXON_TYPE'] = 'Sélectionnez le type de taxon';
 $LANG['DIRECTION'] = 'Direction';
 $LANG['DISTANCE_UNIT'] = 'Unité de distance';
+$LANG['SEARCH_COLLECTION'] = 'Recherche dans la Collection';
 ?>

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -882,3 +882,7 @@ hr {
   font-size: 125%;
   font-weight: bold;
 }
+
+.emphatic-header {
+  background-color: var(--bright-color);
+}


### PR DESCRIPTION
# Description

This PR adds a header to harvestparams.php indicating that the search is collection-specific iff a `db=foo` is in the URL request parameters.

## What harvestparams looked like before (and what it currently looks like if there is no `db=foo` in the URL:

<img width="1552" alt="Screen Shot 2023-10-17 at 3 53 56 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/d2f75df6-9759-47e4-bd2c-71fceccc645c">


## What harvestparams looks like now:

<img width="1552" alt="Screen Shot 2023-10-17 at 3 41 50 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/f6fc961c-1db2-4607-b132-a884effb64a3">


# Questions that I still have

- Is it possible for the harvestparams.php url to accommodate more than one value for db? If so, I will need to accommodate that in the code as well. I didn't see any examples of multiple collections in the [notes for the collprofile redesign](https://markfisherstestbucket.s3.amazonaws.com/Collection+page+redesign.docx).
- I am particularly curious about this line in my code: `$baseUrl = $protocol . "://" . $SERVER_HOST . $CLIENT_ROOT; // @TODO this feels janky; is it reliable?`. Thoughts? Is there a better way to get the base URL for an API call?
- Currently, if the api request for the collection data (where we get the collection name) fails, it fails silently, and the end user is none the wiser (i.e., no error is displayed; the collection name is simply not displayed). The failure is also not logged anywhere. Is this ok?

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=39202242](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=39202242)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
