### PR TITLE
Import and export of associated occurrences

### DIFF
--- a/classes/DwcArchiverOccurrence.php
+++ b/classes/DwcArchiverOccurrence.php
@@ -1,4 +1,6 @@
 <?php
+// Only needed for symbiotaAssociations version number.
+include_once($SERVER_ROOT . '/classes/OccurrenceUtilities.php'); 
 class DwcArchiverOccurrence extends Manager{
 
 	private $occurDefArr = array();
@@ -414,6 +416,12 @@ class DwcArchiverOccurrence extends Manager{
 	}
 
 	public function getAssociationStr($occid){
+
+		// Return symbiotaAssociations JSON for the associatedOccurrences field instead of the text string generated below
+		// TODO: There is room for fine-tuning what conditions will return the JSON
+		// Seems like it should be turned on for schemaType == 'backup', but re-importing that backup currently fails
+		if ($this->schemaType == 'symbiota') return $this->getAssociationJSON($occid);
+
 		if(is_numeric($occid)){
 			$relOccidArr = array();
 			$assocArr = array();
@@ -497,6 +505,141 @@ class DwcArchiverOccurrence extends Manager{
 			}
 		}
 		return trim($retStr,' |');
+	}
+
+	// Function to return any associations as JSON for the associatedOccurrences field
+	public function getAssociationJSON($occid) {
+
+		if (is_numeric($occid)) {
+
+			// Build SQL to find any associations for the occurrence record passed with occid
+			$sql = 'SELECT occid, occidAssociate, relationship, subType, identifier,' .
+				'basisOfRecord, resourceUrl, verbatimSciname, locationOnHost ' .
+				'FROM omoccurassociations ' .
+				'WHERE (occid = '.$occid.' OR occidAssociate = '.$occid.') ';
+
+			if ($rs = $this->conn->query($sql)) {
+
+				// No associations, so just return an empty string, and quit the function
+				if (!$rs->num_rows) return '';
+
+				// Build verbatimText array
+				$verbatimText = array();
+				$verbatimText['type'] = 'verbatimText';
+				$verbatimText['verbatimText'] = '';
+
+				// Get any pre-existing contents of the associatedOccurrences field in omoccurrences
+				$sql = 'SELECT associatedOccurrences FROM omoccurrences WHERE occid = ' . $occid;
+				$rs1 = $this->conn->query($sql);
+				$r = $rs1->fetch_object();
+
+				// Check if the contents of the field already is JSON
+				if ($assocOccArr = json_decode($r->associatedOccurrences, true)) {
+
+					// There's already JSON here
+					// TODO: What should we do? Perform some checks?
+				} else {
+
+					// no JSON content, store what is already in associatedOccurrences in verbatimText array
+					$verbatimText['verbatimText'] = $r->associatedOccurrences != 'NULL' ? $r->associatedOccurrences : '';
+				}
+
+				$rs1->free();
+
+				// No associatedOccurrences array exists, so build one
+				if (!isset($assocOccArr)) {
+
+					// Build JSON array
+					$assocOccArr = array();
+
+					// Build symbiotaAssociations array
+					$symbiotaAssociations = array();
+					$symbiotaAssociations['type'] = 'symbiotaAssociations';
+					$symbiotaAssociations['version'] = OccurrenceUtilities::$assocOccurVersion;
+					$symbiotaAssociations['associations'] = array();
+
+					// Add the symbiotaAssociations array
+					array_push($assocOccArr, $symbiotaAssociations);
+
+					// Add the verbatimText array
+					array_push($assocOccArr, $verbatimText);
+				}
+
+				// Make an array to hold occurrence IDs that need an additional guid (internalOccurrences)
+				$relOccidArr = array();
+
+				// Get each associated occurrence
+				while ($assocArr = $rs->fetch_assoc()) {
+
+					// Filter out any empty fields
+					$assocArr = array_filter($assocArr);
+
+					// Set the association type field
+					if (array_key_exists('occidAssociate', $assocArr)) {
+						$assocArr['type'] = 'internalOccurrence';
+					} else if (array_key_exists('identifier', $assocArr) || array_key_exists('resourceUrl', $assocArr)) {
+						$assocArr['type'] = 'externalOccurrence';
+					} else if (array_key_exists('verbatimSciname', $assocArr)) {
+						$assocArr['type'] = 'genericObservation';
+					} else {
+						// Should not happen, but if so, this seems to be the best fit
+						$assocArr['type'] = 'genericObservation';
+					}
+
+					// Check for cases where the occidAssociate is this occid.
+					// In those cases, we need to switch the occid and occidAssociate and get the inverse relationship
+					if (array_key_exists('occidAssociate', $assocArr) && $assocArr['occidAssociate'] == $occid) {
+						$assocArr['occidAssociate'] = $assocArr['occid'];
+						$assocArr['relationship'] = $this->getInverseRelationship($assocArr['relationship']);
+					}
+
+					// remove occid key, no longer needed
+					unset($assocArr['occid']);
+
+					// Check if the associated occurrence is an internal occurrence
+					// If so, we need to flag this to add the GUID identifier & resource url, in case it gets imported in another portal
+					if (array_key_exists('occidAssociate', $assocArr)) {
+						array_push($relOccidArr, $assocArr['occidAssociate']);
+					}
+
+					// Add associated occurrence array to the full associatedOccurrences array
+					array_push($assocOccArr[0]['associations'], $assocArr);
+
+				}
+
+				// There are some associated occurrences with an internal occidAssociate
+				// For these, we need to get their guids and construct reference URLs, in case they become external references
+				if ($relOccidArr) {
+
+					// Get the server domain
+					$this->setServerDomain();
+
+					// Construct and run query to get guids from an array of occids
+					$sql = 'SELECT occid, guid as guid FROM guidoccurrences g WHERE occid IN(' . implode(',', $relOccidArr) . ')';
+					$rs = $this->conn->query($sql);
+
+					// Loop through each guid, and find the association with the matching occidAssociate
+					while ($r = $rs->fetch_object()) {
+						foreach ($assocOccArr[0]['associations'] as $index => $assocArr) {
+							if (array_key_exists('occidAssociate', $assocArr) && 
+								$assocOccArr[0]['associations'][$index]['occidAssociate'] == $r->occid) {
+
+								// Add the GUID as the identifier, and the resource URL in case this ends up being treated as an external resource
+								$assocOccArr[0]['associations'][$index]['identifier'] = $r->guid;
+								$assocOccArr[0]['associations'][$index]['resourceUrl'] = $this->serverDomain . $GLOBALS['CLIENT_ROOT'] . 
+									'/collections/individual/index.php?guid=' . $r->guid;
+							}
+						}
+					}
+				}
+
+				$rs->free();
+
+				// Return the full symbiotaAssociations array as JSON
+				// TODO: this is returning "null" for fields that are empty, like verbatimText.
+				return json_encode( $assocOccArr, JSON_UNESCAPED_SLASHES);
+			}
+		}
 	}
 
 	public function setIncludeAssociatedSequences(){

--- a/classes/OccurrenceUtilities.php
+++ b/classes/OccurrenceUtilities.php
@@ -8,6 +8,10 @@ class OccurrenceUtilities {
 	static $monthNames = array('jan'=>'01','ene'=>'01','feb'=>'02','mar'=>'03','abr'=>'04','apr'=>'04','may'=>'05','jun'=>'06','jul'=>'07','ago'=>'08',
 		'aug'=>'08','sep'=>'09','oct'=>'10','nov'=>'11','dec'=>'12','dic'=>'12');
 
+	// Current version for associatedOccurrences JSON
+	// TODO: is this the best place for it? No other obvious landing spot.
+	public static $assocOccurVersion = '1.0';
+
  	public function __construct(){
  	}
 
@@ -761,6 +765,111 @@ class OccurrenceUtilities {
 		}
 		unset($recMap['authorinfraspecific']);
 		unset($recMap['authorspecies']);
+
+		// Deal with associatedOccurrence fields, if they exist
+		// Check if they exist, and then check if any of the fields are non-empty
+		if (count($check = preg_grep('/^associatedOccurrence:.*/', array_keys($recMap))) &&
+			strlen(implode(array_intersect_key($recMap, array_flip($check))))) {
+
+			// Check if there is already data in the associatedOccurrences field.
+			if (isset($recMap['associatedOccurrences']) && $recMap['associatedOccurrences']) {
+
+				// Check if the contents of the field already is JSON
+				if ($assocOccArr = json_decode($recMap['associatedOccurrences'], true)) {
+
+					// There's already JSON here
+					// TODO: What should we do? Perform some checks?
+					// Currently, it will just append any data specified by associatedOccurrence:* fields
+				} else {
+
+					// no JSON content, store what is already in associatedOccurrences in verbatimText array
+					$verbatimText = array();
+
+					// Add whatever text is mapped to associatedOccurrences to verbatimText
+					$verbatimText['type'] = 'verbatimText';
+					$verbatimText['verbatimText'] = $recMap['associatedOccurrences'];
+
+				}
+			}
+
+			// No associatedOccurrences array exists, so build one
+			if (!isset($assocOccArr)) {
+				$assocOccArr = array();
+
+				$symbiotaAssociations = array();
+				$symbiotaAssociations['type'] = 'symbiotaAssociations';
+				$symbiotaAssociations['version'] = self::$assocOccurVersion;
+				$symbiotaAssociations['associations'] = array();
+
+				// Add the symbiotaAssociations array
+				array_push($assocOccArr, $symbiotaAssociations);
+
+				// Add the verbatimText array, if it exists
+				if (isset($verbatimText)) array_push($assocOccArr, $verbatimText);
+			}
+
+			// Create associated occurrence array
+			$assocArr = array();
+
+			// Establish the associated occurrence type, check first to see if it's already set (and valid)
+			if (isset($recMap['associatedOccurrence:type'])) {
+
+				// Valid type, so use it
+				if ($recMap['associatedOccurrence:type'] == 'internalOccurrence' ||
+					$recMap['associatedOccurrence:type'] == 'externalOccurrence' ||
+					$recMap['associatedOccurrence:type'] == 'genericObservation') {
+					$assocArr['type'] = $recMap['associatedOccurrence:type'];
+				} else {
+
+					// Invalid type, fall back to genericObservation
+					$assocArr['type'] = 'genericObservation';
+				}
+			}
+
+			// No association type set, try to guess
+			if (!isset($assocArr['type'])) {
+
+				if (isset($recMap['associatedOccurrence:occidAssociate']) && $recMap['associatedOccurrence:occidAssociate']) {
+					$assocArr['type'] = 'internalOccurrence';
+				} else if ((isset($recMap['associatedOccurrence:identifier']) && $recMap['associatedOccurrence:identifier']) ||
+					(isset($recMap['associatedOccurrence:resourceUrl']) && $recMap['associatedOccurrence:resourceUrl'])) {
+					$assocArr['type'] = 'externalOccurrence';
+				} else if (isset($recMap['associatedOccurrence:verbatimSciname']) && $recMap['associatedOccurrence:verbatimSciname']) {
+					$assocArr['type'] = 'genericObservation';
+				} else {
+					// Should not happen, but if so, this seems to be the best fit
+					$assocArr['type'] = 'genericObservation';
+				}
+			}
+
+			// Finished with the type field, so unset it
+			unset($recMap['associatedOccurrence:type']);
+
+			// TODO: restrict fields to controlled vocab for relationship and subtype?
+
+			// Iterate through each remaining associated occurrence field
+			foreach (preg_grep('/^associatedOccurrence:.*/', array_keys($recMap)) as $field) {
+
+				// Save it to the associated occurrence array if it's not empty
+				if ($recMap[$field]) $assocArr[str_replace('associatedOccurrence:', '', $field)] = $recMap[$field];
+
+				// Unset the temporary field as the data is saved in the array
+				unset($recMap[$field]);
+			}
+
+			// Add associated occurrence array to the full associatedOccurrences array
+			array_push($assocOccArr[0]['associations'], $assocArr);
+
+			// Convert to JSON and store in the associatedOccurrences field
+			$recMap['associatedOccurrences'] = json_encode($assocOccArr, JSON_UNESCAPED_SLASHES);
+
+		} else {
+
+			// Unset any remaining associatedOccurrence fields, they are empty
+			$recMap = array_diff_key($recMap, array_flip(preg_grep('/^associatedOccurrence:.*/', array_keys($recMap))));
+
+		}
+
 		//Deal with Specify specific fields
 		if(isset($recMap['specify:forma']) && $recMap['specify:forma']){
 			$recMap['taxonrank'] = 'f.';

--- a/classes/SpecUploadBase.php
+++ b/classes/SpecUploadBase.php
@@ -38,6 +38,7 @@ class SpecUploadBase extends SpecUpload{
 	private $imgFormatDefault = '';
 	private $sourceDatabaseType = '';
 	private $dbpkCnt = 0;
+	private $relationshipArr;
 
 	function __construct() {
 		parent::__construct();
@@ -196,6 +197,24 @@ class SpecUploadBase extends SpecUpload{
 		sort($this->symbFields);
 		if($this->paleoSupport) $this->symbFields = array_merge($this->symbFields,$this->getPaleoTerms());
 		if($this->materialSampleSupport) $this->symbFields = array_merge($this->symbFields,$this->getMaterialSampleTerms());
+
+		//Associated Occurrence fields
+		// All-purpose fields
+		$this->symbFields[] = 'associatedOccurrences';
+		$this->symbFields[] = 'associatedOccurrence:type';
+		$this->symbFields[] = 'associatedOccurrence:basisOfRecord';
+		$this->symbFields[] = 'associatedOccurrence:relationship';
+		$this->symbFields[] = 'associatedOccurrence:subType';
+		$this->symbFields[] = 'associatedOccurrence:locationOnHost';
+		$this->symbFields[] = 'associatedOccurrence:notes';
+		// internalOccurrence
+		$this->symbFields[] = 'associatedOccurrence:occidAssociate';
+		// externalOccurrence
+		$this->symbFields[] = 'associatedOccurrence:identifier';
+		$this->symbFields[] = 'associatedOccurrence:resourceUrl';
+		// genericObservation
+		$this->symbFields[] = 'associatedOccurrence:verbatimSciname';
+
 		//Specify fields
 		$this->symbFields[] = 'specify:subspecies';
 		$this->symbFields[] = 'specify:subspecies_author';
@@ -408,6 +427,10 @@ class SpecUploadBase extends SpecUpload{
 					}
 					elseif(in_array('specify:'.$fieldName,$symbFields)){
 						$tranlatedFieldName = strtolower('specify:'.$fieldName);
+						$isAutoMapped = true;
+					}
+					elseif(in_array('associatedOccurrence:'.$fieldName,$symbFields)){
+						$tranlatedFieldName = strtolower('associatedOccurrence:'.$fieldName);
 						$isAutoMapped = true;
 					}
 				}
@@ -834,6 +857,7 @@ class SpecUploadBase extends SpecUpload{
 		$this->transferIdentificationHistory();
 		$this->transferImages();
 		if($GLOBALS['QUICK_HOST_ENTRY_IS_ACTIVE']) $this->transferHostAssociations();
+		$this->transferAssociatedOccurrences();
 		$this->finalCleanup();
 		$this->outputMsg('<li style="">Upload Procedure Complete ('.date('Y-m-d h:i:s A').')!</li>');
 		$this->outputMsg(' ');
@@ -1462,6 +1486,227 @@ class SpecUploadBase extends SpecUpload{
 		$rs->free();
 	}
 
+	// This function looks for records being imported with JSON in the associatedOccurrences field,
+	// parses it, and attempts to add or update any associated occurrences in the omoccurassociations table.
+	protected function transferAssociatedOccurrences() {
+
+		// Select records that appear to have symbiotaAssociations JSON:
+		$sql = 'SELECT occid, associatedOccurrences FROM `uploadspectemp` WHERE collid = ' . $this->collId .
+			' AND `associatedOccurrences` LIKE \'%{"type":"symbiotaAssociations"%\'';
+
+		// Run the query
+		$rs = $this->conn->query($sql);
+
+		// If any records appear to have associatedOccurrences JSON, transfer associated occurrences
+		if ($rs->num_rows) {
+
+			$this->outputMsg('<li>Transferring associated occurrences for ' . $rs->num_rows . ' records...</li>');
+
+			// Get current user ID
+			$symbUid = $GLOBALS['SYMB_UID'];
+
+			// Counter for the number of associations being imported
+			$assocCount = 0;
+
+			// Handle each record with associated occurrences JSON
+			while ($r = $rs->fetch_object()) {
+
+				// Check if the contents of the field is proper JSON
+				if ($assocOccArr = json_decode($r->associatedOccurrences, true)) {
+					// Proper JSON, parsed successfully
+
+					// Find the symbiotaAssociations and verbatimText arrays in the JSON and save them.
+					foreach ($assocOccArr as $index) {
+
+						// Check if there's an associations array present with all the keys. If so, save it
+						if (array_key_exists('type', $index) && $index['type'] == 'symbiotaAssociations' &&
+							array_key_exists('associations', $index) && array_key_exists('version', $index)) $assocOccur = $index;
+
+						// Check if verbatimText is present and save it.
+						// If so, we'll use it to replace the associatedOccurrences JSON, sanitizing it first for SQL
+						if (array_key_exists('type', $index) && $index['type'] == 'verbatimText' &&
+							array_key_exists('verbatimText', $index)) $verbatimText = $this->cleanInStr($index['verbatimText']);
+					}
+
+					// Check to make sure we found an associated occurrence array
+					if (isset($assocOccur)) {
+
+						// Check symbiotaAssociations version
+						if ($assocOccur['version'] != OccurrenceUtilities::$assocOccurVersion) {
+
+							// JSON symbiotaAssociations versions don't match
+							// TODO: What should we do here?
+						}
+
+					} else {
+
+						// No associated occurrence array found. It must be missing the associations key.
+						// Skip the record and output an error.
+						$this->outputMsg('<li>Transferring associations failed for occid: ' . $r->occid . '. ERROR: malformed associations JSON</li> ');
+						continue;
+					}
+
+					// If no verbatimText was found, just set it to an empty string.
+					if (!isset($verbatimText)) $verbatimText = '';
+
+				} else {
+					// JSON didn't parse, even though it appears to be there. Skip the record and output an error.
+					$this->outputMsg('<li>Transferring associations failed for occid: ' . $r->occid . '. ERROR: malformed JSON</li> ');
+					continue;
+				}
+
+				// Insert each associated occurrence contained in the associatedOccurrences JSON
+				foreach ($assocOccur['associations'] as $assoc) {
+
+					// Increment associations counter
+					$assocCount++;
+
+					// Sanitize the variables for SQL
+					$assoc = array_map(array($this, 'cleanInStr'), $assoc);
+
+					// Get the type, and remove it from the array
+					// TODO: Anything needed to be done with the type here?
+					$type = $assoc['type'];
+					unset($assoc['type']);
+
+					// Association is marked as an internal occurrence, but includes an identifier (guid), and resourceUrl
+					// Need to determine if it is still an internal occurrence, and if so, get its guid
+					// TODO: Should there be a check to make sure that this is an internal occurrence,
+					//   regardless of whether identifier/resourceURL are present?
+					if($type == 'internalOccurrence' && array_key_exists('identifier', $assoc) && array_key_exists('resourceUrl', $assoc)) {
+
+						// Construct and run query to get occid from guid
+						// Check for an occurrenceID first, then a guid.
+						// Finally, check for an occurrenceID or a dbpk that matches
+						$sql = "SELECT occid FROM omoccurrences WHERE occurrenceID = '" . $assoc['identifier'] .
+							"' UNION " .
+							"SELECT occid FROM guidoccurrences WHERE guid = '" . $assoc['identifier'] .
+							"' UNION " .
+							"SELECT occid FROM uploadspectemp WHERE (occurrenceID = '" . $assoc['identifier'] .
+							"' OR dbpk = '" . $assoc['identifier'] . "' OR dbpk = " . $assoc['occidAssociate'] . ")";
+
+						//echo $sql;
+						$rs1 = $this->conn->query($sql);
+
+						// Check to see if we got an occid back. If so, update to use that
+						if ($r1 = $rs1->fetch_object()) {
+
+							// Update the occidAssociate field to use the new occid
+							$assoc['occidAssociate'] = $r1->occid;
+
+							// Remove the externalOccurrence fields, no longer needed
+							unset($assoc['identifier'], $assoc['resourceUrl']);
+
+						} else {
+
+							// GUID record was not found, convert to external occurrence
+							$type = 'externalOccurrence';
+
+							// Remove the internalOccurrence fields
+							unset($assoc['occidAssociate']);
+						}
+					}
+
+					// First, try to update the association record if it already exists
+					// If if exists, it should have identical occid/occidAssociate, relationship, and one of:
+					//   occidAssociate/occid, verbatimSciname, identifier, or resourcUrl
+
+					// Set up a where clause to test whether or not the association already exists
+					// Check whether occidAssociate is set. If so, then the relationships apply to both specimens with one entry
+					if (array_key_exists('occidAssociate', $assoc)) {
+
+						// Check for an identical internal association, and also for its inverse relationship
+						$sqlWhere = " WHERE ((occid = " . $r->occid . " AND occidAssociate = " . $assoc['occidAssociate'] .
+							" AND relationship = '" . $assoc['relationship'] . "') OR (occid = " . $assoc['occidAssociate'] .
+							" AND occidAssociate = " . $r->occid . " AND relationship = '" .
+							$this->getInverseRelationship($assoc['relationship']) . "'))";
+					} else {
+
+						// Check for verbatimSciname if set, otherwise check for identifier if set, and finally for resourceUrl if set
+						$sqlWhere = " WHERE occid = " . $r->occid . " AND relationship = '" . $assoc['relationship'] . "'" .
+							(array_key_exists('verbatimSciname', $assoc) ? " AND verbatimSciname = '" . $assoc['verbatimSciname'] . "'" :
+							(array_key_exists('identifier', $assoc) ? " AND identifier = '" . $assoc['identifier'] . "'" :
+							(array_key_exists('resourceUrl', $assoc) ? " AND resourceUrl = '" . $assoc['resourceUrl'] . "'" : '')));
+					}
+
+					// Check for matching rows: the association already exists
+					$sql = 'SELECT subType, identifier, basisOfRecord, resourceUrl, verbatimSciname, locationOnHost, notes ' .
+						'FROM omoccurassociations' . $sqlWhere;
+					$rs1 = $this->conn->query($sql);
+
+					// If there are matching rows, see if data has changed and we need to update, rather than insert a new association
+					if ($existingAssoc = $rs1->fetch_assoc()) {
+
+						// Filter out any empty fields from the existing data
+						$existingAssoc = array_filter($existingAssoc);
+
+						// Make a new array for updating, and remove the occidAssociate key and relationship, which shouldn't need to change
+						$updateAssoc = $assoc;
+						unset($updateAssoc['occidAssociate'], $updateAssoc['relationship']);
+
+						// If there are keys or data that has changed from the existing data, then update
+						// If nothing has changed, just move on, nothing to insert or update in the omoccurassociations table
+						if (array_diff_assoc($updateAssoc, $existingAssoc)) {
+
+							// Construct update query
+							$sql = 'UPDATE omoccurassociations SET ';
+
+							// Add all the fields that are present in the JSON to the update query, except occidAssociate
+							$sql .= implode(', ', array_map(function($key, $value) {
+								return "{$key} = '{$value}'";
+							}, array_keys($updateAssoc), $updateAssoc));
+
+							// Add where clause to update query.
+							$sql .= $sqlWhere;
+
+							//echo $sql . '<br/>';
+
+							// Run update query, reporting any error
+							if (!$this->conn->query($sql)) {
+								$this->outputMsg('<li>Updating association failed for occid: ' . $r->occid .
+									'. ERROR: '.$this->conn->error.'</li> ');
+							}
+						}
+
+					} else {
+
+						// Build insert query to insert a new association
+						$sql = 'INSERT INTO omoccurassociations (occid, createdUid, '. implode(', ', array_keys($assoc)) . ') ' .
+							'VALUES('.$r->occid . ', ' . $symbUid . ", " .
+							implode(', ', array_map(function($value) {
+								return("'{$value}'");
+							}, $assoc)) . ');';
+
+						//echo $sql . '<br/>';
+
+						// Run insert query, reporting any error
+						if (!$this->conn->query($sql)) {
+							$this->outputMsg('<li>Transferring association failed for occid: ' . $r->occid . '. ERROR: '.$this->conn->error.'</li> ');
+						}
+					}
+				}
+
+				// Build query to update the associatedOccurrences field for the occurrence record
+				// If there was text there before the JSON, this is replaced, otherwise the field is set to NULL.
+				$sql = "UPDATE omoccurrences SET associatedOccurrences = '". ($verbatimText ? $verbatimText : 'NULL') .
+					"' WHERE occid = " . $r->occid;
+
+				// Run update query, reporting any error
+				if (!$this->conn->query($sql)) {
+					$this->outputMsg('<li>Restoring associatedOccurrences text failed for occid: ' . $r->occid . '. ERROR: '.$this->conn->error.'</li> ');
+				}
+
+				// Delete these variables if they exist, so we can check if they got set with the next ocurrence record
+				unset($assocOccur, $verbatimText);
+			}
+			$this->outputMsg('<li style="margin-left:10px;">' . $assocCount . ' associated occurrences transferred or updated</li> ');
+		}
+
+		// Free the database queries
+		$rs->free();
+		$rs1->free();
+	}
+
 	protected function finalCleanup(){
 		$this->outputMsg('<li>Record transfer complete!</li>');
 		$this->outputMsg('<li>Cleaning house...</li>');
@@ -2074,6 +2319,25 @@ class SpecUploadBase extends SpecUpload{
 
 	public function getTargetFieldStr(){
 		return implode(',', $this->targetFieldArr);
+	}
+
+	private function getInverseRelationship($relationship){
+		if(!$this->relationshipArr) $this->setRelationshipArr();
+		if(array_key_exists($relationship, $this->relationshipArr)) return $this->relationshipArr[$relationship];
+		return $relationship;
+	}
+
+	private function setRelationshipArr(){
+		if(!$this->relationshipArr){
+			$sql = 'SELECT t.term, t.inverseRelationship FROM ctcontrolvocabterm t INNER JOIN ctcontrolvocab v  ON t.cvid = v.cvid WHERE v.tableName = "omoccurassociations" AND v.fieldName = "relationship"';
+			if($rs = $this->conn->query($sql)){
+				while($r = $rs->fetch_object()){
+					$this->relationshipArr[$r->term] = $r->inverseRelationship;
+					$this->relationshipArr[$r->inverseRelationship] = $r->term;
+				}
+				$rs->free();
+			}
+		}
 	}
 
 	//Misc support functions

--- a/classes/SpecUploadDwca.php
+++ b/classes/SpecUploadDwca.php
@@ -899,6 +899,7 @@ class SpecUploadDwca extends SpecUploadBase{
 			}
 			else $this->outputMsg('<li>ERROR cross-mapping occurrences: '.$portalManager->getErrorMessage().'</li> ');
 		}
+		$this->transferAssociatedOccurrences();
 		$this->finalCleanup();
 		$this->outputMsg('<li style="">Upload Procedure Complete ('.date('Y-m-d h:i:s A').')!</li>');
 		$this->outputMsg(' ');


### PR DESCRIPTION
# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!

### Overview

This is a first cut of import/export of associated occurrences, using JSON to package them into the associatedOccurrences Darwin core field. I've added the import and export functionality into two separate commits (more details on how that works in each commit). Import can be via JSON in the associatedOccurrences field (as below), or via data that is mapped to special associatedOccurrence:* fields (e.g., associatedOuccurrence:resourceUrl). Export as JSON is only enabled for schemaType = symbiota.

Here is the JSON format that is being used, sketched out by @egbot:
```
[{
		"type": "symbiotaAssociations",
		"version": "1.0",
		"associations": [{
				"type": "externalOccurrence",
				"basisOfRecord": "HumanObservation",
				"relationship": "iNaturalistObservation",
				"resourceUrl": "http://www.inaturalist.org/observations/98914605",
				"identifier": "98914605"
			},
			{
				"type": "internalOccurrence",
				"basisOfRecord": "PreservedSpecimen",
				"relationship": "siblingOf",
				"occidAssociate": 345638
			},
			{
				"type": "internalOccurrence",
				"basisOfRecord": "PreservedSpecimen",
				"relationship": "partOf",
				"subtype": "skull",
				"occidAssociate": 6577866
			},
			{
				"type": "genericObservation",
				"basisOfRecord": "HumanObservation",
				"relationship": "ecologicallyOccursWith",
				"scientificName": "Pinus ponderosa"
			},
			{
				"type": "genericObservation",
				"basisOfRecord": "HumanObservation",
				"relationship": "ecologicallyOccursWith",
				"scientificName": "Androsace occidentalis"
			}
		]
	},
	{
		"type": "verbatimText",
		"verbatimText": ""
	}
]
```

### Outstanding issues
We can talk about these if you like @egbot, @GregPost-ASU. I don't have good solutions for these things, and in some cases I don't have a full understanding of the ramifications.

- In writing this, I've tried to anticipate many potential issues, but it's likely that I missed something given the complexity. It is worth testing both the import and export with various scenarios with portals that have a lot of associated occurrences.
- It seems like this would be useful when exporting as a collection backup (schemaType = backup), since that would mean that associated occurrences are also backed up and can be restored. I experimented with this, but the importing fails. For reasons not clear to me, the records in the uploadspectemp table don't get transferred to the omoccurrences table when they would for other import types. Because of this, when I try to add associated occurrences, it fails because the records don't have an occid from omoccurrences yet.
- While this works for schemaType = symbiota, I think that snapshot collections on most portals are using dwc as their schema. So that would mean that these associated occurrences wouldn't be able to move between portals for those.
- I am not adding duplicate occurrences as associated occurrences. This was added to the darwin core export relatively recently. I think this could be added, but might need to know more, and expand the JSON format.
- I see that some work has recently been done on where guids are stored. It's possible that may need to be taken into account, since I am using guids as the identifier and referenceUrl for internal associations/occurrences in case they become external occurrences, and to verify that these associated occurrences exist on import.
- I'm currently storing the symbiotaAssociations JSON version number in the OccurrenceUtilities class. That doesn't seem like a great place for it, but I don't know what a better alternative is.
- There's currently no checking if the symbiotaAssociations version number doesn't match, and minimal checking if valid JSON is somehow already present in the associatedOccurrences field. If there were JSON in that field that was in a different format from what is specified above, that would break things I think.