### PR TITLE
Admin-based editor search button in collection profile quicksearch

### DIFF
--- a/collections/editor/occurrencetabledisplay.php
+++ b/collections/editor/occurrencetabledisplay.php
@@ -4,6 +4,7 @@ include_once($SERVER_ROOT.'/classes/OccurrenceEditorManager.php');
 include_once($SERVER_ROOT.'/content/lang/collections/editor/occurrencetabledisplay.'.$LANG_TAG.'.php');
 header('Content-Type: text/html; charset='.$CHARSET);
 
+
 $collId = array_key_exists('collid',$_REQUEST)?$_REQUEST['collid']:false;
 $recLimit = array_key_exists('reclimit',$_REQUEST)?$_REQUEST['reclimit']:1000;
 $occIndex = array_key_exists('occindex',$_REQUEST)?$_REQUEST['occindex']:0;
@@ -164,7 +165,7 @@ else{
 		if(($isEditor || $crowdSourceMode)){
 			?>
 			<div id="titleDiv">
-				<div style="float:right;margin:">
+				<div style="float:right;">
 					<a href="#" title="<?php echo htmlspecialchars($LANG['SEARCH_FILTER'], HTML_SPECIAL_CHARS_FLAGS); ?>" onclick="toggleQueryForm();"><img src="../../images/find.png" style="width:16px;" /></a>
 					<?php
 					if($isEditor == 1 || $isGenObs){

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -12,15 +12,15 @@ $collManager = new OccurrenceCollectionProfile();
 $collid = isset($_REQUEST['collid']) ? $collManager->sanitizeInt($_REQUEST['collid']) : 0;
 $occIndex = array_key_exists('occindex',$_REQUEST)?$_REQUEST['occindex']:0;
 
-$occManager = new OccurrenceEditorManager();
-$collIdAsNum = (int)$collid;
-$occManager->setCollId($collIdAsNum);
-$occManager->setQueryVariables();
-$occIndex = 0;
-$recLimit = 1000;
-$recStart = floor($occIndex/$recLimit)*$recLimit;
-$recArr = $occManager->getOccurMap($recStart, $recLimit);
-$occid = array_keys($recArr)[0] ?? 0;
+// $occManager = new OccurrenceEditorManager();
+// $collIdAsNum = (int)$collid;
+// $occManager->setCollId($collIdAsNum);
+// $occManager->setQueryVariables();
+// $occIndex = 0;
+// $recLimit = 1000;
+// $recStart = floor($occIndex/$recLimit)*$recLimit;
+// $recArr = $occManager->getOccurMap($recStart, $recLimit);
+// $occid = array_keys($recArr)[0] ?? 0;
 
 $action = array_key_exists('action', $_REQUEST) ? $_REQUEST['action'] : '';
 $eMode = array_key_exists('emode', $_REQUEST) ? $collManager->sanitizeInt($_REQUEST['emode']) : 0;
@@ -69,9 +69,6 @@ if ($SYMB_UID) {
 		}
 
 		function submitAndRedirectSearchForm(urlPtOne, urlPtTwo, urlPtTwoAlt, urlPtThree, urlPtThreeAlt, isEditorSearch=false, occId=0) {
-			const tmp = <?php echo "test"; ?>;
-			console.log('deleteMe tmp is: ');
-			console.log(tmp);
 			try{
 				const collId = document?.forms['quicksearch']['collid']?.value;
 				const hasIdentifier = Boolean(document?.forms['quicksearch']['catalog-number']?.value);
@@ -81,16 +78,28 @@ if ($SYMB_UID) {
 				}
 				else if(!isEditorSearch && !val){
 					alert("You must provide a search term.");
-				}else if(isEditorSearch && val){
+				}else if(isEditorSearch && val){ // @TODO clean this up. I don't think that this section is necessary anymore
 					const url = urlPtOne.replace('occurrencetabledisplay.php?displayquery=1&collid=', 'occurrenceeditor.php?csmode=0&occindex=0&occid=' + occId + '&collid=') + collId + (hasIdentifier? urlPtTwo: urlPtTwoAlt) + val + (hasIdentifier ? urlPtThree : urlPtThreeAlt); // hacktacular, but good enough for tomorrow's due date
 					// window.location.href = url;
 				}else{
 					const url = urlPtOne + collId + (hasIdentifier? urlPtTwo: urlPtTwoAlt) + val + (hasIdentifier ? urlPtThree : urlPtThreeAlt);
-					// window.location.href = url;
+					window.location.href = url;
 				}
 			}catch(err){
 				console.log(err);
 			}
+		}
+
+		function validateForm (){
+			const taxonSearchVal = document?.forms['quicksearch']['taxon-search']?.value;
+			const catalogNumberValue = document.forms['quicksearch']['catalog-number'].value;
+			if(taxonSearchVal && !catalogNumberValue){
+				 alert("You cannot search the occurrence editor by taxon.");
+				 return false;
+			}else{
+				return true;
+			}
+
 		}
 		
 	</script>
@@ -114,7 +123,7 @@ if ($SYMB_UID) {
 		<section id="tabs" class="fieldset-like no-left-margin" style="float: right;">
 			<h1><span><?php echo (isset($LANG['QUICK_SEARCH']) ? $LANG['QUICK_SEARCH'] : 'Quick Search'); ?></span></h1>
 			<div id="dialogContainer" style="position: relative;">
-				<form name="quicksearch" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/list.php?db=','&catnum=', '&taxa=', '&includeothercatnum=1', '&usethes=1&taxontype=2 '); return false;">
+				<form name="quicksearch" action="processEditorSearch.php" method="POST" onsubmit="return validateForm()">
 					<label for="catalog-number"><?php echo (isset($LANG['OCCURENCE_IDENTIFIER']) ? $LANG['OCCURENCE_IDENTIFIER'] : 'Catalog Number'); ?></label>
 					<span class="skip-link">
 						<?php
@@ -137,21 +146,23 @@ if ($SYMB_UID) {
 					<label for="taxon-search"><?php echo (isset($LANG['TAXON']) ? $LANG['TAXON'] : 'Taxon'); ?></label>
 					<input name="taxon-search" id="taxon-search" type="text" />
 					<br>
+					<?php 
+						if($editCode == 1 || $editCode == 2 || $editCode == 3){
+					?>
+						<button type="submit" id="search-by-catalog-number-admin-btn"; ?>
+							<?php echo (isset($LANG['OCCURRENCE_EDITOR']) ? $LANG['OCCURRENCE_EDITOR'] : 'Edit'); ?>
+						</button>
+					<?php 
+						}
+					?>
+					
+				</form>
+				<!-- <form name="quicksearch-editor" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=','&q_catalognumber=', '', '', '', true, <?php echo $occid ?>); return false;"> -->
+				<form name="quicksearch" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/list.php?db=','&catnum=', '&taxa=', '&includeothercatnum=1', '&usethes=1&taxontype=2 '); return false;">
 					<button type="submit" id="search-by-catalog-number-btn" title="<?php echo (isset($LANG['IIDENTIFIER_PLACEHOLDER_LIST']) ? $LANG['IDENTIFIER_PLACEHOLDER_LIST'] : 'Occurrence ID and Record ID also accepted.'); ?>">
 						<?php echo (isset($LANG['SEARCH']) ? $LANG['SEARCH'] : 'Search'); ?>
 					</button>
 				</form>
-				<?php 
-					if($editCode == 1 || $editCode == 2 || $editCode == 3){
-				?>
-					<form name="quicksearch-editor" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=','&q_catalognumber=', '', '', '', true, <?php echo $occid ?>); return false;">
-						<button type="submit" id="search-by-catalog-number-admin-btn"; ?>
-							<?php echo (isset($LANG['OCCURRENCE_EDITOR']) ? $LANG['OCCURRENCE_EDITOR'] : 'Edit'); ?>
-						</button>
-					</form>
-				<?php 
-					}
-				?>
 			</div>
 		</section>
 		<?php

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -68,19 +68,13 @@ if ($SYMB_UID) {
 			return false;
 		}
 
-		function submitAndRedirectSearchForm(urlPtOne, urlPtTwo, urlPtTwoAlt, urlPtThree, urlPtThreeAlt, isEditorSearch=false, occId=0) {
+		function submitAndRedirectSearchForm(urlPtOne, urlPtTwo, urlPtTwoAlt, urlPtThree, urlPtThreeAlt) {
 			try{
 				const collId = document?.forms['quicksearch']['collid']?.value;
 				const hasIdentifier = Boolean(document?.forms['quicksearch']['catalog-number']?.value);
 				const val = hasIdentifier ? document?.forms['quicksearch']['catalog-number']?.value : document?.forms['quicksearch']['taxon-search']?.value;
-				if(isEditorSearch && val && !hasIdentifier){
-					alert("You cannot search the occurrence editor by taxon.");
-				}
-				else if(!isEditorSearch && !val){
+				if(!val){
 					alert("You must provide a search term.");
-				}else if(isEditorSearch && val){ // @TODO clean this up. I don't think that this section is necessary anymore
-					const url = urlPtOne.replace('occurrencetabledisplay.php?displayquery=1&collid=', 'occurrenceeditor.php?csmode=0&occindex=0&occid=' + occId + '&collid=') + collId + (hasIdentifier? urlPtTwo: urlPtTwoAlt) + val + (hasIdentifier ? urlPtThree : urlPtThreeAlt); // hacktacular, but good enough for tomorrow's due date
-					// window.location.href = url;
 				}else{
 					const url = urlPtOne + collId + (hasIdentifier? urlPtTwo: urlPtTwoAlt) + val + (hasIdentifier ? urlPtThree : urlPtThreeAlt);
 					window.location.href = url;

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -55,12 +55,15 @@ if ($SYMB_UID) {
 			return false;
 		}
 
-		function submitAndRedirectSearchForm(urlPtOne, urlPtTwo, urlPtTwoAlt, urlPtThree, urlPtThreeAlt) {
+		function submitAndRedirectSearchForm(urlPtOne, urlPtTwo, urlPtTwoAlt, urlPtThree, urlPtThreeAlt, isEditorSearch=false) {
 			try{
 				const collId = document?.forms['quicksearch']['collid']?.value;
 				const hasIdentifier = Boolean(document?.forms['quicksearch']['catalog-number']?.value);
 				const val = hasIdentifier ? document?.forms['quicksearch']['catalog-number']?.value : document?.forms['quicksearch']['taxon-search']?.value;
-				if(!val){
+				if(isEditorSearch && val && !hasIdentifier){
+					alert("You cannot search the occurrence editor by taxon.");
+				}
+				else if(!isEditorSearch && !val){
 					alert("You must provide a search term.");
 				}else{
 					const url = urlPtOne + collId + (hasIdentifier? urlPtTwo: urlPtTwoAlt) + val + (hasIdentifier ? urlPtThree : urlPtThreeAlt);
@@ -91,8 +94,8 @@ if ($SYMB_UID) {
 	<div id="innertext">
 		<section id="tabs" class="fieldset-like no-left-margin" style="float: right;">
 			<h1><span><?php echo (isset($LANG['QUICK_SEARCH']) ? $LANG['QUICK_SEARCH'] : 'Quick Search'); ?></span></h1>
-			<form name="quicksearch" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/list.php?db=','&catnum=', '&taxa=', '&includeothercatnum=1', '&usethes=1&taxontype=2 '); return false;">
-				<div id="dialogContainer" style="position: relative;">
+			<div id="dialogContainer" style="position: relative;">
+				<form name="quicksearch" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/list.php?db=','&catnum=', '&taxa=', '&includeothercatnum=1', '&usethes=1&taxontype=2 '); return false;">
 					<label for="catalog-number"><?php echo (isset($LANG['OCCURENCE_IDENTIFIER']) ? $LANG['OCCURENCE_IDENTIFIER'] : 'Catalog Number'); ?></label>
 					<span class="skip-link">
 						<?php
@@ -118,8 +121,19 @@ if ($SYMB_UID) {
 					<button type="submit" id="search-by-catalog-number-btn" title="<?php echo (isset($LANG['IIDENTIFIER_PLACEHOLDER_LIST']) ? $LANG['IDENTIFIER_PLACEHOLDER_LIST'] : 'Occurrence ID and Record ID also accepted.'); ?>">
 						<?php echo (isset($LANG['SEARCH']) ? $LANG['SEARCH'] : 'Search'); ?>
 					</button>
-				</div>
-			</form>
+				</form>
+				<?php 
+					if($editCode == 1 || $editCode == 2 || $editCode == 3){
+				?>
+					<form name="quicksearch-editor" action="javascript:void(0);" onsubmit="submitAndRedirectSearchForm('<?php echo $CLIENT_ROOT ?>/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=','&q_catalognumber=', '', '', '', true); return false;">
+						<button type="submit" id="search-by-catalog-number-admin-btn"; ?>
+							<?php echo (isset($LANG['OCCURRENCE_EDITOR']) ? $LANG['OCCURRENCE_EDITOR'] : 'Edit'); ?>
+						</button>
+					</form>
+				<?php 
+					}
+				?>
+			</div>
 		</section>
 		<?php
 		if ($editCode > 1) {

--- a/collections/misc/processEditorSearch.php
+++ b/collections/misc/processEditorSearch.php
@@ -42,9 +42,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
         $shouldRedirect = true;
     }
 
-    // if no catalog number and no taxon, go to $CLIENT_ROOT . /collections/editor/occurrencetabledisplay.php?displayquery=1&collid= . $collid
-    // if no catalog number and taxon, should have prevent this in the first place
-    // if catalog number, take them to $CLIENT_ROOT . '/collections/editor/occurrenceeditor.php?csmode=0&occindex=0&occid=' . $occid . '&collid=' . $collid
     if($shouldRedirect){
         header("Location: $redirectURL");
         exit;

--- a/collections/misc/processEditorSearch.php
+++ b/collections/misc/processEditorSearch.php
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<?php
+include_once('../../config/symbini.php');
+include_once($SERVER_ROOT.'/classes/OccurrenceEditorManager.php');
+header('Content-Type: text/html; charset=' . $CHARSET);
+
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $message = '<p>Fetching matching occurrence...</p>';
+
+    $catalogNumber = $_POST['catalog-number'];
+    $taxon = $_POST['taxon-search'];
+    $collid = $_POST['collid'];
+
+    $occManager = new OccurrenceEditorManager();
+    $collIdAsNum = (int)$collid;
+    $occManager->setCollId($collIdAsNum);
+    $occManager->setQueryVariables();
+    $occIndex = 0;
+    $recLimit = 1000; // @TODO this is likely not sufficient
+    $recStart = floor($occIndex/$recLimit)*$recLimit;
+    $recArr = $occManager->getOccurMap($recStart, $recLimit);
+    foreach ($recArr as $key => $element) {
+        if (isset($element['catalognumber']) && $element['catalognumber'] === $catalogNumber) {
+            $matchingElement = $element;
+            break;
+        }
+    }
+    $occid = $matchingElement['occid'] ?? '';
+
+    $shouldRedirect = false;
+
+
+    $redirectURL = $CLIENT_ROOT . '/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=' . $collid;
+    if($catalogNumber !== ''){
+        if($occid == ''){
+            $message = '<p>No matching catalog number could be found</p>';
+        }else{
+            $redirectURL = $CLIENT_ROOT . '/collections/editor/occurrenceeditor.php?csmode=0&occindex=0&occid=' . $occid . '&collid=' . $collid;
+            $shouldRedirect = true;
+        }
+    }else{
+        $shouldRedirect = true;
+    }
+
+    // if no catalog number and no taxon, go to $CLIENT_ROOT . /collections/editor/occurrencetabledisplay.php?displayquery=1&collid= . $collid
+    // if no catalog number and taxon, should have prevent this in the first place
+    // if catalog number, take them to $CLIENT_ROOT . '/collections/editor/occurrenceeditor.php?csmode=0&occindex=0&occid=' . $occid . '&collid=' . $collid
+    if($shouldRedirect){
+        header("Location: $redirectURL");
+        exit;
+    } else{
+        echo $message;
+    }
+}
+
+?>

--- a/content/lang/collections/misc/collprofiles.en.php
+++ b/content/lang/collections/misc/collprofiles.en.php
@@ -113,4 +113,5 @@ $LANG['MORE_INFO_ALT'] = 'More information about catalog number';
 $LANG['SEARCH_BY_TAXON'] = 'Search by Taxon';
 $LANG['OCCURENCE_IDENTIFIER'] = 'Catalog Number';
 $LANG['TAXON'] = 'Taxon';
+$LANG['OCCURRENCE_EDITOR'] = 'Edit';
 ?>

--- a/content/lang/collections/misc/collprofiles.es.php
+++ b/content/lang/collections/misc/collprofiles.es.php
@@ -113,4 +113,5 @@ $LANG['MORE_INFO_ALT'] = 'Más información sobre el número de catálogo';
 $LANG['SEARCH_BY_TAXON'] = 'Buscar por taxón';
 $LANG['OCCURENCE_IDENTIFIER'] = 'Numero de Catalogo';
 $LANG['TAXON'] = 'Taxón';
+$LANG['OCCURRENCE_EDITOR'] = 'Editar';
 ?>

--- a/content/lang/collections/misc/collprofiles.fr.php
+++ b/content/lang/collections/misc/collprofiles.fr.php
@@ -113,4 +113,5 @@ $LANG['MORE_INFO_ALT'] = 'Plus d\'informations sur le numéro de catalogue';
 $LANG['SEARCH_BY_TAXON'] = 'Recherche par taxon';
 $LANG['OCCURENCE_IDENTIFIER'] = 'Numéro de Catalogue';
 $LANG['TAXON'] = 'Taxon';
+$LANG['OCCURRENCE_EDITOR'] = 'Modifier';
 ?>


### PR DESCRIPTION
# Description

Super admins, collection admins and editors can now see and use an editor search button in the quick search panel from the collection profile page.

## Search by catalog number (user is super admin currently)

<img width="1552" alt="Screen Shot 2023-11-14 at 1 45 30 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/29a241f8-4d1d-438b-b24a-c17b0798f1f4">

<img width="1552" alt="Screen Shot 2023-11-14 at 1 45 37 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/d3797a92-ac13-44ef-80ff-cbeb762d6ce9">

## Search by nothing in particular (except collection) (user is super admin currently)

<img width="1552" alt="Screen Shot 2023-11-14 at 1 45 45 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/1c52f854-a808-4c30-8b36-e1af655ac399">

<img width="1552" alt="Screen Shot 2023-11-14 at 1 45 50 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/472e39cd-2390-4c6b-9ab0-67c36f90aa20">

## Button not visible if logged out

<img width="1552" alt="Screen Shot 2023-11-14 at 1 55 37 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/dcdf2d10-77b3-4a68-8518-f8983d0204c4">

## Button not visible if logged in as a user who is not super admin, collection admin, or collection editor

<img width="1552" alt="Screen Shot 2023-11-14 at 1 56 27 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/c5fdb270-7965-45f2-ae95-77a53a2a9e4c">

## Button visible as collection editor

<img width="1552" alt="Screen Shot 2023-11-14 at 2 06 38 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/ca6757f9-bfa6-4f6d-982f-25ea2cd5166d">

## Button visible as collection admin

<img width="1552" alt="Screen Shot 2023-11-14 at 2 19 25 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/bfc8a2d3-f685-4d93-a280-11b2880406e7">

## Button not visible when user is removed from collection admin

<img width="1552" alt="Screen Shot 2023-11-14 at 2 20 18 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/4ed0e7a0-856f-487e-b96b-ad584ac7b13b">


# Important Notes

I didn't see a way to search by taxon in occurrencetabledisplay.php, which leads me to believe that it's not an option. I created an alert in case a user tried to do just that, so let me know if I'm incorrect:

## No custom field for taxon search:

<img width="1440" alt="Screen Shot 2023-11-14 at 2 02 44 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/f77a8ee8-63f0-4cd3-8d00-4b9e14d00aa2">

## The alert nudging the user to not search for taxon when using the edit button:

<img width="1552" alt="Screen Shot 2023-11-14 at 1 45 20 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/1c65e2a5-f52e-4223-81b8-b0517ba60f79">



# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=44628020](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=44628020)
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
