### PR TITLE
place canonical symbiota login fieldset under control of

### DIFF
--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -113,6 +113,8 @@ $RIGHTS_TERMS = array(
 $SHOULD_BE_ABLE_TO_CREATE_PUBLIC_USER = true;
 // end Should public users be able to create accounts?
 
+$SYMBIOTA_LOGIN_ENABLED = true;
+
 $SHOULD_INCLUDE_CULTIVATED_AS_DEFAULT=false;
 $SHOULD_USE_HARVESTPARAMS = true;
 

--- a/profile/index.php
+++ b/profile/index.php
@@ -5,6 +5,8 @@ include_once($SERVER_ROOT.'/classes/ProfileManager.php');
 include_once($SERVER_ROOT.'/content/lang/profile/index.'.$LANG_TAG.'.php');
 header("Content-Type: text/html; charset=".$CHARSET);
 
+$SYMBIOTA_LOGIN_ENABLED = $SYMBIOTA_LOGIN_ENABLED ?? true;
+
 $login = array_key_exists('login',$_REQUEST)?$_REQUEST['login']:'';
 $remMe = array_key_exists("remember",$_POST)?$_POST["remember"]:'';
 $emailAddr = array_key_exists('email',$_POST)?$_POST['email']:'';
@@ -170,28 +172,30 @@ include($SERVER_ROOT.'/includes/header.php');
 	?>
 	<div style="width:300px;margin-right:auto;margin-left:auto;">
 		<form id="loginform" name="loginform" action="index.php" onsubmit="return checkCreds();" method="post">
-			<fieldset  class="profile-fieldset profile-login">
-				<legend class="profile-legend"><?php echo (isset($LANG['PORTAL_LOGIN'])?$LANG['PORTAL_LOGIN']:'Portal Login'); ?></legend>
-				<div style="margin: 10px;">
-					<label for="login"><?php echo (isset($LANG['LOGIN_NAME'])?$LANG['LOGIN_NAME']:'Login'); ?>:</label> 
-					<input id="login" name="login" value="<?php echo $login; ?>" style="border-style:inset;" />
-				</div>
-				<div style="margin:10px;">
-					<label for="password"><?php echo (isset($LANG['PASSWORD'])?$LANG['PASSWORD']:"Password"); ?>:</label>
-					<input type="password" id="password" name="password"  style="border-style:inset;" autocomplete="off" />
-				</div>
-				<div style="margin:10px">
-					<input type="checkbox" value='1' name="remember" id="remember" checked >
-					<label for="remember">
-						<?php echo (isset($LANG['REMEMBER'])?$LANG['REMEMBER']:'Remember me on this computer'); ?>
-					</label>
-				</div>
-				<div style="margin:15px;">
-					<input type="hidden" name="refurl" value="<?php echo $refUrl; ?>" />
-					<input type="hidden" id="resetpwd" name="resetpwd" value="">
-					<button name="action" type="submit" value="login"><?php echo (isset($LANG['SIGNIN'])?$LANG['SIGNIN']:'Sign In'); ?></button>
-				</div>
-			</fieldset>
+			<?php if($SYMBIOTA_LOGIN_ENABLED){ ?>
+				<fieldset  class="profile-fieldset profile-login">
+					<legend class="profile-legend"><?php echo (isset($LANG['PORTAL_LOGIN'])?$LANG['PORTAL_LOGIN']:'Portal Login'); ?></legend>
+					<div style="margin: 10px;">
+						<label for="login"><?php echo (isset($LANG['LOGIN_NAME'])?$LANG['LOGIN_NAME']:'Login'); ?>:</label> 
+						<input id="login" name="login" value="<?php echo $login; ?>" style="border-style:inset;" />
+					</div>
+					<div style="margin:10px;">
+						<label for="password"><?php echo (isset($LANG['PASSWORD'])?$LANG['PASSWORD']:"Password"); ?>:</label>
+						<input type="password" id="password" name="password"  style="border-style:inset;" autocomplete="off" />
+					</div>
+					<div style="margin:10px">
+						<input type="checkbox" value='1' name="remember" id="remember" checked >
+						<label for="remember">
+							<?php echo (isset($LANG['REMEMBER'])?$LANG['REMEMBER']:'Remember me on this computer'); ?>
+						</label>
+					</div>
+					<div style="margin:15px;">
+						<input type="hidden" name="refurl" value="<?php echo $refUrl; ?>" />
+						<input type="hidden" id="resetpwd" name="resetpwd" value="">
+						<button name="action" type="submit" value="login"><?php echo (isset($LANG['SIGNIN'])?$LANG['SIGNIN']:'Sign In'); ?></button>
+					</div>
+				</fieldset>
+			<?php }?>
 		</form>
 		<div style="width:300px;text-align:center;margin:20px;">
 			<?php 
@@ -207,24 +211,26 @@ include($SERVER_ROOT.'/includes/header.php');
 			<?php
 		 		} 
 			?>
-			<div style="font-weight:bold;margin-top:5px">
-				<?php echo (isset($LANG['REMEMBER_PWD'])?$LANG['REMEMBER_PWD']:"Can't Remember your password?"); ?>
-			</div>
-			<a href="#" style="color:blue;cursor:pointer;" onclick="resetPassword();"><?php echo (isset($LANG['REST_PWD'])?$LANG['REST_PWD']:'Reset Password'); ?></a>
-			<div style="font-weight:bold;margin-top:5px">
-				<?php echo (isset($LANG['REMEMBER_LOGIN'])?$LANG['REMEMBER_LOGIN']:"Can't Remember Login Name?"); ?>
-			</div>
-			<div>
-				<div><a href="#" onclick="toggle('emaildiv');"><?php echo htmlspecialchars((isset($LANG['RETRIEVE'])?$LANG['RETRIEVE']:'Retrieve Login'), HTML_SPECIAL_CHARS_FLAGS); ?></a></div>
-				<div id="emaildiv" style="display:none;margin:10px 0px 10px 40px;">
-					<fieldset class="profile-fieldset">
-						<form id="retrieveloginform" name="retrieveloginform" action="index.php" method="post">
-							<div><?php echo (isset($LANG['YOUR_EMAIL'])?$LANG['YOUR_EMAIL']:'Your Email'); ?>: <input type="text" name="email" /></div>
-							<div><button name="action" type="submit" value="Retrieve Login"><?php echo (isset($LANG['RETRIEVE'])?$LANG['RETRIEVE']:'Retrieve Login'); ?></button></div>
-						</form>
-					</fieldset>
+			<?php if($SYMBIOTA_LOGIN_ENABLED){ ?>
+				<div style="font-weight:bold;margin-top:5px">
+					<?php echo (isset($LANG['REMEMBER_PWD'])?$LANG['REMEMBER_PWD']:"Can't Remember your password?"); ?>
 				</div>
-			</div>
+				<a href="#" style="color:blue;cursor:pointer;" onclick="resetPassword();"><?php echo (isset($LANG['REST_PWD'])?$LANG['REST_PWD']:'Reset Password'); ?></a>
+				<div style="font-weight:bold;margin-top:5px">
+					<?php echo (isset($LANG['REMEMBER_LOGIN'])?$LANG['REMEMBER_LOGIN']:"Can't Remember Login Name?"); ?>
+				</div>
+				<div>
+					<div><a href="#" onclick="toggle('emaildiv');"><?php echo htmlspecialchars((isset($LANG['RETRIEVE'])?$LANG['RETRIEVE']:'Retrieve Login'), HTML_SPECIAL_CHARS_FLAGS); ?></a></div>
+					<div id="emaildiv" style="display:none;margin:10px 0px 10px 40px;">
+						<fieldset class="profile-fieldset">
+							<form id="retrieveloginform" name="retrieveloginform" action="index.php" method="post">
+								<div><?php echo (isset($LANG['YOUR_EMAIL'])?$LANG['YOUR_EMAIL']:'Your Email'); ?>: <input type="text" name="email" /></div>
+								<div><button name="action" type="submit" value="Retrieve Login"><?php echo (isset($LANG['RETRIEVE'])?$LANG['RETRIEVE']:'Retrieve Login'); ?></button></div>
+							</form>
+						</fieldset>
+					</div>
+				</div>
+			<?php } ?>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
# Description

This PR makes the native Symbiota login form disableable via a new config variable: `$SYMBIOTA_LOGIN_ENABLED`. If absent, this value defaults to true. This will be useful for the USDA portal, which should only be login-able via MS EntraID. However, it may eventually also be useful for future portals wishing to modularize their login workflow(s).

## When $SYMBIOTA_LOGIN_ENABLED = true:

<img width="1552" alt="Screen Shot 2023-12-04 at 8 34 23 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/92493808-c3e4-47da-8611-1394c58059f8">

## When $SYMBIOTA_LOGIN_ENABLED = false:

<img width="1552" alt="Screen Shot 2023-12-04 at 8 47 40 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/efae9000-36eb-4392-b10b-0dc59fbf1ea1">


## Lingering Question

Should 

> Can't remember your password?
> Reset Password
> Can't Remember Login Name?
> Retrieve Login

Also be hidden when $SYMBIOTA_LOGIN_ENABLED = false? My gut says yes.

Note that 
> Don't have an Account?
> Create an account

Is distinct and already toggleable with `$SHOULD_BE_ABLE_TO_CREATE_PUBLIC_USER`.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=46118192](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=46118192)
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
