### PR TITLE
Taxonomydisplay.php list display bug

### DIFF
--- a/classes/TaxonomyDisplayManager.php
+++ b/classes/TaxonomyDisplayManager.php
@@ -263,7 +263,7 @@ class TaxonomyDisplayManager extends Manager{
 					$sciName = str_replace($this->targetStr,"<b>".$this->targetStr."</b>",$sciName);
 					$taxonRankId = $this->taxaArr[$key]["rankid"];
 					if($this->taxaArr[$key]["rankid"] >= 180){
-						$sciName = " <i>".$sciName."</i> ";
+						$sciName = " <i>". htmlspecialchars($sciName, HTML_SPECIAL_CHARS_FLAGS) ."</i> ";
 					}
 					if($this->displayAuthor) $sciName .= ' '.$this->taxaArr[$key]["author"];
 				}
@@ -276,7 +276,7 @@ class TaxonomyDisplayManager extends Manager{
 				$indent = $taxonRankId;
 				if($indent > 230) $indent -= 10;
 				echo "<div>".str_repeat('&nbsp;',intval($indent/5));
-				if($taxonRankId > 139) echo '<a href="../index.php?taxon=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">' . htmlspecialchars($sciName, HTML_SPECIAL_CHARS_FLAGS) . '</a>';
+				if($taxonRankId > 139) echo '<a href="../index.php?taxon=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">' . $sciName. '</a>';
 				else echo $sciName;
 				if($this->isEditor) echo ' <a href="taxoneditor.php?tid=' . htmlspecialchars($key, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank"><img src="../../images/edit.png" style="width:11px" alt="Edit" /></a>';
 				if(!$this->displayFullTree){

--- a/classes/TaxonomyDisplayManager.php
+++ b/classes/TaxonomyDisplayManager.php
@@ -259,11 +259,11 @@ class TaxonomyDisplayManager extends Manager{
 				$sciName = "";
 				$taxonRankId = 0;
 				if(array_key_exists($key,$this->taxaArr)){
-					$sciName = $this->taxaArr[$key]["sciname"];
+					$sciName = htmlspecialchars($this->taxaArr[$key]["sciname"], HTML_SPECIAL_CHARS_FLAGS);
 					$sciName = str_replace($this->targetStr,"<b>".$this->targetStr."</b>",$sciName);
 					$taxonRankId = $this->taxaArr[$key]["rankid"];
 					if($this->taxaArr[$key]["rankid"] >= 180){
-						$sciName = " <i>". htmlspecialchars($sciName, HTML_SPECIAL_CHARS_FLAGS) ."</i> ";
+						$sciName = " <i>". $sciName ."</i> ";
 					}
 					if($this->displayAuthor) $sciName .= ' '.$this->taxaArr[$key]["author"];
 				}


### PR DESCRIPTION
# Before Changes:
<img width="934" alt="Screenshot 2023-12-06 at 10 11 56 AM" src="https://github.com/BioKIC/Symbiota/assets/86389284/58700c2f-b548-4941-98ff-956971b0599c">

# After Changes:
<img width="934" alt="Screenshot 2023-12-06 at 10 11 01 AM" src="https://github.com/BioKIC/Symbiota/assets/86389284/7086fec7-da2e-4e93-a670-1c39a02f321e">

# Changes Made:

The issue of displaying "\<i>" was caused by htmlspecialchars removing tags. Originally if the rankid of sciname >=180 - that sciname is "assigned" italics tags ($sciName = " \<i>" . $sciName . "\<i> "). However, when displayed, htmlspecialchars is used on sciname which removes italics property  leaving plain string "\<i>".

My solution is to use htmlspecialchars on sciname alone and "assign" italics tags to that trimmed string. This way we're still protected from double-encoding and properly displaying the required fonts.

Other possible sciName values are hardcoded and don't need html trimming. 

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [N/A] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [X] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [N/A] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [N/A] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
