### PR TITLE
Crowdsource lang tags corrections

### DIFF
--- a/collections/specprocessor/crowdsource/index.php
+++ b/collections/specprocessor/crowdsource/index.php
@@ -57,7 +57,7 @@ $statusStr = '';
 		<div style="margin:20px;">
 			<h2><?php echo $LANG['TOP_SCORES']; ?></h2>
 			<table class="styledtable" style="font-family:Arial;font-size:12px;width:300px;">
-				<tr><th style="min-width: 150px"><b>User</b></th><th style="text-align:center"><b><?php echo $LANG['APPROVED_SCORE']; ?></b></th><th style="text-align:center"><b><?php echo $LANG['PENDING_SCORE']; ?></b></th></tr>
+				<tr><th style="min-width: 150px"><b><?php echo $LANG['USER']; ?></b></th><th style="text-align:center"><b><?php echo $LANG['APPROVED_SCORE']; ?></b></th><th style="text-align:center"><b><?php echo $LANG['PENDING_SCORE']; ?></b></th></tr>
 				<?php
 				$topScoreArr = $csManager->getTopScores($catid);
 				if($topScoreArr){
@@ -84,16 +84,16 @@ $statusStr = '';
 				<legend><b><?php echo $LANG['YOUR_STANDING']; ?></b></legend>
 				<?php
 				if($SYMB_UID){
-					echo '<div style="margin-top:5px">Specimens processed as volunteer: '.number_format($userStats['totalcnt']);
-					if($userStats['nonvolcnt']) echo '<span style="margin-left:25px">(Additional as non-volunteer: '.number_format($userStats['nonvolcnt']).'*)</span>';
+					echo '<div style="margin-top:5px">' . $LANG['SPEC_PROC_AS_VOL'] . ': ' . number_format($userStats['totalcnt']);
+					if($userStats['nonvolcnt']) echo '<span style="margin-left:25px">(Additional as non-volunteer: '.number_format($userStats['nonvolcnt']) . '*)</span>';
 					echo '</div>';
-					echo '<div style="margin-top:5px">Pending points: '.number_format($userStats['ppoints']);
+					echo '<div style="margin-top:5px">' . $LANG['PEND_POINTS'] . ': '. number_format($userStats['ppoints']);
 					if($userStats['ppoints']) echo ' (<a href="review.php?rstatus=5&uid=' . htmlspecialchars($SYMB_UID, HTML_SPECIAL_CHARS_FLAGS) .  '">' . htmlspecialchars($LANG['VIEW_RECORDS'], HTML_SPECIAL_CHARS_FLAGS) . '</a>)';
 					echo '</div>';
-					echo '<div style="margin-top:5px">Approved points: '.number_format($userStats['apoints']);
+					echo '<div style="margin-top:5px">' . $LANG['APP_POINTS'] . ': ' . number_format($userStats['apoints']);
 					if($userStats['apoints']) echo ' (<a href="review.php?rstatus=10&uid=' . htmlspecialchars($SYMB_UID, HTML_SPECIAL_CHARS_FLAGS) . '">' . htmlspecialchars($LANG['VIEW_RECORDS'], HTML_SPECIAL_CHARS_FLAGS) . '</a>)';
 					echo '</div>';
-					echo '<div style="margin-top:5px">Total possible score: '.number_format($userStats['ppoints']+$userStats['apoints']).'</div>';
+					echo '<div style="margin-top:5px">' . $LANG['TOT_POSS_SCORE'] . ': ' . number_format($userStats['ppoints']+$userStats['apoints']) . '</div>';
 					if($userStats['nonvolcnt']) echo '<div style="margin-top:10px">* ' . $LANG['ONLY_PROCESSED_SPECIMENS_ELIGIBLE'] . '</div>';
 				}
 				else{

--- a/content/lang/collections/specprocessor/crowdsource/index.en.php
+++ b/content/lang/collections/specprocessor/crowdsource/index.en.php
@@ -7,10 +7,15 @@ Language: English
 
 $LANG['CROWDSOURCE_SCORE_BOARD'] = 'Crowdsourcing Score Board';
 $LANG['TOP_SCORES'] = 'Top Scores';
+$LANG['USER'] = 'User';
 $LANG['APPROVED_SCORE'] = 'Approved Score';
 $LANG['PENDING_SCORE'] = 'Pending Score';
 $LANG['TOP_SCORES_NOT_AVAIL'] = 'Top scores not yet available';
 $LANG['YOUR_STANDING'] = 'Your Current Standing';
+$LANG['SPEC_PROC_AS_VOL'] = 'Specimens processed as volunteer';
+$LANG['PEND_POINTS'] = 'Pending points';
+$LANG['APP_POINTS'] = 'Approved points';
+$LANG['TOT_POSS_SCORE'] = 'Total Possible Score';
 $LANG['VIEW_RECORDS'] = 'view records';
 $LANG['ONLY_PROCESSED_SPECIMENS_ELIGIBLE'] = 'Only specimens processed as a volunteer are eligible for points';
 $LANG['LOGIN'] = 'Login';

--- a/content/lang/collections/specprocessor/crowdsource/index.es.php
+++ b/content/lang/collections/specprocessor/crowdsource/index.es.php
@@ -7,10 +7,15 @@ Language: Espa&ntilde;ol
 
 $LANG['CROWDSOURCE_SCORE_BOARD'] = 'Pizarra de Puntaje del Crowdsourcing';
 $LANG['TOP_SCORES'] = 'Puntaje M&aacute;s Alta';
+$LANG['USER'] = 'Usuario';
 $LANG['APPROVED_SCORE'] = 'Puntaje Aprobada';
 $LANG['PENDING_SCORE'] = 'Puntaje Pendiente';
 $LANG['TOP_SCORES_NOT_AVAIL'] = ' Puntaje m&aacute;s alta a&uacute;n no disponible';
 $LANG['YOUR_STANDING'] = 'Posici&oacute;n Actual';
+$LANG['SPEC_PROC_AS_VOL'] = 'Especímenes procesados como voluntario';
+$LANG['PEND_POINTS'] = 'Puntaje pendiente';
+$LANG['APP_POINTS'] = 'Puntaje aprobada';
+$LANG['TOT_POSS_SCORE'] = 'Puntuación total posible';
 $LANG['VIEW_RECORDS'] = 'ver registros';
 $LANG['ONLY_PROCESSED_SPECIMENS_ELIGIBLE'] = 'Solamente las especimenes revisado por un voluntario son elegibles por recibir puntaje';
 $LANG['LOGIN'] = 'Iniciar Sesi&oacute;n';

--- a/content/lang/collections/specprocessor/crowdsource/index.fr.php
+++ b/content/lang/collections/specprocessor/crowdsource/index.fr.php
@@ -1,0 +1,35 @@
+<?php
+/*
+------------------
+Language: Français
+------------------
+*/
+
+$LANG['CROWDSOURCE_SCORE_BOARD'] = 'Tableau de Score Crowdsourcing';
+$LANG['TOP_SCORES'] = 'Meilleurs Ccores';
+$LANG['USER'] = 'Utilisateur';
+$LANG['APPROVED_SCORE'] = 'Score approuvé';
+$LANG['PENDING_SCORE'] = 'Score en attente';
+$LANG['TOP_SCORES_NOT_AVAIL'] = 'Meilleurs scores pas encore disponibles';
+$LANG['YOUR_STANDING'] = 'Votre statut actuel';
+$LANG['SPEC_PROC_AS_VOL'] = 'Spécimens traités en tant que volontaires';
+$LANG['PEND_POINTS'] = 'Points en attente';
+$LANG['APP_POINTS'] = 'Points approuvés';
+$LANG['TOT_POSS_SCORE'] = 'Score total possible';
+$LANG['VIEW_RECORDS'] = 'afficher les enregistrements';
+$LANG['ONLY_PROCESSED_SPECIMENS_ELIGIBLE'] = 'Seuls les spécimens traités en tant que volontaire sont éligibles aux points';
+$LANG['LOGIN'] = 'Connexion';
+$LANG['TO_VIEW_CURRENT'] = 'pour afficher les statistiques actuelles';
+$LANG['YOUR_STATS_BY_COLL'] = 'Vos statistiques par collections';
+$LANG['COLLECTION'] = 'Collection';
+$LANG['SPEC_COUNTS'] = 'Spécimen<br/>Nombre';
+$LANG['PENDING_POINTS'] = 'Points en attente<br/>';
+$LANG['APPROVED_POINTS'] = 'Approuvé<br/>Points';
+$LANG['OPEN_RECORDS'] = 'Ouvrir<br/>Enregistrements';
+$LANG['NOTE_EDITOR'] = '<b>Remarque :</b> Vous avez été identifié comme éditeur officiel d\'une ou plusieurs collections.
+            Vos points ne seront pas comptés dans le tableau Top Score pour les spécimens
+            qui appartiennent à la collection sur laquelle vous disposez de droits de modification.
+            Les meilleurs scores sont affichés uniquement pour les spécimens inscrits sur une base volontaire.';
+
+
+?>

--- a/content/lang/collections/specprocessor/crowdsource/index.fr.php
+++ b/content/lang/collections/specprocessor/crowdsource/index.fr.php
@@ -6,7 +6,7 @@ Language: Français
 */
 
 $LANG['CROWDSOURCE_SCORE_BOARD'] = 'Tableau de Score Crowdsourcing';
-$LANG['TOP_SCORES'] = 'Meilleurs Ccores';
+$LANG['TOP_SCORES'] = 'Meilleurs Scores';
 $LANG['USER'] = 'Utilisateur';
 $LANG['APPROVED_SCORE'] = 'Score approuvé';
 $LANG['PENDING_SCORE'] = 'Score en attente';


### PR DESCRIPTION
While troubleshooting crowdsourcing tools, I found some missing lang tags, added here.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.