### PR TITLE
Mysql and MariaDB Compatibility issues for password function

### DIFF
--- a/classes/ProfileManager.php
+++ b/classes/ProfileManager.php
@@ -91,7 +91,7 @@ class ProfileManager extends Manager{
 	private function authenticateUsingPassword($pwdStr){
 		$status = false;
 		if($pwdStr){
-			$sql = 'SELECT uid, firstname, username FROM users WHERE (password = PASSWORD(?)) AND (username = ? OR email = ?) ';
+			$sql = 'SELECT uid, firstname, username FROM users WHERE (password = CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?)))))) AND (username = ? OR email = ?) ';
 			if($stmt = $this->conn->prepare($sql)){
 				if($stmt->bind_param('sss', $pwdStr, $this->userName, $this->userName)){
 					$stmt->execute();
@@ -223,7 +223,7 @@ class ProfileManager extends Manager{
 			$this->resetConnection();
 			if($isSelf){
 				$testStatus = true;
-				$sql = 'SELECT uid FROM users WHERE (uid = ?) AND (password = PASSWORD(?))';
+				$sql = 'SELECT uid FROM users WHERE (uid = ?) AND (password = CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?))))))';
 				if($stmt = $this->conn->prepare($sql)){
 					$stmt->bind_param('is', $this->uid, $oldPwd);
 					$stmt->execute();
@@ -287,7 +287,7 @@ class ProfileManager extends Manager{
 
 	private function updatePassword($uid, $newPassword){
 		$status = false;
-		$sql = 'UPDATE users SET password = PASSWORD(?) WHERE (uid = ?)';
+		$sql = 'UPDATE users SET password = CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?))))) WHERE (uid = ?)';
 		if($stmt = $this->conn->prepare($sql)){
 			$stmt->bind_param('si', $newPassword, $uid);
 			$stmt->execute();
@@ -328,7 +328,7 @@ class ProfileManager extends Manager{
 		$initialDynamicProperties['accessibilityPref'] = $isAccessiblePreferred === "1" ? true : false;
 		$jsonDynProps = json_encode($initialDynamicProperties);
 
-		$sql = 'INSERT INTO users(username, password, email, firstName, lastName, title, institution, country, city, state, zip, guid, dynamicProperties) VALUES(?,PASSWORD(?),?,?,?,?,?,?,?,?,?,?,?)';
+		$sql = 'INSERT INTO users(username, password, email, firstName, lastName, title, institution, country, city, state, zip, guid, dynamicProperties) VALUES(?,CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?))))),?,?,?,?,?,?,?,?,?,?,?)';
 		$this->resetConnection();
 		if($stmt = $this->conn->prepare($sql)) {
 			$stmt->bind_param('sssssssssssss', $this->userName, $pwd, $email, $firstName, $lastName, $title, $institution, $country, $city, $state, $zip, $guid, $jsonDynProps);


### PR DESCRIPTION
…(SHA1(?))))) which is a drop in replacement and hash the same values

This function was depericated due to concerns about security regarding password replace of mysql users not general purpose hashing security. So this replace should be fine and doesn't require a package or 3rd party solution for now.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!

## Summary
There is compatibility issues with MySQL and MariaDB because the `password()` function in MySQL has been deprecated for a while see (MySQL Password Deprication)[https://dev.mysql.com/worklog/task/?id=6409] as to why. The TLDR is that the `password()` function was used to set MySQL user passwords and that was generally and unsafe practice to encourage because of SQL injection. However in our use case of just hashing a password for a user account I don't think any of this concern is warranted and SHA1 is a decent encryption technique so we should be good in that department.

## Solution
Solution is a swap from the password function to the direct usage of hashing function.
So from this
```sql
PASSWORD('mypass')
```
to this
```sql
CONCAT('*', UPPER(SHA1(UNHEX(SHA1('mypass')))))
```
