### PR TITLE
add my profile into header and remove about ARS

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -278,6 +278,9 @@ $actionPage = $SHOULD_USE_HARVESTPARAMS ? "harvestparams.php" : "./search/index.
             }
           ?>
           <li>
+            <a title="My Profile" href="<?php echo $CLIENT_ROOT ?>/profile/viewprofile.php"><b>My Profile</b></a>
+          </li>
+          <li>
             <a title="ARS Home" href="https://www.ars.usda.gov/"><b>ARS Home</b></a>
           </li>
           <li>
@@ -287,9 +290,9 @@ $actionPage = $SHOULD_USE_HARVESTPARAMS ? "harvestparams.php" : "./search/index.
               </b>
             </a>
           </li>
-          <li>
+          <!-- <li>
             <a title="About ARS" href="https://www.ars.usda.gov/about-ars/"><b>About ARS</b></a>
-          </li>
+          </li> -->
           <?php
             if($USER_DISPLAY_NAME){
           ?>


### PR DESCRIPTION
# Description

This PR adds "My Profile" back into the header.

It also remove the "About ARS" link from the header. Justification: 1) if I kept both in, there's some wonky text overlap with the ARS banner as one shrinks the screen. This is solvable if I experiment with media query pixel cutoffs, but IMHO not worth the extra effort because 2) the "ARS Home" link has its own "About ARS" link, so it's only one additional click for a curious user.

If that's not a strong enough justification, I'll implement the media query fix.

## Before

<img width="1552" alt="Screen Shot 2023-12-19 at 9 03 03 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/75b8e831-ca61-4828-9efc-e742b28815c4">


## After

<img width="1552" alt="Screen Shot 2023-12-19 at 9 02 48 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/ca12b5c4-23e8-483e-b519-7f320eeac7d1">


# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A in this case
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=47889985](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=47889985)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
