### PR TITLE
scrub references to v202209 and replace with uswds within collections…

### DIFF
--- a/collections/search/css/app.css
+++ b/collections/search/css/app.css
@@ -3,7 +3,7 @@
    BASE STYLES
    @mixin ============================= */
 
-@import "../../../css/v202209/symbiota/variables.css";
+@import "../../../css/uswds/symbiota/variables.css";
 /* BASE STYLES ******************************************/
 /* Typography */
 .inner-search body {

--- a/collections/search/css/main.css
+++ b/collections/search/css/main.css
@@ -47,7 +47,7 @@
   --alertredborder: #cc0000;
 }
 
-@import "../../../css/v202209/symbiota/variables.css";
+@import "../../../css/uswds/symbiota/variables.css";
 
 /******* 1. GENERAL ********/
 

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -39,7 +39,7 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 	echo '<link href="' . $CLIENT_ROOT . '/collections/search/css/app.css" type="text/css" rel="stylesheet" />';
 	
 	echo '<link href="' . $CLIENT_ROOT . '/collections/search/css/tables.css" type="text/css" rel="stylesheet" />';
-	echo '<link href="' . $CLIENT_ROOT . '/css/v202209/symbiota/collections/sharedCollectionStyling.css" type="text/css" rel="stylesheet" />';
+	echo '<link href="' . $CLIENT_ROOT . '/css/uswds/symbiota/collections/sharedCollectionStyling.css" type="text/css" rel="stylesheet" />';
 	?>
 	<script src="js/jquery-3.2.1.min.js" type="text/javascript"></script>
 	<script>


### PR DESCRIPTION
…/search

# Description

This PR makes it so that the portal-specific colors are drawn from css/uswds/symbiota/variables.css rather than css/v202209/symbiota/variables.css.

Note that these changes occur within the code base itself, rather than in a .css file.
These changes ONLY need to be custom in the USDA portal, so these are not changes that would need to be implemented in Development or, to my knowledge, other portals.

I am prepared to handle future merge conflicts in these files and don't anticipate them being difficult. If anyone has recommendations for a different way to implement this, though, I'm open to change it.

## Before

<img width="1552" alt="Screen Shot 2023-12-20 at 7 28 34 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/60f80bf3-4c4e-4091-8deb-f0f6dc24520c">

## After

<img width="1552" alt="Screen Shot 2023-12-20 at 7 28 17 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/0d07f493-5691-4ba0-9c80-71cd87c0f2f8">

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=48004040](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=48004040)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A
    
# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
