### PR TITLE
Hotfix 12 18 23 mysql compat

### DIFF
--- a/classes/ProfileManager.php
+++ b/classes/ProfileManager.php
@@ -88,7 +88,7 @@ class ProfileManager extends Manager{
 	private function authenticateUsingPassword($pwdStr){
 		$status = false;
 		if($pwdStr){
-			$sql = 'SELECT uid, firstname, username FROM users WHERE (password = PASSWORD(?)) AND (username = ? OR email = ?) ';
+			$sql = 'SELECT uid, firstname, username FROM users WHERE (password = CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?)))))) AND (username = ? OR email = ?) ';
 			if($stmt = $this->conn->prepare($sql)){
 				if($stmt->bind_param('sss', $pwdStr, $this->userName, $this->userName)){
 					$stmt->execute();
@@ -215,7 +215,7 @@ class ProfileManager extends Manager{
 			$this->resetConnection();
 			if($isSelf){
 				$testStatus = true;
-				$sql = 'SELECT uid FROM users WHERE (uid = ?) AND (password = PASSWORD(?))';
+				$sql = 'SELECT uid FROM users WHERE (uid = ?) AND (password = CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?))))))';
 				if($stmt = $this->conn->prepare($sql)){
 					$stmt->bind_param('is', $this->uid, $oldPwd);
 					$stmt->execute();
@@ -279,7 +279,7 @@ class ProfileManager extends Manager{
 
 	private function updatePassword($uid, $newPassword){
 		$status = false;
-		$sql = 'UPDATE users SET password = PASSWORD(?) WHERE (uid = ?)';
+		$sql = 'UPDATE users SET password = CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?))))) WHERE (uid = ?)';
 		if($stmt = $this->conn->prepare($sql)){
 			$stmt->bind_param('si', $newPassword, $uid);
 			$stmt->execute();
@@ -316,7 +316,7 @@ class ProfileManager extends Manager{
 		$country = array_key_exists('country', $postArr) ? strip_tags($postArr['country']) : '';
 		$guid = array_key_exists('guid', $postArr) ? strip_tags($postArr['guid']) : '';
 
-		$sql = 'INSERT INTO users(username, password, email, firstName, lastName, title, institution, country, city, state, zip, guid) VALUES(?,PASSWORD(?),?,?,?,?,?,?,?,?,?,?)';
+		$sql = 'INSERT INTO users(username, password, email, firstName, lastName, title, institution, country, city, state, zip, guid) VALUES(?,CONCAT(\'*\', UPPER(SHA1(UNHEX(SHA1(?))))),?,?,?,?,?,?,?,?,?,?)';
 		$this->resetConnection();
 		if($stmt = $this->conn->prepare($sql)) {
 			$stmt->bind_param('ssssssssssss', $this->userName, $pwd, $email, $firstName, $lastName, $title, $institution, $country, $city, $state, $zip, $guid);

--- a/config/schema/1.0/db_schema-1.0.sql
+++ b/config/schema/1.0/db_schema-1.0.sql
@@ -217,7 +217,7 @@ CREATE TABLE `agents` (
   `endyearactive` int(11) DEFAULT NULL,
   `notes` varchar(255) DEFAULT NULL,
   `rating` int(11) DEFAULT '10',
-  `guid` varchar(900) DEFAULT NULL,
+  `guid` varchar(150) DEFAULT NULL,
   `preferredrecbyid` bigint(20) DEFAULT NULL,
   `initialtimestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `uuid` char(43) DEFAULT NULL,

--- a/config/schema/1.0/patches/db_schema_patch-3.0.sql
+++ b/config/schema/1.0/patches/db_schema_patch-3.0.sql
@@ -17,8 +17,8 @@ CREATE TABLE `adminconfig` (
 );
 
 ALTER TABLE `agents` 
-  CHANGE COLUMN `taxonomicgroups` `taxonomicGroups` VARCHAR(900) NULL DEFAULT NULL ,
-  CHANGE COLUMN `collectionsat` `collectionsAt` VARCHAR(900) NULL DEFAULT NULL ,
+  CHANGE COLUMN `taxonomicgroups` `taxonomicGroups` text NULL DEFAULT NULL ,
+  CHANGE COLUMN `collectionsat` `collectionsAt` text NULL DEFAULT NULL ,
   CHANGE COLUMN `mbox_sha1sum` `mboxSha1Sum` CHAR(40) NULL DEFAULT NULL ;
 
 ALTER TABLE `agents`
@@ -425,7 +425,7 @@ ALTER TABLE `institutions`
   CHANGE COLUMN `Phone` `Phone` VARCHAR(100) NULL DEFAULT NULL,
   CHANGE COLUMN `Contact` `Contact` VARCHAR(255) NULL DEFAULT NULL,
   CHANGE COLUMN `Email` `Email` VARCHAR(255) NULL DEFAULT NULL,
-  CHANGE COLUMN `Notes` `Notes` VARCHAR(19500) NULL DEFAULT NULL;
+  CHANGE COLUMN `Notes` `Notes` text NULL DEFAULT NULL;
 
 
 ALTER TABLE `omcollections` 
@@ -963,7 +963,7 @@ ALTER TABLE `uploaddetermtemp`
   ADD COLUMN `verbatimTaxonRank` VARCHAR(45) NULL AFTER `specificEpithet`,
   ADD COLUMN `taxonRank` VARCHAR(45) NULL AFTER `verbatimTaxonRank`,
   ADD COLUMN `infraSpecificEpithet` VARCHAR(45) NULL AFTER `taxonRank`,
-  ADD COLUMN `taxonRemarks` VARCHAR(2000) NULL AFTER `identificationRemarks`,
+  ADD COLUMN `taxonRemarks` text NULL AFTER `identificationRemarks`,
   ADD COLUMN `identificationVerificationStatus` VARCHAR(45) NULL AFTER `taxonRemarks`,
   ADD COLUMN `taxonConceptID` VARCHAR(45) NULL AFTER `identificationVerificationStatus`,
   CHANGE COLUMN `identifiedBy` `identifiedBy` VARCHAR(255) NOT NULL DEFAULT '',

--- a/config/schema/3.0/db_schema-3.0.sql
+++ b/config/schema/3.0/db_schema-3.0.sql
@@ -193,11 +193,11 @@ CREATE TABLE `agents` (
   `endYearActive` int(11) DEFAULT NULL,
   `notes` varchar(255) DEFAULT NULL,
   `rating` int(11) DEFAULT 10,
-  `guid` varchar(900) DEFAULT NULL,
+  `guid` varchar(150) DEFAULT NULL,
   `preferredRecByID` bigint(20) DEFAULT NULL,
   `biography` text DEFAULT NULL,
-  `taxonomicGroups` varchar(900) DEFAULT NULL,
-  `collectionsAt` varchar(900) DEFAULT NULL,
+  `taxonomicGroups` text DEFAULT NULL,
+  `collectionsAt` text DEFAULT NULL,
   `curated` tinyint(1) DEFAULT 0,
   `notOtherwiseSpecified` tinyint(1) DEFAULT 0,
   `type` enum('Individual','Team','Organization') DEFAULT NULL,
@@ -966,7 +966,7 @@ CREATE TABLE `institutions` (
   `contact` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `url` varchar(250) DEFAULT NULL,
-  `notes` varchar(19500) DEFAULT NULL,
+  `notes` text DEFAULT NULL,
   `modifiedUid` int(10) unsigned DEFAULT NULL,
   `modifiedTimeStamp` datetime DEFAULT NULL,
   `initialTimestamp` timestamp NOT NULL DEFAULT current_timestamp(),
@@ -2268,7 +2268,7 @@ CREATE TABLE `omoccurrences` (
 ) ENGINE=InnoDB;
 
 
-DELIMITER ;;
+DELIMITER |
 CREATE TRIGGER `omoccurrences_insert` AFTER INSERT ON `omoccurrences`
 FOR EACH ROW BEGIN
 	IF NEW.`decimalLatitude` IS NOT NULL AND NEW.`decimalLongitude` IS NOT NULL THEN
@@ -2279,7 +2279,8 @@ FOR EACH ROW BEGIN
 		INSERT INTO omoccurrencesfulltext (`occid`,`recordedby`,`locality`) 
 		VALUES (NEW.`occid`,NEW.`recordedby`,CONCAT_WS("; ", NEW.`municipality`, NEW.`locality`));
 	END IF;
-END ;;
+END;
+|
 
 CREATE TRIGGER `omoccurrences_update` AFTER UPDATE ON `omoccurrences`
 FOR EACH ROW BEGIN
@@ -2308,13 +2309,15 @@ FOR EACH ROW BEGIN
 	ELSE 
 		DELETE FROM omoccurrencesfulltext WHERE `occid` = NEW.`occid`;
 	END IF;
-END ;;
+END;
+|
 
 CREATE TRIGGER `omoccurrences_delete` BEFORE DELETE ON `omoccurrences`
 FOR EACH ROW BEGIN
 	DELETE FROM omoccurpoints WHERE `occid` = OLD.`occid`;
 	DELETE FROM omoccurrencesfulltext WHERE `occid` = OLD.`occid`;
-END ;;
+END;
+|
 DELIMITER ;
 
 
@@ -2782,7 +2785,7 @@ CREATE TABLE `specprocessorrawlabels` (
 ) ENGINE=InnoDB;
 
 
-DELIMITER ;;
+DELIMITER |
 CREATE TRIGGER `specprocessorrawlabelsfulltext_insert` AFTER INSERT ON `specprocessorrawlabels`
 FOR EACH ROW BEGIN
   INSERT INTO specprocessorrawlabelsfulltext (
@@ -2794,8 +2797,8 @@ FOR EACH ROW BEGIN
     NEW.`imgid`,
     NEW.`rawstr`
   );
-END ;;
-
+END;
+|
 
 CREATE TRIGGER `specprocessorrawlabelsfulltext_update` AFTER UPDATE ON `specprocessorrawlabels`
 FOR EACH ROW BEGIN
@@ -2803,7 +2806,8 @@ FOR EACH ROW BEGIN
     `imgid` = NEW.`imgid`,
     `rawstr` = NEW.`rawstr`
   WHERE `prlid` = NEW.`prlid`;
-END ;;
+END;
+|
 DELIMITER ;
 
 
@@ -2822,11 +2826,12 @@ CREATE TABLE `specprocessorrawlabelsfulltext` (
 ) ENGINE=MyISAM;
 
 
-DELIMITER ;;
+DELIMITER |
 CREATE TRIGGER `specprocessorrawlabelsfulltext_delete` BEFORE DELETE ON `specprocessorrawlabelsfulltext`
 FOR EACH ROW BEGIN
   DELETE FROM specprocessorrawlabelsfulltext WHERE `prlid` = OLD.`prlid`;
-END ;;
+END;
+|
 DELIMITER ;
 
 
@@ -3524,11 +3529,11 @@ CREATE TABLE `uploadspectemp` (
   `taxonRank` varchar(32) DEFAULT NULL,
   `infraspecificEpithet` varchar(255) DEFAULT NULL,
   `scientificNameAuthorship` varchar(255) DEFAULT NULL,
-  `taxonRemarks` varchar(2000) DEFAULT NULL,
+  `taxonRemarks` text DEFAULT NULL,
   `identifiedBy` varchar(255) DEFAULT NULL,
   `dateIdentified` varchar(45) DEFAULT NULL,
-  `identificationReferences` varchar(2000) DEFAULT NULL,
-  `identificationRemarks` varchar(2000) DEFAULT NULL,
+  `identificationReferences` text DEFAULT NULL,
+  `identificationRemarks` text DEFAULT NULL,
   `identificationQualifier` varchar(255) DEFAULT NULL COMMENT 'cf, aff, etc',
   `typeStatus` varchar(255) DEFAULT NULL,
   `recordedBy` varchar(255) DEFAULT NULL COMMENT 'Collector(s)',

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -5,7 +5,7 @@
 - [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
 - [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
 - [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
-- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
+- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
 - [ ] There are no linter errors
 - [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
 - [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed


### PR DESCRIPTION
# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!

#779 

## Summary
There was compatibility issues with MySQL and MariaDB over the `password()` function because it was depericated in MySQL, see (MySQL Password Deprication)[https://dev.mysql.com/worklog/task/?id=6409] as to why. The TLDR is that the `password()` function was used to set MySQL user passwords and that was generally and unsafe practice to encourage because of SQL injection. However in our use case of just hashing a password for a user account I don't think any of this concern is warranted and SHA1 is a decent encryption technique so we should be good in that department.

The second issue was less of compatibility between MySQL and MariaDB but there were some long standing issues of fields that made the row size too large to use without external configuration. Not sure if I should update the [INSTALL.md](docs/INSTALL.md) with instructions / known issues with some versions of MariaDB.

## Solution
Solution is a swap from the password function to the direct usage of hashing function.
So from this
```sql
PASSWORD('mypass')
```
to this
```sql
CONCAT('*', UPPER(SHA1(UNHEX(SHA1('mypass')))))
```
## Types Changes
| Table | Attribute | Old Type | New Type |
| ----- | --------- | --------- | ---------- |
| agents | guid | `varchar(900)` | `text` |
| agents | taxonomicgroups | `varchar(900)` | `text` |
| institutions | Notes | `varchar(19500)` | `text` |
| omcollections | taxonRemarks | `varchar(2000)` | `text` |
| uploadspectemp | taxonRemarks | `varchar(2000)` | `text` |
| uploadspectemp | identificationReferences | `varchar(2000)` | `text` |
| uploadspectemp | identificationRemarks | `varchar(2000)` | `text` |

## Other Changes
Change from using `;;` as a delimiter for the triggers and used `|` instead to prevent issues when running the script from top to bottom

