### PR TITLE
Key v1 lang tag fix

### DIFF
--- a/content/lang/ident/key.en.php
+++ b/content/lang/ident/key.en.php
@@ -30,4 +30,10 @@ $LANG['IMG_NOT_AVAILABLE'] = 'Image<br/>Not<br/>Available';
 $LANG['EDITMORP'] = 'Edit morphology';
 $LANG['ERROR_CLID_NULL'] = 'Error: checklist identifier is NULL';
 
+// key-v1.php
+$LANG['TAXON'] = 'Taxon';
+$LANG['DISPRESSPEC'] = 'Load Species List';
+$LANG['DISPLAY'] = 'Display';
+$LANG['SCINAME'] = 'Scientific Name';
+$LANG['COMMON'] = 'Common Name';
 ?>

--- a/content/lang/ident/key.es.php
+++ b/content/lang/ident/key.es.php
@@ -30,4 +30,10 @@ $LANG['IMG_NOT_AVAILABLE'] = 'Imagen<br/>no<br/>disponible';
 $LANG['EDITMORP'] = 'Editar la morfolog&iacute;a';
 $LANG['ERROR_CLID_NULL'] = 'Error: el identificador de la lista es NULL';
 
+// key-v1.php
+$LANG['TAXON'] = 'Taxón';
+$LANG['DISPRESSPEC'] = 'Cargar Lista';
+$LANG['DISPLAY'] = 'Mostrar';
+$LANG['SCINAME'] = 'Nombre Científico';
+$LANG['COMMON'] = 'Nombre Común';
 ?>

--- a/ident/key-v1.php
+++ b/ident/key-v1.php
@@ -57,7 +57,7 @@ if($chars){
 
 <html>
 <head>
-	<title><?php echo $DEFAULT_TITLE.$LANG['WEBKEY'].preg_replace('/\<[^\>]+\>/','',$dataManager->getClName()); ?></title>
+	<title><?php echo $DEFAULT_TITLE.$LANG['WEBKEY']. ' ' . preg_replace('/\<[^\>]+\>/','',$dataManager->getClName()); ?></title>
 	<?php
 	include_once($SERVER_ROOT.'/includes/head.php');
 	include_once($SERVER_ROOT.'/includes/googleanalytics.php');

--- a/ident/key-v1.php
+++ b/ident/key-v1.php
@@ -57,7 +57,7 @@ if($chars){
 
 <html>
 <head>
-	<title><?php echo $DEFAULT_TITLE.$LANG['WEBKEY']. ' ' . preg_replace('/\<[^\>]+\>/','',$dataManager->getClName()); ?></title>
+	<title><?php echo $DEFAULT_TITLE.$LANG['WEBKEY'] . ' ' . preg_replace('/\<[^\>]+\>/','',$dataManager->getClName()); ?></title>
 	<?php
 	include_once($SERVER_ROOT.'/includes/head.php');
 	include_once($SERVER_ROOT.'/includes/googleanalytics.php');


### PR DESCRIPTION
Add some missing lang tags that belong to ident/key-v1.php

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.