### PR TITLE
add span element in h3 nested in fieldset-like section element, add m…

### DIFF
--- a/collections/misc/protectedspecies.php
+++ b/collections/misc/protectedspecies.php
@@ -152,6 +152,7 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 	<div style="clear:both">
 		<section class="fieldset-like">
 			<h1><span>Global Protections</span></h1>
+			<br/>
 			<?php
 			if($isEditor){
 				?>
@@ -176,11 +177,18 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 			if($rsArr){
 				foreach($rsArr as $family => $speciesArr){
 					?>
-					<h3><?php echo $family; ?></h3>
-					<div style='margin-left:20px;'>
+					<h3>
+						<span>
+							<?php echo $family; ?>
+						</span>
+					</h3>
+					<div style='margin-left:20px; margin-bottom:20px;'>
 						<?php
 						foreach($speciesArr as $tid => $nameArr){
-							echo '<div id="tid-'.$tid.'"><a href="../../taxa/index.php?taxon=' . htmlspecialchars($tid, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank"><i>' . htmlspecialchars($nameArr['sciname'], HTML_SPECIAL_CHARS_FLAGS) . '</i> ' . htmlspecialchars($nameArr['author'], HTML_SPECIAL_CHARS_FLAGS) . '</a> ';
+							echo '<div id="tid-'.$tid.'">';
+							echo '<a href="../../taxa/index.php?taxon=' . htmlspecialchars($tid, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">';
+							echo '<i>' . htmlspecialchars($nameArr['sciname'], HTML_SPECIAL_CHARS_FLAGS) . '</i> ';
+							echo htmlspecialchars($nameArr['author'], HTML_SPECIAL_CHARS_FLAGS) . '</a> ';
 							if($isEditor){
 								?>
 								<span class="editobj" style="display:none;">
@@ -217,7 +225,7 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 					echo '<a href="../../checklists/checklist.php?clid=' . htmlspecialchars($clid, HTML_SPECIAL_CHARS_FLAGS) . '">';
 					echo $stateArr['locality'].': '.$stateArr['name'];
 					echo '</a>';
-					if(strpos($stateArr['access'], 'private') !== false) echo ' (private)';
+					if(strpos($stateArr['access'] ?? '', 'private') !== false) echo ' (private)';
 					echo '</div>';
 					$emptyList = false;
 				}


### PR DESCRIPTION
…argins and breaks where needed to adjust the aesthetics

# Description

This PR improves the aesthetics of collections/misc/protectedspecies.php as a result of an issue identified by @themerekat while she was QAing [https://github.com/BioKIC/Symbiota/pull/881](https://github.com/BioKIC/Symbiota/pull/881) that was not germane to that branch, but rather to the Development branch.

Specifically, this PR:

- Adds a break and a span within the h3 element in order to be consistent with the .fieldset-like class defined in base.css.
- Adds some line breaks in collections/misc/protectedspecies.php in order to improve developer readability of the code in the future.
- Adds null coalescing operator for potentially null value being pass as an argument to the strpos method.

## Before

<img width="1552" alt="Screen Shot 2024-01-30 at 3 23 44 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/42f89600-c807-4939-a964-3e490d555eb5">

## After

<img width="1552" alt="Screen Shot 2024-01-30 at 3 23 26 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/57f0e2db-5313-4e44-b963-b15d4dadacc9">


# Pull Request Checklist:

# Pre-Approval

- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
