### PR TITLE
Protected but cultivated fix 2

### DIFF
--- a/classes/ChecklistManager.php
+++ b/classes/ChecklistManager.php
@@ -1,5 +1,6 @@
 <?php
 include_once($SERVER_ROOT.'/classes/Manager.php');
+include_once($SERVER_ROOT.'/classes/ImInventories.php');
 include_once($SERVER_ROOT.'/classes/ChecklistVoucherAdmin.php');
 
 class ChecklistManager extends Manager{
@@ -660,39 +661,16 @@ class ChecklistManager extends Manager{
 	public function addNewSpecies($postArr){
 		if(!$this->clid) return 'ERROR adding species: checklist identifier not set';
 		$insertStatus = false;
-		$dataArr = array('tid','familyoverride','morphospecies','habitat','abundance','notes','source','internalnotes');
-		$colSql = '';
-		$valueSql = '';
-		foreach($dataArr as $v){
-			if(isset($postArr[$v]) && $postArr[$v]){
-				$colSql .= ','.$v;
-				if(is_numeric($postArr[$v])) $valueSql .= ','.$postArr[$v];
-				else $valueSql .= ',"'.$this->cleanInStr($postArr[$v]).'"';
-			}
-		}
-		$conn = MySQLiConnectionFactory::getCon('write');
-		$sql = 'INSERT INTO fmchklsttaxalink (clid'.$colSql.') VALUES ('.$this->clid.$valueSql.')';
-		if($conn->query($sql)){
-			if($this->clMetadata['type'] == 'rarespp' && $this->clMetadata['locality'] && is_numeric($postArr['tid'])){
-				$sqlRare = 'UPDATE omoccurrences o INNER JOIN taxstatus ts1 ON o.tidinterpreted = ts1.tid '.
-					'INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted '.
-					'SET o.localitysecurity = 1 '.
-					'WHERE (o.localitysecurity IS NULL OR o.localitysecurity = 0) AND (o.localitySecurityReason IS NULL) '.
-					'AND (ts1.taxauthid = 1) AND (ts2.taxauthid = 1) AND (o.stateprovince = "'.$this->clMetadata['locality'].'") AND (ts2.tid = '.$postArr['tid'].')';
-				$conn->query($sqlRare);
-			}
-		}
-		else{
-			$mysqlErr = $conn->error;
+		$inventoryManager = new ImInventories();
+		if(!$inventoryManager->insertChecklistTaxaLink($postArr)){
 			$insertStatus = 'ERROR adding species: ';
-			if(strpos($mysqlErr,'Duplicate') !== false){
+			if(strpos($inventoryManager->getErrorMessage(), 'Duplicate') !== false){
 				$insertStatus .= 'Species already exists within checklist';
 			}
 			else{
-				$insertStatus .= $conn->error;
+				$insertStatus .= $inventoryManager->getErrorMessage();
 			}
 		}
-		$conn->close();
 		return $insertStatus;
 	}
 

--- a/classes/ChecklistManager.php
+++ b/classes/ChecklistManager.php
@@ -664,11 +664,16 @@ class ChecklistManager extends Manager{
 		$inventoryManager = new ImInventories();
 		if(!$inventoryManager->insertChecklistTaxaLink($postArr)){
 			$insertStatus = 'ERROR adding species: ';
-			if(strpos($inventoryManager->getErrorMessage(), 'Duplicate') !== false){
-				$insertStatus .= 'Species already exists within checklist';
+			if($inventoryManager->getErrorMessage()){
+				if(strpos($inventoryManager->getErrorMessage(), 'Duplicate') !== false){
+					$insertStatus .= 'Species already exists within checklist';
+				}
+				else{
+					$insertStatus .= $inventoryManager->getErrorMessage();
+				}
 			}
 			else{
-				$insertStatus .= $inventoryManager->getErrorMessage();
+				$insertStatus .= 'unknown error';
 			}
 		}
 		return $insertStatus;

--- a/classes/ChecklistVoucherManager.php
+++ b/classes/ChecklistVoucherManager.php
@@ -1,7 +1,7 @@
 <?php
 include_once($SERVER_ROOT.'/classes/ChecklistVoucherAdmin.php');
 
-class ChecklistVoucherManager extends  ChecklistVoucherAdmin{
+class ChecklistVoucherManager extends ChecklistVoucherAdmin{
 
 	private $tid;
 	private $taxonName;
@@ -162,15 +162,18 @@ class ChecklistVoucherManager extends  ChecklistVoucherAdmin{
 		$rs = $this->conn->query($sql);
 		if($r = $rs->fetch_object()){
 			if($r->securitystatus == 0){
-				//Set occurrence
-				$sqlRare = 'UPDATE omoccurrences o INNER JOIN taxstatus ts1 ON o.tidinterpreted = ts1.tid '.
-					'INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted '.
-					'SET o.localitysecurity = NULL '.
-					'WHERE (o.localitysecurity = 1) AND (o.localitySecurityReason IS NULL) AND (ts1.taxauthid = 1) AND (ts2.taxauthid = 1) '.
-					'AND o.stateprovince = "'.$rareLocality.'" AND ts2.tid = '.$this->tid;
-				//echo $sqlRare; exit;
-				if(!$this->conn->query($sqlRare)){
-					$this->errorMessage = "ERROR resetting locality security during taxon delete: ".$this->conn->error;
+				$sqlRare = 'UPDATE omoccurrences o INNER JOIN taxstatus ts1 ON o.tidinterpreted = ts1.tid
+					INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted
+					SET o.localitysecurity = 0
+					WHERE (o.localitysecurity = 1) AND (o.localitySecurityReason IS NULL) AND (ts1.taxauthid = 1) AND (ts2.taxauthid = 1)
+					AND o.stateprovince = ? AND ts2.tid = ?';
+				if($stmt = $this->conn->prepare($sqlRare)){
+					$stmt->bind_param('si', $rareLocality, $this->tid);
+					$stmt->execute();
+					if($stmt->error){
+						$this->errorMessage = 'ERROR resetting locality security during taxon delete: '.$stmt->error;
+					}
+					$stmt->close();
 				}
 			}
 		}

--- a/classes/ObservationSubmitManager.php
+++ b/classes/ObservationSubmitManager.php
@@ -29,22 +29,25 @@ class ObservationSubmitManager {
 				$eventDay = date('d',$dateObj);
 				$startDay = date('z',$dateObj)+1;
 			}
-			//Get tid for scinetific name
+			//Get tid for scientific name
 			$tid = 0;
-			$localitySecurity = (array_key_exists('localitysecurity',$postArr)?1:0);
+			$localitySecurity = (array_key_exists('localitysecurity', $postArr) ? 1 : 0);
 			if($postArr['sciname']){
 				$result = $this->conn->query('SELECT tid, securitystatus FROM taxa WHERE (sciname = "'.$postArr['sciname'].'")');
 				if($row = $result->fetch_object()){
 					$tid = $row->tid;
-					if($row->securitystatus > 0) $localitySecurity = $row->securitystatus;
-					if(!$localitySecurity){
-						//Check to see if species is rare or sensitive within a state
-						$sql = 'SELECT cl.tid '.
-							'FROM fmchecklists c INNER JOIN fmchklsttaxalink cl ON c.clid = cl.clid '.
-							'WHERE c.type = "rarespp" AND c.locality = "'.$postArr['stateprovince'].'" AND cl.tid = '.$tid;
-						$rs = $this->conn->query($sql);
-						if($rs->num_rows){
-							$localitySecurity = 1;
+					if(empty($postArr['cultivationstatus'])){
+						//Set localitySecurity based on global or state protection setting, but only if not cultivated
+						if($row->securitystatus > 0) $localitySecurity = $row->securitystatus;
+						if(!$localitySecurity){
+							//Check to see if species is rare or sensitive within a state
+							$sql = 'SELECT cl.tid
+								FROM fmchecklists c INNER JOIN fmchklsttaxalink cl ON c.clid = cl.clid
+								WHERE c.type = "rarespp" AND c.locality = "'.$postArr['stateprovince'].'" AND cl.tid = '.$tid;
+							$rs = $this->conn->query($sql);
+							if($rs->num_rows){
+								$localitySecurity = 1;
+							}
 						}
 					}
 				}

--- a/classes/OccurrenceMaintenance.php
+++ b/classes/OccurrenceMaintenance.php
@@ -312,9 +312,10 @@ class OccurrenceMaintenance {
 		$sensitiveArr = $this->getSensitiveTaxa();
 
 		if($sensitiveArr){
-			$sql = 'UPDATE omoccurrences '.
-				'SET LocalitySecurity = 1 '.
-				'WHERE (LocalitySecurity IS NULL OR LocalitySecurity = 0) AND (localitySecurityReason IS NULL) AND (tidinterpreted IN('.implode(',',$sensitiveArr).')) ';
+			$sql = 'UPDATE omoccurrences
+				SET localitySecurity = 1
+				WHERE (localitySecurity IS NULL OR localitySecurity = 0) AND (localitySecurityReason IS NULL)
+				AND (cultivationStatus = 0 OR cultivationStatus IS NULL) AND (tidinterpreted IN('.implode(',',$sensitiveArr).')) ';
 			if($this->collidStr) $sql .= 'AND collid IN('.$this->collidStr.')';
 			if($this->conn->query($sql)){
 				$status += $this->conn->affected_rows;
@@ -363,13 +364,13 @@ class OccurrenceMaintenance {
 		return $status;
 	}
 
-	public function protectStateRareSpecies($clid,$locality){
+	public function protectStateRareSpecies($clid, $locality){
 		$status = 0;
 		$occArr = array();
 		$sql = 'SELECT o.occid FROM omoccurrences o INNER JOIN taxstatus ts1 ON o.tidinterpreted = ts1.tid '.
 			'INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted '.
 			'INNER JOIN fmchklsttaxalink cl ON  ts2.tid = cl.tid '.
-			'WHERE (o.localitysecurity IS NULL OR o.localitysecurity = 0) AND (o.localitySecurityReason IS NULL) '.
+			'WHERE (o.localitysecurity IS NULL OR o.localitysecurity = 0) AND (o.localitySecurityReason IS NULL) AND (o.cultivationStatus = 0 OR o.cultivationStatus IS NULL) '.
 			'AND (o.stateprovince = "'.$locality.'") AND (cl.clid = '.$clid.') AND (ts1.taxauthid = 1) AND (ts2.taxauthid = 1) ';
 		$rs = $this->conn->query($sql);
 		while($r = $rs->fetch_object()){
@@ -399,7 +400,7 @@ class OccurrenceMaintenance {
 				'FROM omoccurrences o INNER JOIN taxstatus ts1 ON o.tidinterpreted = ts1.tid '.
 				'INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted '.
 				'INNER JOIN fmchklsttaxalink cl ON  ts2.tid = cl.tid '.
-				'WHERE (o.localitysecurity IS NULL OR o.localitysecurity = 0) AND (o.localitySecurityReason IS NULL) '.
+				'WHERE (o.localitysecurity IS NULL OR o.localitysecurity = 0) AND (o.localitySecurityReason IS NULL) AND (o.cultivationStatus = 0 OR o.cultivationStatus IS NULL) '.
 				'AND (o.stateprovince = "'.$state.'") AND (cl.clid = '.$clid.') AND (ts1.taxauthid = 1) AND (ts2.taxauthid = 1) ';
 			$rs = $this->conn->query($sql);
 			if($r = $rs->fetch_object()){

--- a/classes/OccurrenceMaintenance.php
+++ b/classes/OccurrenceMaintenance.php
@@ -315,7 +315,7 @@ class OccurrenceMaintenance {
 			$sql = 'UPDATE omoccurrences
 				SET localitySecurity = 1
 				WHERE (localitySecurity IS NULL OR localitySecurity = 0) AND (localitySecurityReason IS NULL)
-				AND (cultivationStatus = 0 OR cultivationStatus IS NULL) AND (tidinterpreted IN('.implode(',',$sensitiveArr).')) ';
+				AND (cultivationStatus = 0 OR cultivationStatus IS NULL) AND (tidinterpreted IN(' . implode(',', $sensitiveArr) . ')) ';
 			if($this->collidStr) $sql .= 'AND collid IN('.$this->collidStr.')';
 			if($this->conn->query($sql)){
 				$status += $this->conn->affected_rows;

--- a/classes/RpcOccurrenceEditor.php
+++ b/classes/RpcOccurrenceEditor.php
@@ -234,6 +234,27 @@ class RpcOccurrenceEditor extends RpcBase{
 		return $retArr;
 	}
 
+	//Used by /collections/editor/rpc/localitysecuritycheck.php
+	public function getStateSecuritySetting($tid, $state){
+		$retStr = 0;
+		if(is_numeric($tid) && $state){
+			$sql = 'SELECT c.clid
+				FROM fmchecklists c INNER JOIN fmchklsttaxalink cl ON c.clid = cl.clid
+				INNER JOIN taxstatus ts1 ON cl.tid = ts1.tid
+				INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted
+				WHERE c.type = "rarespp" AND ts1.taxauthid = 1 AND ts2.taxauthid = 1
+				AND (ts2.tid = ?) AND (c.locality = ?)';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('is', $tid, $state);
+				$stmt->execute();
+				$stmt->store_result();
+				if($stmt->num_rows) $retStr = 1;
+				$stmt->close();
+			}
+		}
+		return $retStr;
+	}
+
 	//Used by Geographic Thesaurus calls
 	public function getGeography($term, $target, $parentTerm){
 		$retArr = Array();

--- a/classes/TaxonomyEditorManager.php
+++ b/classes/TaxonomyEditorManager.php
@@ -612,9 +612,9 @@ class TaxonomyEditorManager extends Manager{
 				$stmt->bind_param('s', $dataArr["sciname"]);
 				$stmt->execute();
 				if($stmt->error){
-					if(isset($this->langArr['WARNING_OCCURRENCES_NOT UPDATED'])) echo $this->langArr['WARNING_OCCURRENCES_NOT'];
+					if(isset($this->langArr['WARNING_OCCURRENCES_NOT'])) echo $this->langArr['WARNING_OCCURRENCES_NOT'];
 					else echo 'WARNING: Taxon loaded into taxa, but occurrences must be updated with matching name';
-					echo ': '.$this->conn->error;
+					echo ': ' . $this->conn->error;
 				}
 				$stmt->close();
 			}

--- a/classes/TaxonomyEditorManager.php
+++ b/classes/TaxonomyEditorManager.php
@@ -238,8 +238,15 @@ class TaxonomyEditorManager extends Manager{
 		//If SecurityStatus was changed, set security status within omoccurrence table
 		if($postArr['securitystatus'] != $_REQUEST['securitystatusstart']){
 			if(is_numeric($postArr['securitystatus'])){
-				$sql2 = 'UPDATE omoccurrences SET localitysecurity = '.$postArr['securitystatus'].' WHERE (tidinterpreted = '.$this->tid.') AND (localitySecurityReason IS NULL)';
-				$this->conn->query($sql2);
+				$sql2 = 'UPDATE omoccurrences SET localitysecurity = 0 WHERE (tidinterpreted = ?) AND (localitySecurityReason IS NULL)';
+				if($postArr['securitystatus']){
+					$sql2 = 'UPDATE omoccurrences SET localitysecurity = 1 WHERE (tidinterpreted = ?) AND (localitySecurityReason IS NULL) AND (cultivationStatus = 0 OR cultivationStatus IS NULL)';
+				}
+				if($stmt = $this->conn->prepare($sql2)){
+					$stmt->bind_param('i', $this->tid);
+					$stmt->execute();
+					$stmt->close();
+				}
 			}
 		}
 		return $statusStr;
@@ -599,12 +606,28 @@ class TaxonomyEditorManager extends Manager{
 				return (isset($this->langArr['ERROR_MISSING_PARENTID'])?$this->langArr['ERROR_MISSING_PARENTID']:'ERROR loading taxon due to missing parentTid');
 			}
 
-			//Link new name to existing specimens and set locality secirity if needed
-			$sql1 = 'UPDATE omoccurrences o INNER JOIN taxa t ON o.sciname = t.sciname SET o.TidInterpreted = t.tid ';
-			if($dataArr['securitystatus'] == 1) $sql1 .= ',o.localitysecurity = 1 ';
-			$sql1 .= 'WHERE (o.sciname = "'.$this->cleanInStr($dataArr["sciname"]).'") ';
-			if(!$this->conn->query($sql1)){
-				echo (isset($this->langArr['WARNING_OCCURRENCES_NOT UPDATED'])?$this->langArr['WARNING_OCCURRENCES_NOT']:'WARNING: Taxon loaded into taxa, but  occurrences must be updated with matching name').': '.$this->conn->error;
+			//Link new name to existing specimens
+			$sqlUpdate1 = 'UPDATE omoccurrences o INNER JOIN taxa t ON o.sciname = t.sciname SET o.TidInterpreted = t.tid WHERE (o.sciname = ?)';
+			if($stmt = $this->conn->prepare($sqlUpdate1)){
+				$stmt->bind_param('s', $dataArr["sciname"]);
+				$stmt->execute();
+				if($stmt->error){
+					if(isset($this->langArr['WARNING_OCCURRENCES_NOT UPDATED'])) echo $this->langArr['WARNING_OCCURRENCES_NOT'];
+					else echo 'WARNING: Taxon loaded into taxa, but occurrences must be updated with matching name';
+					echo ': '.$this->conn->error;
+				}
+				$stmt->close();
+			}
+			if($dataArr['securitystatus'] == 1){
+				//Set locality security
+				$sqlUpdate2 = 'UPDATE omoccurrences o INNER JOIN taxa t ON o.sciname = t.sciname
+					SET o.localitysecurity = 1
+					WHERE (o.localitySecurityReason IS NULL) AND (cultivationStatus = 0 OR cultivationStatus IS NULL) AND (o.sciname = ?) ';
+				if($stmt = $this->conn->prepare($sqlUpdate2)){
+					$stmt->bind_param('s', $dataArr["sciname"]);
+					$stmt->execute();
+					$stmt->close();
+				}
 			}
 
 			//Link occurrence images to the new name

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -505,7 +505,7 @@ else{
 	<script src="../../js/symb/collections.coordinateValidation.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/wktpolygontools.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/collections.georef.js?ver=2" type="text/javascript"></script>
-	<script src="../../js/symb/collections.editor.main.js?ver=8b" type="text/javascript"></script>
+	<script src="../../js/symb/collections.editor.main.js?ver=8" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.tools.js?ver=4" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.imgtools.js?ver=3" type="text/javascript"></script>
 	<script src="../../js/jquery.imagetool-1.7.js?ver=140310" type="text/javascript"></script>

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -505,7 +505,7 @@ else{
 	<script src="../../js/symb/collections.coordinateValidation.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/wktpolygontools.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/collections.georef.js?ver=2" type="text/javascript"></script>
-	<script src="../../js/symb/collections.editor.main.js?ver=7b" type="text/javascript"></script>
+	<script src="../../js/symb/collections.editor.main.js?ver=8b" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.tools.js?ver=4" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.imgtools.js?ver=3" type="text/javascript"></script>
 	<script src="../../js/jquery.imagetool-1.7.js?ver=140310" type="text/javascript"></script>

--- a/collections/editor/rpc/localitysecuritycheck.php
+++ b/collections/editor/rpc/localitysecuritycheck.php
@@ -4,12 +4,13 @@ include_once($SERVER_ROOT . '/classes/RpcOccurrenceEditor.php');
 header('Content-Type: application/json; charset=' . $CHARSET);
 
 $retStr = 0;
-$tid = filter_var($_POST['tid'], FILTER_SANITIZE_NUMBER_INT);
-$state = $_POST['state'];
+$tid = filter_var($_POST['tid'] ?? '', FILTER_SANITIZE_NUMBER_INT);
+$state = $_POST['state'] ?? '';
 
-$dataManager = new RpcOccurrenceEditor();
-$retStr = $dataManager->getStateSecuritySetting($tid, $state);
+if($tid && $state){
+	$dataManager = new RpcOccurrenceEditor();
+	$retStr = $dataManager->getStateSecuritySetting($tid, $state);
+}
 
-if($retStr) echo json_encode($retStr);
-else echo 0;
+echo $retStr;
 ?>

--- a/collections/editor/rpc/localitysecuritycheck.php
+++ b/collections/editor/rpc/localitysecuritycheck.php
@@ -1,34 +1,15 @@
 <?php
-include_once('../../../config/symbini.php'); 
-include_once($SERVER_ROOT.'/config/dbconnection.php');
-header("Content-Type: application/json; charset=".$CHARSET);
-
-$con = MySQLiConnectionFactory::getCon("readonly");
+include_once('../../../config/symbini.php');
+include_once($SERVER_ROOT . '/classes/RpcOccurrenceEditor.php');
+header('Content-Type: application/json; charset=' . $CHARSET);
 
 $retStr = 0;
-$tid = trim($con->real_escape_string($_REQUEST['tid']));
-$state = trim($con->real_escape_string($_REQUEST['state']));
+$tid = filter_var($_POST['tid'], FILTER_SANITIZE_NUMBER_INT);
+$state = $_POST['state'];
 
-if(is_numeric($tid) && $state){
-	$sql = 'SELECT c.clid '.
-		'FROM fmchecklists c INNER JOIN fmchklsttaxalink cl ON c.clid = cl.clid '.
-		'INNER JOIN taxstatus ts1 ON cl.tid = ts1.tid '.
-		'INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted '.
-		'WHERE c.type = "rarespp" AND ts1.taxauthid = 1 AND ts2.taxauthid = 1 '.
-		'AND (ts2.tid = '.$tid.') AND (c.locality = "'.$state.'")';
-	//echo $sql;
-	$rs = $con->query($sql);
-	if($rs->num_rows){
-		$retStr = 1;
-	}
-	$rs->free();
-}
-$con->close();
+$dataManager = new RpcOccurrenceEditor();
+$retStr = $dataManager->getStateSecuritySetting($tid, $state);
 
-if($retStr){
-	echo json_encode($retStr);
-}
-else{
-	echo 0;
-}
+if($retStr) echo json_encode($retStr);
+else echo 0;
 ?>

--- a/collections/misc/protectedspecies.php
+++ b/collections/misc/protectedspecies.php
@@ -122,7 +122,7 @@ include($SERVER_ROOT.'/includes/header.php');
 	<div style="float:right;">
 		<form name="searchform" action="protectedspecies.php" method="post">
 			<fieldset style="margin:0px 15px;padding:10px">
-				<legend><b><?= $LANG['FILTER'] ?></b></legend>
+				<legend><?= $LANG['FILTER'] ?></legend>
 				<div style="margin:3px">
 					<label for="searchtaxon"><?= $LANG['TAXON_SEARCH'] ?>:</label>
 					<input id="searchtaxon" name="searchtaxon" type="text" value="<?= htmlspecialchars($searchTaxon, HTML_SPECIAL_CHARS_FLAGS) ?>" />
@@ -178,11 +178,11 @@ include($SERVER_ROOT.'/includes/header.php');
 			if($rsArr){
 				foreach($rsArr as $family => $speciesArr){
 					?>
-					<h3>
+					<h2>
 						<span>
 							<?= $family ?>
 						</span>
-					</h3>
+					</h2>
 					<div style='margin-left:20px; margin-bottom:20px;'>
 						<?php
 						foreach($speciesArr as $tid => $nameArr){

--- a/collections/misc/protectedspecies.php
+++ b/collections/misc/protectedspecies.php
@@ -1,16 +1,19 @@
 <?php
-use PhpOffice\PhpSpreadsheet\Reader\Xml\Style\NumberFormat;
-
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceProtectedSpecies.php');
-include_once($SERVER_ROOT.'/content/lang/collections/misc/protectedspecies.' . $LANG_TAG . '.php');
+if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/collections/misc/protectedspecies.' . $LANG_TAG . '.php')){
+	include_once($SERVER_ROOT.'/content/lang/collections/misc/protectedspecies.' . $LANG_TAG . '.php');
+}
+else{
+	include_once($SERVER_ROOT.'/content/lang/collections/misc/protectedspecies.en.php');
+}
 header('Content-Type: text/html; charset=' . $CHARSET);
 
 $searchTaxon = array_key_exists('searchtaxon', $_REQUEST) ? $_REQUEST['searchtaxon'] : '';
 $action = array_key_exists('submitaction', $_REQUEST) ? $_REQUEST['submitaction'] : '';
 
 $isEditor = 0;
-if($IS_ADMIN || array_key_exists('RareSppAdmin',$USER_RIGHTS)){
+if($IS_ADMIN || array_key_exists('RareSppAdmin', $USER_RIGHTS)){
 	$isEditor = 1;
 }
 
@@ -30,14 +33,14 @@ $rsArr = $rsManager->getProtectedSpeciesList();
 <!DOCTYPE html>
 <html lang="<?php echo $LANG_TAG ?>">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET; ?>">
-	<title>Rare, Threatened, Sensitive Species</title>
-	<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
+	<meta http-equiv="Content-Type" content="text/html; charset=<?= $CHARSET; ?>">
+	<title><?= $LANG['TITLE'] ?></title>
+	<link href="<?= $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
 	include_once($SERVER_ROOT.'/includes/head.php');
 	?>
-	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
-	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
+	<script src="<?= $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
+	<script src="<?= $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
 	<script>
 		$(document).ready(function() {
 			$("#speciestoadd").autocomplete({ source: "rpc/speciessuggest.php" },{ minLength: 3, autoFocus: true });
@@ -75,7 +78,7 @@ $rsArr = $rsManager->getProtectedSpeciesList();
 		function submitAddSpecies(f){
 			var sciName = f.speciestoadd.value;
 			if(sciName == ""){
-				alert("Enter the scientific name of species you wish to add");
+				alert("<?= $LANG['ENTER_SCINAME'] ?>");
 				return false;
 			}
 
@@ -88,62 +91,60 @@ $rsArr = $rsManager->getProtectedSpeciesList();
 				f.tidtoadd.value = data;
 				f.submit();
 			}).fail(function(jqXHR){
-				alert("ERROR: Scientific name does not exist in database. Did you spell it correctly? If so, it may have to be added to taxa table.");
+				alert("<?= $LANG['SCINAME_NOT_EXIST'] ?>");
 			});
 		}
 	</script>
+	<style>
+		.icon-img{ width:1.5em; border:0px; }
+		.message-div{ margin: 10px; font-weight: bold; }
+	</style>
 </head>
 <body>
 <?php
-$displayLeftMenu = (isset($collections_misc_rarespeciesMenu)?$collections_misc_rarespeciesMenu:true);
 include($SERVER_ROOT.'/includes/header.php');
-if(isset($collections_misc_rarespeciesCrumbs)){
-	echo "<div class='navpath'>";
-	echo "<a href='../index.php'>Home</a> &gt;&gt; ";
-	echo $collections_misc_rarespeciesCrumbs." &gt;&gt;";
-	echo " <b>Sensitive Species for Masking Locality Details</b>";
-	echo "</div>";
-}
 ?>
-<!-- This is inner text! -->
+<div class='navpath'>
+	<a href='../index.php'><?= $LANG['HOME'] ?></a> &gt;&gt;
+	<b><?= $LANG['SENSITIVE_TAXA'] ?></b>
+</div>
 <div id="innertext">
 	<?php
 	if($isEditor){
 		?>
-		<div style="float:right;cursor:pointer;" onclick="toggle('editobj');" title="Toggle Editing Functions">
-			<?php echo $LANG['EDIT'] ?> <img style="width:1.5em;border:0px;" src="../../images/edit.png" alt="pencil icon depicting edit capability" />
+		<div style="float:right;" title="<?= $LANG['TOGGLE_EDIT'] ?>">
+			<a href="#" onclick="toggle('editobj');" ><?= $LANG['EDIT'] ?> <img class="icon-img" src="../../images/edit.png" alt="<?= $LANG['PENCIL_ICON'] ?>"></a>
 		</div>
 		<?php
 	}
 	?>
-	<h1>Protected Species</h1>
+	<h1><?= $LANG['PROTECTED_SPECIES'] ?></h1>
 	<div style="float:right;">
 		<form name="searchform" action="protectedspecies.php" method="post">
 			<fieldset style="margin:0px 15px;padding:10px">
-				<legend><b>Filter</b></legend>
+				<legend><b><?= $LANG['FILTER'] ?></b></legend>
 				<div style="margin:3px">
-					<label for="searchtaxon"><?php echo $LANG['TAXON_SEARCH'] ?>:</label>
+					<label for="searchtaxon"><?= $LANG['TAXON_SEARCH'] ?>:</label>
 					<input id="searchtaxon" name="searchtaxon" type="text" value="<?= htmlspecialchars($searchTaxon, HTML_SPECIAL_CHARS_FLAGS) ?>" />
 				</div>
 				<div style="margin:3px">
-					<button name="submitaction" type="submit" value="<?php echo $LANG['SEARCH']; ?>" >
-						<?php echo $LANG['SEARCH']; ?>
+					<button name="submitaction" type="submit" value="<?= $LANG['SEARCH']; ?>" >
+						<?= $LANG['SEARCH']; ?>
 					</button>
 				</div>
 			</fieldset>
 		</form>
 	</div>
 	<div class="bottom-breathing-room">
-		Species in the list below have protective status with specific locality details below county withheld (e.g. decimal lat/long).
-		Rare, threatened, or sensitive status are the typical causes for protection though species that are cherished by collectors or wild harvesters may also appear on the list.
+		<?= $LANG['DESCRIPTION'] ?>
 	</div>
 	<div>
 		<?php
 		$occurCnt = $rsManager->getSpecimenCnt();
-		if($occurCnt) echo '<div class="bottom-breathing-room">Occurrences protected: '.number_format($occurCnt).'</div>';
+		if($occurCnt) echo '<div class="bottom-breathing-room">' . $LANG['OCCURRENCES_PROTECTED'] . ': '.number_format($occurCnt).'</div>';
 		if($isEditor){
 			if($action == 'checkstats'){
-				echo '<div>Number of specimens affected: '.$rsManager->protectGlobalSpecies().'</div>';
+				echo '<div>' . $LANG['NUMBER_AFFECTED'] . ': '.$rsManager->protectGlobalSpecies().'</div>';
 			}
 			else{
 				echo "<div><a href=\"protectedspecies.php?submitaction=checkstats\">" . $LANG['VERIFY_PROTECTIONS'] . "</a></div>";
@@ -153,7 +154,7 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 	</div>
 	<div style="clear:both">
 		<section class="fieldset-like">
-			<h1><span>Global Protections</span></h1>
+			<h1><span><?= $LANG['GLOBAL_PROTECTIONS'] ?></span></h1>
 			<br/>
 			<?php
 			if($isEditor){
@@ -161,15 +162,15 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 				<div class="editobj" style="display:none;width:400px;margin-bottom:20px">
 					<form name="addspeciesform" action='protectedspecies.php' method='post' >
 						<fieldset style='margin:5px'>
-							<legend><b>Add Taxon to List</b></legend>
+							<legend><b><?= $LANG['ADD_TAXON'] ?></b></legend>
 							<div style="margin:3px;">
-								Scientific Name:
+								<?= $LANG['SCIENTIFIC_NAME'] ?>:
 								<input type="text" id="speciestoadd" name="speciestoadd" style="width:300px" />
 								<input type="hidden" id="tidtoadd" name="tidtoadd" value="" />
 							</div>
 							<div style="margin:3px;">
 								<input type="hidden" name="submitaction" value="addspecies" />
-								<button value="Add Species" onclick="submitAddSpecies(this.form)" >Add Species</button>
+								<button value="Add Species" onclick="submitAddSpecies(this.form)" ><?= $LANG['ADD_SPECIES'] ?></button>
 							</div>
 						</fieldset>
 					</form>
@@ -181,26 +182,26 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 					?>
 					<h3>
 						<span>
-							<?php echo $family; ?>
+							<?= $family ?>
 						</span>
 					</h3>
 					<div style='margin-left:20px; margin-bottom:20px;'>
 						<?php
 						foreach($speciesArr as $tid => $nameArr){
 							echo '<div id="tid-'.$tid.'">';
-							echo '<a href="../../taxa/index.php?taxon=' . htmlspecialchars($tid, HTML_SPECIAL_CHARS_FLAGS) . '" target="_blank">';
+							echo '<a href="../../taxa/index.php?taxon=' . $tid . '" target="_blank">';
 							echo '<i>' . htmlspecialchars($nameArr['sciname'], HTML_SPECIAL_CHARS_FLAGS) . '</i> ';
 							echo htmlspecialchars($nameArr['author'], HTML_SPECIAL_CHARS_FLAGS) . '</a> ';
 							if($isEditor){
 								?>
 								<span class="editobj" style="display:none;">
-									<a href="protectedspecies.php?submitaction=deletespecies&tidtodel=<?php echo htmlspecialchars($tid, HTML_SPECIAL_CHARS_FLAGS);?>">
-										<img src="../../images/del.png" style="width:13px;border:0px;" title="remove species from list" />
+									<a href="protectedspecies.php?submitaction=deletespecies&tidtodel=<?= $tid ?>">
+										<img class="icon-img" src="../../images/del.png" title="<?= $LANG['REMOVE_SPECIES'] ?>" />
 									</a>
 								</span>
 								<?php
 							}
-							echo "</div>";
+							echo '</div>';
 						}
 						?>
 					</div>
@@ -209,34 +210,30 @@ if(isset($collections_misc_rarespeciesCrumbs)){
 			}
 			else{
 				?>
-				<div style="margin:20px;font-weight:bold;font-size:120%;">
-					No species were returned marked for global protection.
-				</div>
+				<div class="message-div"><?= $LANG['NO_TAXA'] ?></div>
 				<?php
 			}
 			?>
 		</section>
 		<section class="fieldset-like">
-			<h1><span>State/Province Level Protections</span></h1>
+			<h1><span><?= $LANG['STATE_PROTECTIONS'] ?></span></h1>
 			<?php
 			$stateList = $rsManager->getStateList();
 			$emptyList = true;
 			foreach($stateList as $clid => $stateArr){
 				if($isEditor || $stateArr['access'] == 'public'){
 					echo '<div>';
-					echo '<a href="../../checklists/checklist.php?clid=' . htmlspecialchars($clid, HTML_SPECIAL_CHARS_FLAGS) . '">';
+					echo '<a href="../../checklists/checklist.php?clid=' . $clid . '">';
 					echo $stateArr['locality'].': '.$stateArr['name'];
 					echo '</a>';
-					if(strpos($stateArr['access'] ?? '', 'private') !== false) echo ' (private)';
+					if(strpos($stateArr['access'] ?? '', 'private') !== false) echo ' (' . $LANG['PRIVATE'] . ')';
 					echo '</div>';
 					$emptyList = false;
 				}
 			}
 			if($emptyList){
 				?>
-				<div style="margin:20px;font-weight:bold;font-size:120%;">
-					 No checklists returned
-				</div>
+				<div class="message-div"><?= $LANG['NO_CHECKLIST'] ?></div>
 				<?php
 			}
 			?>

--- a/collections/misc/protectedspecies.php
+++ b/collections/misc/protectedspecies.php
@@ -128,9 +128,7 @@ include($SERVER_ROOT.'/includes/header.php');
 					<input id="searchtaxon" name="searchtaxon" type="text" value="<?= htmlspecialchars($searchTaxon, HTML_SPECIAL_CHARS_FLAGS) ?>" />
 				</div>
 				<div style="margin:3px">
-					<button name="submitaction" type="submit" value="<?= $LANG['SEARCH']; ?>" >
-						<?= $LANG['SEARCH']; ?>
-					</button>
+					<button name="submitaction" type="submit" value="searchTaxonSubmit" ><?= $LANG['SEARCH']; ?></button>
 				</div>
 			</fieldset>
 		</form>
@@ -164,13 +162,13 @@ include($SERVER_ROOT.'/includes/header.php');
 						<fieldset style='margin:5px'>
 							<legend><b><?= $LANG['ADD_TAXON'] ?></b></legend>
 							<div style="margin:3px;">
-								<?= $LANG['SCIENTIFIC_NAME'] ?>:
+								<label for="speciestoadd"><?= $LANG['SCIENTIFIC_NAME'] ?>:</label>
 								<input type="text" id="speciestoadd" name="speciestoadd" style="width:300px" />
 								<input type="hidden" id="tidtoadd" name="tidtoadd" value="" />
 							</div>
 							<div style="margin:3px;">
 								<input type="hidden" name="submitaction" value="addspecies" />
-								<button value="Add Species" onclick="submitAddSpecies(this.form)" ><?= $LANG['ADD_SPECIES'] ?></button>
+								<button name="addSpeciesbutton" type="button" onclick="submitAddSpecies(this.form)" ><?= $LANG['ADD_SPECIES'] ?></button>
 							</div>
 						</fieldset>
 					</form>

--- a/content/lang/collections/misc/protectedspecies.en.php
+++ b/content/lang/collections/misc/protectedspecies.en.php
@@ -1,6 +1,28 @@
 <?php
+$LANG['TITLE'] = 'Rare, Threatened, Sensitive Species';
+$LANG['ENTER_SCINAME'] = 'Enter the scientific name of species you wish to add';
+$LANG['SCINAME_NOT_EXIST'] = 'ERROR: Scientific name does not exist in database. Did you spell it correctly? If so, it may have to be added to taxa table';
+$LANG['HOME'] = 'Home';
+$LANG['SENSITIVE_TAXA'] = 'Sensitive Species for Masking Locality Details';
+$LANG['TOGGLE_EDIT'] = 'Toggle Editing Functions';
 $LANG['EDIT'] = 'Edit';
+$LANG['PENCIL_ICON'] = 'pencil icon depicting edit capability';
+$LANG['PROTECTED_SPECIES'] = 'Protected Species';
+$LANG['FILTER'] = 'Filter';
 $LANG['TAXON_SEARCH'] = 'Taxon Search';
-$LANG['VERIFY_PROTECTIONS'] = 'Verify Protections';
 $LANG['SEARCH']= 'Search';
+$LANG['DESCRIPTION'] = 'Species in the list below have protective status with specific locality details below county withheld (e.g. decimal lat/long).
+	Rare, threatened, or sensitive status are the typical causes for protection though species that are cherished by collectors or wild harvesters may also appear on the list.';
+$LANG['OCCURRENCES_PROTECTED'] = 'Occurrences protected';
+$LANG['NUMBER_AFFECTED'] = 'Number of specimens affected';
+$LANG['VERIFY_PROTECTIONS'] = 'Verify Protections';
+$LANG['GLOBAL_PROTECTIONS'] = 'Global Protections';
+$LANG['ADD_TAXON'] = 'Add Taxon to List';
+$LANG['SCIENTIFIC_NAME'] = 'Scientific Name';
+$LANG['ADD_SPECIES'] = 'Add Species';
+$LANG['REMOVE_SPECIES'] = 'remove species from list';
+$LANG['NO_TAXA'] = 'No species were returned marked for global protection';
+$LANG['PRIVATE'] = 'private';
+$LANG['STATE_PROTECTIONS'] = 'State/Province Level Protections';
+$LANG['NO_CHECKLIST'] = 'No checklists returned';
 ?>

--- a/content/lang/collections/misc/protectedspecies.es.php
+++ b/content/lang/collections/misc/protectedspecies.es.php
@@ -1,6 +1,28 @@
 <?php
+$LANG['TITLE'] = 'Especies raras, amenazadas y sensibles';
+$LANG['ENTER_SCINAME'] = 'Ingrese el nombre científico de la especie que desea agregar';
+$LANG['SCINAME_NOT_EXIST'] = 'ERROR: El nombre científico no existe en la base de datos. ¿Usted escribe correctamente? Si es así, es posible que deba agregarse a la tabla de taxones';
+$LANG['HOME'] = 'Inicio';
+$LANG['SENSITIVE_TAXA'] = 'Especies sensibles para enmascarar detalles de la localidad';
+$LANG['TOGGLE_EDIT'] = 'Alternar funciones de edición';
 $LANG['EDIT'] = 'Editar';
+$LANG['PENCIL_ICON'] = 'icono de lápiz que representa la capacidad de edición';
+$LANG['PROTECTED_SPECIES'] = 'Especies protegidas';
+$LANG['FILTER'] = 'Filtrar';
 $LANG['TAXON_SEARCH'] = 'Búsqueda de Taxones';
-$LANG['VERIFY_PROTECTIONS'] = 'Verificar Protecciones';
 $LANG['SEARCH']= 'Buscar';
+$LANG['DESCRIPTION'] = 'Las especies en la lista a continuación tienen un estado de protección con detalles de localidad específicos debajo del condado retenidos (por ejemplo, latitud/longitud decimal).
+	Las causas típicas de protección son situaciones raras, amenazadas o sensibles, aunque también pueden aparecer en la lista especies apreciadas por los recolectores o recolectores silvestres.';
+$LANG['OCCURRENCES_PROTECTED'] = 'Ocurrencias protegidas';
+$LANG['NUMBER_AFFECTED'] = 'Número de ejemplares afectados';
+$LANG['VERIFY_PROTECTIONS'] = 'Verificar Protecciones';
+$LANG['GLOBAL_PROTECTIONS'] = 'Protecciones globales';
+$LANG['ADD_TAXON'] = 'Agregar taxón a la lista';
+$LANG['SCIENTIFIC_NAME'] = 'Nombre científico';
+$LANG['ADD_SPECIES'] = 'Agregar especies';
+$LANG['REMOVE_SPECIES'] = 'eliminar especies de la lista';
+$LANG['NO_TAXA'] = 'Ninguna especie fue devuelta marcada para protección global';
+$LANG['PRIVATE'] = 'privado';
+$LANG['STATE_PROTECTIONS'] = 'Protecciones a nivel estatal/provincial';
+$LANG['NO_CHECKLIST'] = 'No se devolvieron listas de verificación';
 ?>

--- a/content/lang/collections/misc/protectedspecies.fr.php
+++ b/content/lang/collections/misc/protectedspecies.fr.php
@@ -1,6 +1,28 @@
 <?php
+$LANG['TITLE'] = 'Espèces rares, menacées et sensibles';
+$LANG['ENTER_SCINAME'] = "Entrez le nom scientifique de l'espèce que vous souhaitez ajouter";
+$LANG['SCINAME_NOT_EXIST'] = "ERREUR : le nom scientifique n'existe pas dans la base de données. L'avez vous épeler correctement? Si tel est le cas, il faudra peut-être l'ajouter au tableau des taxons.";
+$LANG['HOME'] = 'Accueil';
+$LANG['SENSITIVE_TAXA'] = 'Espèces sensibles pour masquer les détails de la localité';
+$LANG['TOGGLE_EDIT'] = "Basculer les fonctions d'édition";
 $LANG['EDIT'] = 'Modifier';
+$LANG['PENCIL_ICON'] = "icône en forme de crayon représentant la capacité d'édition";
+$LANG['PROTECTED_SPECIES'] = 'Espèces protégées';
+$LANG['FILTER'] = 'Filtre';
 $LANG['TAXON_SEARCH'] = 'Recherche de Taxons';
-$LANG['VERIFY_PROTECTIONS'] = 'Vérifier les Protections';
 $LANG['SEARCH']= 'Recherche';
+$LANG['DESCRIPTION'] = 'Les espèces de la liste ci-dessous ont un statut de protection, les détails spécifiques de la localité sous le comté étant retenus (par exemple, latitude/longitude décimale).
+Les statuts rares, menacés ou sensibles sont les causes typiques de protection, bien que les espèces chéries par les collectionneurs ou les chasseurs sauvages puissent également figurer sur la liste.';
+$LANG['OCCURRENCES_PROTECTED'] = 'Événements protégés';
+$LANG['NUMBER_AFFECTED'] = 'Nombre de spécimens affectés';
+$LANG['VERIFY_PROTECTIONS'] = 'Vérifier les Protections';
+$LANG['GLOBAL_PROTECTIONS'] = 'Protections mondiales';
+$LANG['ADD_TAXON'] = 'Ajouter un taxon à la liste';
+$LANG['SCIENTIFIC_NAME'] = 'Nom scientifique';
+$LANG['ADD_SPECIES'] = 'Ajouter des espèces';
+$LANG['REMOVE_SPECIES'] = 'supprimer les espèces de la liste';
+$LANG['NO_TAXA'] = "Aucune espèce n'a été renvoyée marquée pour une protection mondiale";
+$LANG['PRIVATE'] = 'privé';
+$LANG['STATE_PROTECTIONS'] = "Protections au niveau de l’État/de la province";
+$LANG['NO_CHECKLIST'] = 'Aucune liste de contrôle renvoyée';
 ?>

--- a/js/symb/collections.editor.main.js
+++ b/js/symb/collections.editor.main.js
@@ -255,7 +255,7 @@ function verifyFullFormSciName(){
 				$( 'select[name=confidenceranking]' ).val(8);
 			}
 			*/
-			if(data.status == 1){
+			if(data.status == 1 && !$("input[name=cultivationstatus]").prop('checked')){
 				$("select[name=localitysecurity]").val(1);
 				securityChanged(document.fullform);
 			}
@@ -307,7 +307,7 @@ function localitySecurityCheck(){
 			dataType: "json",
 			data: { tid: tidIn, state: stateIn }
 		}).done(function( data ) {
-			if(data == "1"){
+			if(data == "1" && !$("input[name=cultivationstatus]").prop('checked')){
 				$("select[name=localitysecurity]").val(1);
 				securityChanged(document.fullform);
 			}
@@ -333,6 +333,11 @@ function fieldChanged(fieldName){
 		document.fullform.editedfields.value = document.fullform.editedfields.value + fieldName + ";";
 	}
 	catch(ex){
+	}
+	if(fieldName == 'cultivationstatus'){
+		if($("input[name=cultivationstatus]").prop('checked') && $("input[name=localitysecurityreason]").val() == ""){
+			$("select[name=localitysecurity]").val(0);
+		}
 	}
 }
 

--- a/js/symb/collections.editor.main.js
+++ b/js/symb/collections.editor.main.js
@@ -89,7 +89,9 @@ $(document).ready(function() {
 			$( "#tidinterpreted" ).val("");
 			$( 'input[name=scientificnameauthorship]' ).val("");
 			$( 'input[name=family]' ).val("");
-			$( 'input[name=localitysecurity]' ).prop('checked', false);
+			if($("input[name=localitysecurityreason]").val() == ""){
+				$("select[name=localitysecurity]").val(0);
+			}
 			fieldChanged('sciname');
 			fieldChanged('tidinterpreted');
 			fieldChanged('scientificnameauthorship');
@@ -254,7 +256,8 @@ function verifyFullFormSciName(){
 			}
 			*/
 			if(data.status == 1){
-				$( 'input[name=localitysecurity]' ).prop('checked', true);
+				$("select[name=localitysecurity]").val(1);
+				securityChanged(document.fullform);
 			}
 			else{
 				if(data.tid){
@@ -305,7 +308,8 @@ function localitySecurityCheck(){
 			data: { tid: tidIn, state: stateIn }
 		}).done(function( data ) {
 			if(data == "1"){
-				$( 'input[name=localitysecurity]' ).prop('checked', true);
+				$("select[name=localitysecurity]").val(1);
+				securityChanged(document.fullform);
 			}
 		});
 	}

--- a/taxa/taxonomy/taxonomydisplay.php
+++ b/taxa/taxonomy/taxonomydisplay.php
@@ -43,11 +43,7 @@ if($IS_ADMIN || array_key_exists('Taxonomy', $USER_RIGHTS)){
 <head>
 	<title><?php echo $DEFAULT_TITLE . ' ' . $LANG['TAX_DISPLAY'] . ': ' . $taxonDisplayObj->getTargetStr(); ?></title>
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET; ?>"/>
-<<<<<<< HEAD
-	<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
-=======
 	<link href="<?= $CSS_BASE_PATH ?>/jquery-ui.css" type="text/css" rel="stylesheet">
->>>>>>> Development
 	<?php
 	include_once($SERVER_ROOT.'/includes/head.php');
 	include_once($SERVER_ROOT.'/includes/googleanalytics.php');


### PR DESCRIPTION
Adjustments to how global and state-based locality security is applied (addresses issue: https://github.com/BioKIC/Symbiota/issues/954)

- Fixed bug interfering with locality security automatically being set within editor when a rare species is entered into form
- Remove all automatic setting of locality security for cultivated specimens
- Move data access from localitysecuritycheck rpc call file into the rpc class file (update old code)
- Finish internationalizing text within protectspecies.php (only partially done previously)
- Consolidate some of inventory/checklist editing functions within a shared ImInventory class. Trying to slowly merge some of the duplicated editing functions distributed throughout the code into shared class files dedicated to DB actions 
- Included some SQL conversions to prepare statement formats
- Minor adjustments to avoid warnings when variables are not supplied

# Pull Request Checklist:
# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
