### PR TITLE
Taxon image styling problem

### DIFF
--- a/css/v202209/symbiota/base.css
+++ b/css/v202209/symbiota/base.css
@@ -547,3 +547,8 @@ b {
 .gridlike-form-row-input {
   width: 40%;
 }
+
+.div--overflow-wrap-anywhere {
+  overflow-wrap: anywhere;
+  width: 100%;
+}

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -113,6 +113,13 @@ hr {
   width: 90%;
 }
 
+#innertext--max-width-100 {
+  margin: 0 auto;
+  padding: 3rem 0;
+  background-color: var(--body-bg-color);
+  width: 100%;
+}
+
 #innertext p {
   color: var(--body-text-color);
   line-height: 1.5;

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -113,13 +113,6 @@ hr {
   width: 90%;
 }
 
-#innertext--max-width-100 {
-  margin: 0 auto;
-  padding: 3rem 0;
-  background-color: var(--body-bg-color);
-  width: 100%;
-}
-
 #innertext p {
   color: var(--body-text-color);
   line-height: 1.5;

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -904,3 +904,8 @@ div.no-margin-left {
   white-space: nowrap;
   overflow-x: scroll;
 }
+
+.div--overflow-wrap-anywhere {
+  overflow-wrap: anywhere;
+  width: 100%;
+}

--- a/css/v202209/symbiota/main.css
+++ b/css/v202209/symbiota/main.css
@@ -904,8 +904,3 @@ div.no-margin-left {
   white-space: nowrap;
   overflow-x: scroll;
 }
-
-.div--overflow-wrap-anywhere {
-  overflow-wrap: anywhere;
-  width: 100%;
-}

--- a/taxa/profile/tpimageeditor.php
+++ b/taxa/profile/tpimageeditor.php
@@ -17,7 +17,7 @@ if($tid){
 }
 ?>
 <!-- This is inner text! -->
-<div id="innertext--max-width-100" style="background-color:white;">
+<div id="innertext" style="background-color:white;">
 	<?php
 	if($isEditor && $tid){
 		if($category == "imagequicksort"){

--- a/taxa/profile/tpimageeditor.php
+++ b/taxa/profile/tpimageeditor.php
@@ -240,7 +240,7 @@ if($tid){
 										?>
 									</div>
 								</div>
-								<div>
+								<div class="div--overflow-wrap-anywhere">
 									<?php
 									if($imgArr['occid']){
 										?>

--- a/taxa/profile/tpimageeditor.php
+++ b/taxa/profile/tpimageeditor.php
@@ -17,7 +17,7 @@ if($tid){
 }
 ?>
 <!-- This is inner text! -->
-<div id="innertext" style="background-color:white;">
+<div id="innertext--max-width-100" style="background-color:white;">
 	<?php
 	if($isEditor && $tid){
 		if($category == "imagequicksort"){
@@ -211,146 +211,145 @@ if($tid){
 			if($images = $imageEditor->getImages()){
 				?>
 				<div style='clear:both;'>
-					<table>
+					<section class="gridlike-form">
 						<?php
 						foreach($images as $imgArr){
 							?>
-							<tr><td>
-								<div style="margin:20px;float:left;text-align:center;">
-									<?php
-									$webUrl = $imgArr["url"];
-									$tnUrl = $imgArr["thumbnailurl"];
-									if($GLOBALS['imageDomain']){
-										if(substr($imgArr["url"],0,1) == "/") $webUrl = $GLOBALS["imageDomain"].$imgArr["url"];
-										if(substr($imgArr["thumbnailurl"],0,1) == "/") $tnUrl = $GLOBALS["imageDomain"].$imgArr["thumbnailurl"];
-									}
-									if(!$tnUrl) $tnUrl = $webUrl;
-									?>
-									<a href="../../imagelib/imgdetails.php?imgid=<?php echo htmlspecialchars($imgArr['imgid'], HTML_SPECIAL_CHARS_FLAGS); ?>">
-										<img src="<?php echo $tnUrl;?>" style="width:200px;"/>
-									</a>
-									<?php
-									if($imgArr["originalurl"]){
-										$origUrl = (array_key_exists("imageDomain",$GLOBALS)&&substr($imgArr["originalurl"],0,1)=="/"?$GLOBALS["imageDomain"]:"").$imgArr["originalurl"];
-										?>
-										<br /><a href="<?php echo htmlspecialchars($origUrl, HTML_SPECIAL_CHARS_FLAGS);?>"><?php echo htmlspecialchars($LANG['OPEN_LARGE_IMAGE'], HTML_SPECIAL_CHARS_FLAGS); ?></a>
+							<section class="gridlike-form-row bottom-breathing-room-relative">
+								<div>
+									<div style="margin:20px;float:left;text-align:center;">
 										<?php
-									}
-									?>
+										$webUrl = $imgArr["url"];
+										$tnUrl = $imgArr["thumbnailurl"];
+										if($GLOBALS['imageDomain']){
+											if(substr($imgArr["url"],0,1) == "/") $webUrl = $GLOBALS["imageDomain"].$imgArr["url"];
+											if(substr($imgArr["thumbnailurl"],0,1) == "/") $tnUrl = $GLOBALS["imageDomain"].$imgArr["thumbnailurl"];
+										}
+										if(!$tnUrl) $tnUrl = $webUrl;
+										?>
+										<a href="../../imagelib/imgdetails.php?imgid=<?php echo htmlspecialchars($imgArr['imgid'], HTML_SPECIAL_CHARS_FLAGS); ?>">
+											<img src="<?php echo $tnUrl;?>" style="width:200px;"/>
+										</a>
+										<?php
+										if($imgArr["originalurl"]){
+											$origUrl = (array_key_exists("imageDomain",$GLOBALS)&&substr($imgArr["originalurl"],0,1)=="/"?$GLOBALS["imageDomain"]:"").$imgArr["originalurl"];
+											?>
+											<br /><a href="<?php echo htmlspecialchars($origUrl, HTML_SPECIAL_CHARS_FLAGS);?>"><?php echo htmlspecialchars($LANG['OPEN_LARGE_IMAGE'], HTML_SPECIAL_CHARS_FLAGS); ?></a>
+											<?php
+										}
+										?>
+									</div>
 								</div>
-							</td>
-							<td valign="middle" style="width:90%">
-								<?php
-								if($imgArr['occid']){
-									?>
-									<div style="float:right;margin-right:10px;" title="<?php echo $LANG['MUST_HAVE_EDIT_PERM']; ?>">
-										<a href="../../collections/editor/occurrenceeditor.php?occid=<?php echo htmlspecialchars($imgArr['occid'], HTML_SPECIAL_CHARS_FLAGS); ?>&tabtarget=2" target="_blank">
-											<img src="../../images/edit.png" style="width:1.3em;border:0px;"/>
-										</a>
-									</div>
+								<div>
 									<?php
-								}
-								else{
-									?>
-									<div style='float:right;margin-right:10px;'>
-										<a href="../../imagelib/imgdetails.php?imgid=<?php echo htmlspecialchars($imgArr["imgid"], HTML_SPECIAL_CHARS_FLAGS);?>&emode=1">
-											<img src="../../images/edit.png" style="width:1.3em;border:0px;" />
-										</a>
-									</div>
-									<?php
-								}
-								?>
-								<div style='margin:60px 0px 10px 10px;clear:both;'>
-									<?php
-									if($imgArr["tid"] != $tid){
+									if($imgArr['occid']){
 										?>
-										<div>
-											<b><?php echo $LANG['IMAGE_LINKED_FROM']; ?>:</b>
-											<a href="tpeditor.php?tid=<?php echo htmlspecialchars($imgArr["tid"], HTML_SPECIAL_CHARS_FLAGS);?>" target=""><?php echo htmlspecialchars($imgArr["sciname"], HTML_SPECIAL_CHARS_FLAGS);?></a>
-										</div>
-										<?php
-									}
-									if($imgArr["caption"]){
-										?>
-										<div>
-											<b><?php echo $LANG['CAPTION']; ?>:</b>
-											<?php echo $imgArr["caption"];?>
-										</div>
-										<?php
-									}
-									?>
-									<div>
-										<b><?php echo $LANG['PHOTOGRAPHER']; ?>:</b>
-										<?php echo $imgArr["photographerdisplay"];?>
-									</div>
-									<?php
-									if($imgArr["owner"]){
-										?>
-										<div>
-											<b><?php echo $LANG['MANAGER']; ?>:</b>
-											<?php echo $imgArr["owner"];?>
-										</div>
-										<?php
-									}
-									if($imgArr["sourceurl"]){
-										?>
-										<div>
-											<b><?php echo $LANG['SOURCE_URL']; ?>:</b>
-											<a href="<?php echo htmlspecialchars($imgArr["sourceurl"], HTML_SPECIAL_CHARS_FLAGS);?>" target="_blank"><?php echo htmlspecialchars($imgArr["sourceurl"], HTML_SPECIAL_CHARS_FLAGS); ?></a>
-										</div>
-										<?php
-									}
-									if($imgArr["copyright"]){
-										?>
-										<div>
-											<b><?php echo $LANG['COPYRIGHT']; ?>:</b>
-											<?php echo $imgArr["copyright"];?>
-										</div>
-										<?php
-									}
-									if($imgArr["locality"]){
-										?>
-										<div>
-											<b><?php echo $LANG['LOCALITY']; ?>:</b>
-											<?php echo $imgArr["locality"];?>
-										</div>
-										<?php
-									}
-									if($imgArr["occid"]){
-										?>
-										<div>
-											<b><?php echo $LANG['OCC_REC_NUM']; ?>:</b>
-											<a href="<?php echo htmlspecialchars($CLIENT_ROOT, HTML_SPECIAL_CHARS_FLAGS);?>/collections/individual/index.php?occid=<?php echo htmlspecialchars($imgArr["occid"], HTML_SPECIAL_CHARS_FLAGS); ?>">
-												<?php echo $imgArr["occid"];?>
+										<div style="float:right;margin-right:10px;" title="<?php echo $LANG['MUST_HAVE_EDIT_PERM']; ?>">
+											<a href="../../collections/editor/occurrenceeditor.php?occid=<?php echo htmlspecialchars($imgArr['occid'], HTML_SPECIAL_CHARS_FLAGS); ?>&tabtarget=2" target="_blank">
+												<img src="../../images/edit.png" style="width:1.3em;border:0px;"/>
 											</a>
 										</div>
 										<?php
 									}
-									if($imgArr["notes"]){
+									else{
 										?>
-										<div>
-											<b><?php echo $LANG['NOTES']; ?>:</b>
-											<?php echo $imgArr["notes"];?>
+										<div style='float:right;margin-right:10px;'>
+											<a href="../../imagelib/imgdetails.php?imgid=<?php echo htmlspecialchars($imgArr["imgid"], HTML_SPECIAL_CHARS_FLAGS);?>&emode=1">
+												<img src="../../images/edit.png" style="width:1.3em;border:0px;" />
+											</a>
 										</div>
 										<?php
 									}
 									?>
-									<div>
-										<b><?php echo $LANG['SORT_SEQUENCE']; ?>:</b>
-										<?php echo $imgArr["sortsequence"];?>
+									<div style='margin:60px 0px 10px 10px;clear:both;'>
+										<?php
+										if($imgArr["tid"] != $tid){
+											?>
+											<div>
+												<b><?php echo $LANG['IMAGE_LINKED_FROM']; ?>:</b>
+												<a href="tpeditor.php?tid=<?php echo htmlspecialchars($imgArr["tid"], HTML_SPECIAL_CHARS_FLAGS);?>" target=""><?php echo htmlspecialchars($imgArr["sciname"], HTML_SPECIAL_CHARS_FLAGS);?></a>
+											</div>
+											<?php
+										}
+										if($imgArr["caption"]){
+											?>
+											<div>
+												<b><?php echo $LANG['CAPTION']; ?>:</b>
+												<?php echo $imgArr["caption"];?>
+											</div>
+											<?php
+										}
+										?>
+										<div>
+											<b><?php echo $LANG['PHOTOGRAPHER']; ?>:</b>
+											<?php echo $imgArr["photographerdisplay"];?>
+										</div>
+										<?php
+										if($imgArr["owner"]){
+											?>
+											<div>
+												<b><?php echo $LANG['MANAGER']; ?>:</b>
+												<?php echo $imgArr["owner"];?>
+											</div>
+											<?php
+										}
+										if($imgArr["sourceurl"]){
+											?>
+											<div>
+												<b><?php echo $LANG['SOURCE_URL']; ?>:</b>
+												<a href="<?php echo htmlspecialchars($imgArr["sourceurl"], HTML_SPECIAL_CHARS_FLAGS);?>" target="_blank"><?php echo htmlspecialchars($imgArr["sourceurl"], HTML_SPECIAL_CHARS_FLAGS); ?></a>
+											</div>
+											<?php
+										}
+										if($imgArr["copyright"]){
+											?>
+											<div>
+												<b><?php echo $LANG['COPYRIGHT']; ?>:</b>
+												<?php echo $imgArr["copyright"];?>
+											</div>
+											<?php
+										}
+										if($imgArr["locality"]){
+											?>
+											<div>
+												<b><?php echo $LANG['LOCALITY']; ?>:</b>
+												<?php echo $imgArr["locality"];?>
+											</div>
+											<?php
+										}
+										if($imgArr["occid"]){
+											?>
+											<div>
+												<b><?php echo $LANG['OCC_REC_NUM']; ?>:</b>
+												<a href="<?php echo htmlspecialchars($CLIENT_ROOT, HTML_SPECIAL_CHARS_FLAGS);?>/collections/individual/index.php?occid=<?php echo htmlspecialchars($imgArr["occid"], HTML_SPECIAL_CHARS_FLAGS); ?>">
+													<?php echo $imgArr["occid"];?>
+												</a>
+											</div>
+											<?php
+										}
+										if($imgArr["notes"]){
+											?>
+											<div>
+												<b><?php echo $LANG['NOTES']; ?>:</b>
+												<?php echo $imgArr["notes"];?>
+											</div>
+											<?php
+										}
+										?>
+										<div>
+											<b><?php echo $LANG['SORT_SEQUENCE']; ?>:</b>
+											<?php echo $imgArr["sortsequence"];?>
+										</div>
 									</div>
 								</div>
-
-							</td></tr>
-							<tr><td colspan='2'>
-								<div style='margin:10px 0px 0px 0px;clear:both;'>
-									<hr />
-								</div>
-							</td></tr>
+							</section>
+							<div>
+								<hr/>
+							</div>
 							<?php
 						}
 						?>
-					</table>
+					</section>
 				</div>
 				<?php
 			}


### PR DESCRIPTION
# Before:
<img width="1201" alt="Screenshot 2024-03-01 at 10 50 21 AM" src="https://github.com/egbot/Symbiota/assets/86389284/9ad0b4bd-7be3-4066-b837-8788e747e700">

<img width="1201" alt="Screenshot 2024-03-01 at 10 50 32 AM" src="https://github.com/egbot/Symbiota/assets/86389284/c15cd564-32e1-404f-95df-9f6fe94edf89">

# After:
<img width="1201" alt="Screenshot 2024-03-01 at 10 37 38 AM" src="https://github.com/egbot/Symbiota/assets/86389284/9e58fc6e-9518-481a-8719-46273a61dff1">
<img width="1201" alt="Screenshot 2024-03-01 at 10 37 50 AM" src="https://github.com/egbot/Symbiota/assets/86389284/0afefd6c-1739-43f1-975d-8528d98af073">

# Changes Made:

- removed table - replaced with "gridlike" class sections

# Important Note:

Currently the text wrap works based on words, so if there is a very long sequence of symbols without delimiters it will still go out of border. Could be an issue with long URL addresses.

Potential solution:    "overflow-wrap: anywhere". This will force text wrap.

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [N/A] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [N/A] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [N/A] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [N/A] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address:
https://github.com/BioKIC/Symbiota/issues/863
- [N/A] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
