### PR TITLE
assign skip-link class to caption element and change aria-describedby…

### DIFF
--- a/collections/editor/editreviewer.php
+++ b/collections/editor/editreviewer.php
@@ -355,9 +355,9 @@ $navStr .= '</div>';
 					<?php
 					echo '<div style="clear:both">'.$navStr.'</div>';
 					?>
-					<table class="styledtable" style="font-family:Arial;font-size:1.25rem;" aria-label="<?php echo (isset($LANG['TABLE']) ? $LANG['TABLE'] : 'Table of Records'); ?>" aria-describedby="table-desc">
-						<caption id="table-desc" class="bottom-breathing-room-relative top-breathing-room-rel">
-							<?php echo (isset($LANG['TABLE_DESC']) ? $LANG['TABLE_DESC'] : 'The table contains Record Id, Catalog Number, Review Status, Applied Status, Editor Name, Timestamp, Field Name, Old Value, and New Value for each entry'); ?>
+					<table class="styledtable" style="font-family:Arial;font-size:1.25rem;" aria-label="<?php echo (isset($LANG['TABLE']) ? $LANG['TABLE'] : 'Table of Records'); ?>" aria-labeledby="table-desc">
+						<caption id="table-desc" class="bottom-breathing-room-relative top-breathing-room-rel skip-link">
+							<?php echo $LANG['TABLE_DESC']; ?>
 						</caption>
 						<tr>
 							<th> <input name='selectall' type="checkbox" onclick="selectAllId(this)" aria-label="<?php echo (isset($LANG['SELECT_ALL']) ? $LANG['SELECT_ALL'] : 'Select/Unselect All'); ?>" /></th>


### PR DESCRIPTION
… to aria-labeledby

## Before

<img width="1552" alt="Screen Shot 2024-03-14 at 12 52 48 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/ecd1bd34-0a84-4cb9-9872-55152c43f82e">


## After

<img width="1552" alt="Screen Shot 2024-03-14 at 12 50 08 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/2cc0b24f-b177-4e13-848f-4f0c63c09c0d">

# Description

This PR hides the table caption from users not using screen readers. It also changes from aria-describedby to aria-labeledby so that screen readers read it correctly.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
    - N/A
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [ ] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/BioKIC/Symbiota/issues/889](https://github.com/BioKIC/Symbiota/issues/889)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
