### PR TITLE
Make geography1-div display more robust

### DIFF
--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -960,29 +960,25 @@ else{
 											}
 											?>
 											<legend><?php echo $LANG['LOCALITY']; ?></legend>
-											<div id="geography1-div" class="fieldGroup-div" style="<?= ($displayGeo1Div ? 'display:block' : '') ?>">
+											<div id="geography1-div" class="fieldGroup-div" style="<?= ($displayGeo1Div ? 'display:flex' : 'display:none') ?>">
 												<div id="continentDiv" class="field-div">
 													<?= $LANG['CONTINENT']; ?>
 													<a href="#" onclick="return dwcDoc('continent')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
-													<br/>
 													<input type="text" id="ffcontinent" name="continent" value="<?= $continent ?>" onchange="fieldChanged('continent');" autocomplete="off" />
 												</div>
 												<div id="waterBodyDiv" class="field-div">
 													<?= $LANG['WATER_BODY']; ?>
 													<a href="#" onclick="return dwcDoc('waterBody')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
-													<br/>
 													<input type="text" id="ffwaterbody" name="waterbody" value="<?= $waterBody ?>" onchange="fieldChanged('waterbody');" autocomplete="off" />
 												</div>
 												<div id="islandGroupDiv" class="field-div">
 													<?= $LANG['ISLAND_GROUP']; ?>
 													<a href="#" onclick="return dwcDoc('islandGroup')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
-													<br/>
 													<input type="text" id="ffislandgroup" name="islandgroup" value="<?= $islandGroup ?>" onchange="fieldChanged('islandgroup');" autocomplete="off" />
 												</div>
 												<div id="islandDiv" class="field-div">
 													<?= $LANG['ISLAND']; ?>
 													<a href="#" onclick="return dwcDoc('island')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
-													<br/>
 													<input type="text" id="ffisland" name="island" value="<?= $island ?>" onchange="fieldChanged('island');" autocomplete="off" />
 												</div>
 											</div>
@@ -1016,7 +1012,7 @@ else{
 													<a href="#" onclick="return dwcDoc('locationID')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 													<br/>
 													<input type="text" id="locationid" name="locationid" value="<?php echo array_key_exists('locationid',$occArr)?$occArr['locationid']:''; ?>" onchange="fieldChanged('locationid');" autocomplete="off" />
-													<a id="geography1Toggle" onclick="toggle('geography1-div');">
+													<a id="geography1Toggle" onclick="toggle('geography1-div', 'flex');">
 														<img class="editimg" src="../../images/editplus.png">
 													</a>
 												</div>

--- a/js/symb/collections.editor.query.js
+++ b/js/symb/collections.editor.query.js
@@ -242,30 +242,31 @@ function resetCustomElements(x){
 	}
 }
 
-function toggle(target){
-	var ele = document.getElementById(target);
-	if(ele){
-		if(ele.style.display=="none" || ele.style.display==""){
-			ele.style.display="block";
-  		}
-	 	else {
-	 		ele.style.display="none";
-	 	}
-	}
-	else{
-		var divObjs = document.getElementsByTagName("div");
-	  	for (i = 0; i < divObjs.length; i++) {
-	  		var divObj = divObjs[i];
-	  		if(divObj.getAttribute("class") == target || divObj.getAttribute("className") == target){
-				if(divObj.style.display=="none"){
-					divObj.style.display="";
-				}
-			 	else {
-			 		divObj.style.display="none";
-			 	}
-			}
-		}
-	}
+
+function toggle(target, displayStyle = "block") {
+  var ele = document.getElementById(target);
+  if (ele) {
+    if (ele.style.display == "none" || ele.style.display == "") {
+      ele.style.display = displayStyle;
+    } else {
+      ele.style.display = "none";
+    }
+  } else {
+    var divObjs = document.getElementsByTagName("div");
+    for (i = 0; i < divObjs.length; i++) {
+      var divObj = divObjs[i];
+      if (
+        divObj.getAttribute("class") == target ||
+        divObj.getAttribute("className") == target
+      ) {
+        if (divObj.style.display == "none") {
+          divObj.style.display = "";
+        } else {
+          divObj.style.display = "none";
+        }
+      }
+    }
+  }
 }
 
 //Misc


### PR DESCRIPTION
# Description

This PR was motivated by a weird look for the geography1-div in the branch we're using for the usda portal.

The specifics of the solution are mentioned as comments in the files changed tab, but essentially it:
 
- enforces an explicit display: none when not displaying
- accommodates display:flex in addition to display: block

## Before

<img width="1552" alt="Screen Shot 2024-03-19 at 11 32 55 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/1202158b-4f9d-422b-ac56-701a6625f4ad">

## After (also, it now defaults to display: none when there is no data present to populate that div)

<img width="1552" alt="Screen Shot 2024-03-19 at 11 20 37 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/b8d99f81-bae4-49dd-9175-e8d66cee585b">


# Pull Request Checklist:

# Pre-Approval

- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - This page isn't particularly responsive. It should be a separate ticket/issue after all of the anticipated occurrenceeditor changes have been implemented.
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [ ] Comment which GitHub issue(s), if any does this PR address
    - N/A
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
