### PR TITLE
Decorative alt collection thumbnails

### DIFF
--- a/classes/OccurrenceSearchSupport.php
+++ b/classes/OccurrenceSearchSupport.php
@@ -251,7 +251,7 @@ class OccurrenceSearchSupport {
 								if($cArr["icon"]){
 									$cIcon = (substr($cArr["icon"],0,6)=='images'?$CLIENT_ROOT:'').$cArr["icon"];
 									?>
-									<a href = '<?= $CLIENT_ROOT ?>/collections/misc/collprofiles.php?collid=<?= $collid ?>'><img src="<?= $cIcon ?>" style="border:0px;width:30px;height:30px;" /></a>
+									<a href = '<?= $CLIENT_ROOT ?>/collections/misc/collprofiles.php?collid=<?= $collid ?>'><img alt="" src="<?= $cIcon ?>" style="border:0px;width:30px;height:30px;" /></a>
 									<?php
 								}
 								?>

--- a/classes/OccurrenceSearchSupport.php
+++ b/classes/OccurrenceSearchSupport.php
@@ -124,7 +124,7 @@ class OccurrenceSearchSupport {
 								<?php
 								if($catIcon){
 									$catIcon = (substr($catIcon,0,6)=='images'?$CLIENT_ROOT:'').$catIcon;
-									echo '<img src="'.$catIcon.'" style="border:0px;width:30px;height:30px;" />';
+									echo '<img alt="" src="'.$catIcon.'" style="border:0px;width:30px;height:30px;" />';
 								}
 								?>
 							</div>

--- a/collections/search/singleCollectionGroupDetails.php
+++ b/collections/search/singleCollectionGroupDetails.php
@@ -15,7 +15,7 @@ $idStr = $collCnt . '-' . $catId;
         <?php
         if($catIcon){
             $catIcon = (substr($catIcon,0,6)=='images'?$CLIENT_ROOT:'').$catIcon;
-            echo '<img src="'.$catIcon.'" style="border:0px;width:30px;height:30px;" />';
+            echo '<img alt="" src="' . $catIcon . '" style="border:0px;width:30px;height:30px;" />';
         }
         ?>
         </div>

--- a/collections/search/singleCollectionWithoutCategoryDetails.php
+++ b/collections/search/singleCollectionWithoutCategoryDetails.php
@@ -9,7 +9,7 @@
                 if($cArr["icon"]){
                     $cIcon = (substr($cArr["icon"],0,6)=='images'?$CLIENT_ROOT:'').$cArr["icon"];
                     ?>
-                    <a href = '<?php echo htmlspecialchars($CLIENT_ROOT, HTML_SPECIAL_CHARS_FLAGS); ?>/collections/misc/collprofiles.php?collid=<?php echo htmlspecialchars($collid, HTML_SPECIAL_CHARS_FLAGS); ?>'><img src="<?php echo htmlspecialchars($cIcon, HTML_SPECIAL_CHARS_FLAGS); ?>" style="border:0px;width:30px;height:30px;" /></a>
+                    <a href = '<?php echo htmlspecialchars($CLIENT_ROOT, HTML_SPECIAL_CHARS_FLAGS); ?>/collections/misc/collprofiles.php?collid=<?php echo htmlspecialchars($collid, HTML_SPECIAL_CHARS_FLAGS); ?>'><img alt="Icon associated with collection:  <?php echo isset($cArr["collname"]) ? substr($cArr["collname"],0, 20) : substr($cArr["instcode"],0, 20) ?>" src="<?php echo htmlspecialchars($cIcon, HTML_SPECIAL_CHARS_FLAGS); ?>" style="border:0px;width:30px;height:30px;" /></a>
                     <?php
                 }
                 ?>


### PR DESCRIPTION
# Description

This PR adds decorative (`alt=""`) or meaningful alt attributes to the thumbnail images associated with collections in harvestparams or search/index.php (the new search page). This was a requirement mentioned by Lisa during the 508 compliance eval.

## Before

<img width="1552" alt="Screen Shot 2024-04-10 at 6 53 37 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/2b9160ae-33c2-4062-81ed-f9ed3f979b3f">

## After

<img width="1552" alt="Screen Shot 2024-04-10 at 6 51 23 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/edd1955e-412e-4ea2-a3b3-ab7419655f70">


# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/BioKIC/Symbiota/issues/1137](https://github.com/BioKIC/Symbiota/issues/1137)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
