### PR TITLE
Make "delete comment" button red

### DIFF
--- a/collections/misc/commentlist.php
+++ b/collections/misc/commentlist.php
@@ -264,7 +264,7 @@ if($isEditor){
 								}
 								?>
 								<span style="margin-left:20px;">
-									<button name="formsubmit" type="submit" value="Delete Comment"  onclick="return confirm('<?php echo $LANG['SURE_DELETE_COMMENT']; ?>')" ><?php echo $LANG['DEL_COMMENT']; ?></button>
+									<button name="formsubmit" type="submit" value="Delete Comment" style="background-color:#DF5151" onclick="return confirm('<?php echo $LANG['SURE_DELETE_COMMENT']; ?>')" ><?php echo $LANG['DEL_COMMENT']; ?></button>
 								</span>
 								<input name="comid" type="hidden" value="<?php echo $comid; ?>" />
 							</form>


### PR DESCRIPTION
# Pull Request Checklist:

### BEFORE
![image](https://github.com/BioKIC/Symbiota/assets/16688784/eaa0c36b-7abe-4de4-9867-bc470158d9e2)

### AFTER
![image](https://github.com/BioKIC/Symbiota/assets/16688784/751e11cf-07d1-438f-8812-f0dbcef702c5)

@Atticus29 and @GregPost-ASU , interested to hear what's the best way to deal with this. Should we create a new css grouping called "delete button" that has a red hue, rather than adding in-line styling?

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.