### PR TITLE
3.1 record search form fixes

### DIFF
--- a/collections/editor/includes/queryform.php
+++ b/collections/editor/includes/queryform.php
@@ -258,25 +258,25 @@ else{
 						?>
 					</select>
 					<a href="#" onclick="toggleCustomDiv(<?php echo ($x+1); ?>);return false;">
-						<img class="editimg" src="../../images/editplus.png" style="width:1.2em;" alt="<?php echo htmlspecialchars($LANG['IMG_EDIT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" />
+						<img class="editimg" src="../../images/plus.png" style="width:1.2em;" alt="<?php echo htmlspecialchars($LANG['IMG_EDIT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" />
 					</a>
 				</div>
 				<?php
 			}
 			?>
-			<div class="fieldGroupDiv">
 				<?php
 				if($isGenObs && ($IS_ADMIN || ($collId && array_key_exists("CollAdmin",$USER_RIGHTS) && in_array($collId,$USER_RIGHTS["CollAdmin"])))){
 					?>
-					<div>
-						<input type="checkbox" name="q_returnall" value="1" <?php echo ($qReturnAll?'CHECKED':''); ?> /> <?php echo $LANG['SHOW_RECS_ALL']; ?>
+					<div class="fieldGroupDiv">
+						<div>
+							<input type="checkbox" name="q_returnall" value="1" <?php echo ($qReturnAll?'CHECKED':''); ?> /> <?php echo $LANG['SHOW_RECS_ALL']; ?>
+						</div>
 					</div>
 					<?php
 				}
 				?>
-			</div>
 			<div class="fieldGroupDiv">
-				<div class="bottom-breathing-room-rel">
+				<div>
 
 					<?php
 					if(!$crowdSourceMode){
@@ -307,7 +307,7 @@ else{
 				<input type="hidden" name="occindex" value="<?php echo $occManager->getOccIndex(); ?>" />
 				<input type="hidden" name="occidlist" value="<?php echo $occManager->getOccidIndexStr(); ?>" />
 				<input type="hidden" name="direction" value="" />
-				<section class="flex-form">
+				<section class="flex-form bottom-breathing-room-rel">
 					<div style="margin-left: 0;">
 						<button name="submitaction" type="submit" onclick="submitQueryEditor(this.form)" ><?php echo $LANG['DISPLAY_EDITOR']; ?></button>
 					</div>
@@ -317,7 +317,9 @@ else{
 					<div style="margin-left: 0;">
 						<button type="button" name="reset" value="Reset Form" onclick="resetQueryForm(this.form)">Reset Form</button>
 					</div>
-					<div>
+				</section>
+				<section class="flex-form">
+					<div class="fieldGroupDiv" style="margin-left: 0;">
 						<label for="orderby"><?php echo $LANG['SORT_BY']; ?>:</label>
 						<select name="orderby" id="orderby">
 							<option value=""></option>
@@ -350,22 +352,24 @@ else{
 							<option value="DESC" <?php echo ($qOrderByDir=='DESC'?'SELECTED':''); ?>><?php echo $LANG['DESCENDING']; ?></option>
 						</select>
 					</div>
+					<div style="display: flex; align-items: center; margin-bottom: 1rem;">
 						<label for="reclimit">
 							<?php
 							if(!isset($recLimit) || !$recLimit) $recLimit = 1000;
 							echo $LANG['OUTPUT'] . ':';
 							?>
 						</label>
-						<select name="reclimit" id="reclimit">
+						<select name="reclimit" id="reclimit" class="left-breathing-room-rel">
 							<option <?php echo ($recLimit==500?'selected':''); ?>>500</option>
 							<option <?php echo ($recLimit==1000?'selected':''); ?>>1000</option>
 							<option <?php echo ($recLimit==2000?'selected':''); ?>>2000</option>
 							<option <?php echo ($recLimit==3000?'selected':''); ?>>3000</option>
 						</select> <?php //echo $LANG['RECORDS']; ?>
+					</div>
 				</section>
-				<div>
+				<div style="display: flex; align-content: center;">
 					<input name="dynamictable" id="dynamictable-1" type="checkbox" value="1" <?php if(isset($dynamicTable) && $dynamicTable) echo 'checked'; ?> />
-					<label for="dynamictable-1"><?php echo $LANG['DYNAMIC_TABLE']; ?></label>
+					<label class="left-breathing-room-rel"for="dynamictable-1"><?php echo $LANG['DYNAMIC_TABLE']; ?></label>
 				</div>
  			</div>
 		</fieldset>

--- a/collections/editor/includes/queryform.php
+++ b/collections/editor/includes/queryform.php
@@ -258,7 +258,7 @@ else{
 						?>
 					</select>
 					<a href="#" onclick="toggleCustomDiv(<?php echo ($x+1); ?>);return false;">
-						<img class="editimg" src="../../images/plus.png" style="width:1.2em;" alt="<?php echo htmlspecialchars($LANG['IMG_EDIT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" />
+						<img class="editimg" src="../../images/plus.png" style="width:1.2em;" alt="<?php echo htmlspecialchars($LANG['ADD_CUSTOM_FIELD'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" />
 					</a>
 				</div>
 				<?php

--- a/collections/editor/includes/queryform.php
+++ b/collections/editor/includes/queryform.php
@@ -79,8 +79,16 @@ else{
 ?>
 <div id="querydiv" style="clear:both;width:900px;display:<?php echo ($displayQuery?'block':'none'); ?>;">
 	<form name="queryform" action="<?php echo $_SERVER['SCRIPT_NAME']; ?>" method="post" onsubmit="return verifyQueryForm(this)">
-		<fieldset style="padding:5px;">
+		<fieldset style="padding:5px; position: relative">
 			<legend><?php echo $LANG['RECORD_SEARCH_FORM']; ?></legend>
+			<button style="position: absolute; right: 3vw;" type="button" class="icon-button" onclick="copyQueryLink(event)" title="<?php echo $LANG['COPY_SEARCH']; ?>" aria-label="<?php echo $LANG['COPY_LINK']; ?>">
+				<span style="display:flex; align-content: center;">
+						<svg alt="Link icon. Copies the search terms as a link." style="width:1.2em;margin-right:5px;" xmlns="http://www.w3.org/2000/svg" fill="var(--light-color)" height="24" viewBox="0 -960 960 960" width="24"><path d="M440-280H280q-83 0-141.5-58.5T80-480q0-83 58.5-141.5T280-680h160v80H280q-50 0-85 35t-35 85q0 50 35 85t85 35h160v80ZM320-440v-80h320v80H320Zm200 160v-80h160q50 0 85-35t35-85q0-50-35-85t-85-35H520v-80h160q83 0 141.5 58.5T880-480q0 83-58.5 141.5T680-280H520Z"/></svg>
+						<span style="align-content: center;">
+							<?php echo $LANG['COPY_LINK']; ?>
+						</span>
+				</span>
+			</button>
 			<?php
 			if(!$crowdSourceMode){
 				?>
@@ -92,21 +100,11 @@ else{
 					<div class="fieldDiv" title="<?php echo $LANG['SEPARATE_RANGES']; ?>">
 						<label for="q_recordnumber"><?php echo $LANG['NUMBER']; ?>:</label>
 						<input type="text" name="q_recordnumber" id="q_recordnumber" value="<?php echo $qRecordNumber; ?>" style="width:120px;" onchange="setOrderBy(this)" />
+							<label  title="<?php echo $LANG['ENTER_RANGES']; ?>" for="q_eventdate"><?php echo $LANG['DATE']; ?>:</label>
+							<input type="text" name="q_eventdate" id="q_eventdate" value="<?php echo $qEventDate; ?>" style="width:160px" onchange="setOrderBy(this)" />
+						</div>
 					</div>
-					<div class="fieldDiv" title="<?php echo $LANG['ENTER_RANGES']; ?>">
-						<label for="q_eventdate"><?php echo $LANG['DATE']; ?>:</label>
-						<input type="text" name="q_eventdate" id="q_eventdate" value="<?php echo $qEventDate; ?>" style="width:160px" onchange="setOrderBy(this)" />
-					</div>
-
-					<button type="button" class="icon-button float-right" onclick="copyQueryLink(event)" title="<?php echo $LANG['COPY_SEARCH']; ?>" aria-label="<?php echo $LANG['COPY_LINK']; ?>">
-						<span style="display:flex; align-content: center;">
-								<svg alt="Link icon. Copies the search terms as a link." style="width:1.2em;margin-right:5px;" xmlns="http://www.w3.org/2000/svg" fill="var(--light-color)" height="24" viewBox="0 -960 960 960" width="24"><path d="M440-280H280q-83 0-141.5-58.5T80-480q0-83 58.5-141.5T280-680h160v80H280q-50 0-85 35t-35 85q0 50 35 85t85 35h160v80ZM320-440v-80h320v80H320Zm200 160v-80h160q50 0 85-35t35-85q0-50-35-85t-85-35H520v-80h160q83 0 141.5 58.5T880-480q0 83-58.5 141.5T680-280H520Z"/></svg>
-								<span style="align-content: center;">
-									<?php echo $LANG['COPY_LINK']; ?>
-								</span>
-						</span>
-					</button>
-				</div>
+					
 				<?php
 			}
 			?>
@@ -126,7 +124,7 @@ else{
 				}
 				else{
 					?>
-					<div class="fieldDiv" title="<?php echo $LANG['SEPARATE_RANGES']; ?>">
+					<div class="fieldDiv " title="<?php echo $LANG['SEPARATE_RANGES']; ?>">
 						<label for="q_othercatalognumbers"><?php echo $LANG['OTHER_CAT_NUMS']; ?>:</label>
 						<input type="text" name="q_othercatalognumbers" id="q_othercatalognumbers" value="<?php echo $qOtherCatalogNumbers; ?>" />
 					</div>
@@ -138,20 +136,18 @@ else{
 			if(!$crowdSourceMode){
 				?>
 				<div class="fieldGroupDiv">
-					<div class="fieldDiv" style="<?php echo ($isGenObs?'display:none':''); ?>">
+					<div class="fieldDiv" style="display: flex; align-items: center; <?php echo ($isGenObs?'display:none':''); ?>">
 						<label for="q_recordenteredby"><?php echo $LANG['ENTERED_BY']; ?>:</label>
-						<input type="text" name="q_recordenteredby" id="q_recordenteredby" value="<?php echo $qRecordEnteredBy; ?>" style="width:70px;" onchange="setOrderBy(this)" />
-					</div>
-					<div>
-						<button type="button" onclick="enteredByCurrentUser()" style="font-size:70%" title="<?php echo $LANG['LIMIT_TO_CURRENT']; ?>"><?php echo $LANG['CU']; ?></button>
-					</div>
-					<div class="fieldDiv" title="<?php echo $LANG['ENTER_RANGES']; ?>">
-						<label for="q_dateentered"><?php echo $LANG['DATE_ENTERED']; ?>:</label>
-						<input type="text" name="q_dateentered" id="q_dateentered" value="<?php echo $qDateEntered; ?>" style="width:160px" onchange="setOrderBy(this)" />
-					</div>
-					<div class="fieldDiv" title="<?php echo $LANG['ENTER_RANGES']; ?>">
-						<label for="q_datelastmodified"><?php echo $LANG['DATE_MODIFIED']; ?>:</label>
-						<input type="text" name="q_datelastmodified" id="q_datelastmodified" value="<?php echo $qDateLastModified; ?>" style="width:160px" onchange="setOrderBy(this)" />
+						<input class="left-breathing-room-rel" type="text" name="q_recordenteredby" id="q_recordenteredby" value="<?php echo $qRecordEnteredBy; ?>" style="max-width:70px;" onchange="setOrderBy(this)" />
+						<div>
+							<button class="left-breathing-room-rel" type="button" onclick="enteredByCurrentUser()" style="font-size:70%" title="<?php echo $LANG['LIMIT_TO_CURRENT']; ?>"><?php echo $LANG['CU']; ?></button>
+						</div>
+							<label title="<?php echo $LANG['ENTER_RANGES']; ?>" class="left-breathing-room-rel" for="q_dateentered"><?php echo $LANG['DATE_ENTERED']; ?>:</label>
+							<input class="left-breathing-room-rel" type="text" name="q_dateentered" id="q_dateentered" value="<?php echo $qDateEntered; ?>" style="width:160px" onchange="setOrderBy(this)" />
+							<div title="<?php echo $LANG['ENTER_RANGES']; ?>">
+								<label class="left-breathing-room-rel" for="q_datelastmodified"><?php echo $LANG['DATE_MODIFIED']; ?>:</label>
+								<input class="left-breathing-room-rel" type="text" name="q_datelastmodified" id="q_datelastmodified" value="<?php echo $qDateLastModified; ?>" style="width:160px" onchange="setOrderBy(this)" />
+							</div>
 					</div>
 				</div>
 				<div class="fieldGroupDiv">

--- a/collections/editor/occurrencetabledisplay.php
+++ b/collections/editor/occurrencetabledisplay.php
@@ -145,7 +145,7 @@ else{
 		table.styledtable td { white-space: nowrap; }
 		fieldset{ padding:15px }
 		fieldset > legend{ font-weight:bold }
-		.fieldGroupDiv{ clear:both; margin-bottom:2px; overflow: auto}
+		.fieldGroupDiv{ clear:both; margin-bottom: 1rem; overflow: auto}
 		.fieldDiv{ float:left; margin-right: 1rem;}
 		#innertext{ background-color: white; margin: 0px 10px; }
 		.editimg{ width: 15px; }

--- a/collections/editor/occurrencetabledisplay.php
+++ b/collections/editor/occurrencetabledisplay.php
@@ -146,7 +146,7 @@ else{
 		fieldset{ padding:15px }
 		fieldset > legend{ font-weight:bold }
 		.fieldGroupDiv{ clear:both; margin-bottom:2px; overflow: auto}
-		.fieldDiv{ float:left; margin-right: 20px}
+		.fieldDiv{ float:left; margin-right: 1rem;}
 		#innertext{ background-color: white; margin: 0px 10px; }
 		.editimg{ width: 15px; }
 		.accessible-font {

--- a/content/lang/collections/editor/includes/queryform.en.php
+++ b/content/lang/collections/editor/includes/queryform.en.php
@@ -130,5 +130,5 @@ $LANG['CUSTOM_VALUE'] = 'Custom Value';
 $LANG['CLOSE_PAREN_FIELD'] = 'Close Parentheses Field';
 $LANG['NEW_CUSTOM_FIELD'] = 'Add another custom field';
 $LANG['ORDER_BY'] = 'Order by';
-$LANG['IMG_EDIT'] = 'Edit Button';
+$LANG['IMG_EDIT'] = 'Add New Custom Field';
 ?>

--- a/content/lang/collections/editor/includes/queryform.en.php
+++ b/content/lang/collections/editor/includes/queryform.en.php
@@ -130,5 +130,5 @@ $LANG['CUSTOM_VALUE'] = 'Custom Value';
 $LANG['CLOSE_PAREN_FIELD'] = 'Close Parentheses Field';
 $LANG['NEW_CUSTOM_FIELD'] = 'Add another custom field';
 $LANG['ORDER_BY'] = 'Order by';
-$LANG['IMG_EDIT'] = 'Add New Custom Field';
+$LANG['ADD_CUSTOM_FIELD'] = 'Add New Custom Field';
 ?>

--- a/content/lang/collections/editor/includes/queryform.es.php
+++ b/content/lang/collections/editor/includes/queryform.es.php
@@ -130,5 +130,5 @@ $LANG['CUSTOM_VALUE'] = 'Valor personalizado';
 $LANG['CLOSE_PAREN_FIELD'] = 'Cerrar campo entre paréntesis';
 $LANG['NEW_CUSTOM_FIELD'] = 'Agregar otro campo personalizado';
 $LANG['ORDER_BY'] = 'Ordenar por';
-$LANG['IMG_EDIT'] = 'Botón Editar';
+$LANG['ADD_CUSTOM_FIELD'] = 'Agregar Nuevo Filtro de Búsqueda Personalizado';
 ?>

--- a/content/lang/collections/editor/includes/queryform.fr.php
+++ b/content/lang/collections/editor/includes/queryform.fr.php
@@ -130,5 +130,5 @@ $LANG['CUSTOM_VALUE'] = 'Valeur personnalisée';
 $LANG['CLOSE_PAREN_FIELD'] = 'Fermer le champ des parenthèses';
 $LANG['NEW_CUSTOM_FIELD'] = 'Ajouter un autre champ personnalisé';
 $LANG['ORDER_BY'] = 'Trier par';
-$LANG['IMG_EDIT'] = 'Bouton Modifier';
+$LANG['ADD_CUSTOM_FIELD'] = 'Ajouter un Nouveau Filtre de Recherche Personnalisé';
 ?>


### PR DESCRIPTION
# Description

This PR makes the requested fixes in [this ticket](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=61354349&sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=37442788&sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Status). Specifically, it makes various aesthetic improvements to the occurrencetabledisplay:

- Makes Entered By, Date Entered, and Date Modified all on the same line (not awkwardly misaligned)
- Puts Sort By, Order By, Record Output on same line
- Unifies spacing between lines
- Changes icon after "Custom Field 1" to a plus sign instead of pencil with lines.

It also changed some translations for the plus sign.

The following look like they were already resolved by previous PRs and/or are related to the form layout that the end user has toggled.

- Put "Display Table" buttons on the same line
- Make sure that Copy Link icon is the same color as the text

# Known Issues

For the following requirement: 

- Change color of buttons -> I confirmed that these buttons are leveraging the styling in main.css:

```
button {
  background-color: var(--darkest-color);
```

, meaning that the portal-owner can modifiy the color in variables.css.

It's possible that the ticket meant that I was supposed to change this to a different color in variables.css (i.e., not "darkest-color")? But, that would affect all buttons portal-wide. Is that desired? I think button colors should be standardized across the product both for a unity of aesthetic and from a code maintainability point of view.

## Before

<img width="1552" alt="Screen Shot 2024-04-30 at 11 17 13 AM" src="https://github.com/BioKIC/Symbiota/assets/2775448/84ea0814-9ae6-470e-8d40-5f558668e82e">

## After

<img width="1552" alt="Screen Shot 2024-04-30 at 2 09 00 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/2468ec91-ff5b-456b-8367-ca8d07463562">

# QA Notes

This branch is deployed live in [https://dev001.symbiota.org/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=12](https://dev001.symbiota.org/collections/editor/occurrencetabledisplay.php?displayquery=1&collid=12)

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - This page does not seem to have any responsive features. Should be a separate ticket.
- [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
    - There is a bit of in-line styling that I added to this. queryForm.php doesn't seem to have a css file of its own nor a <style> element in it. Happy to add one if it feels warranted, but to me it did not.
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/BioKIC/Symbiota/issues/1188](https://github.com/BioKIC/Symbiota/issues/1188)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
