### PR TITLE
Data Import bug fix

### DIFF
--- a/classes/SpecUpload.php
+++ b/classes/SpecUpload.php
@@ -342,7 +342,7 @@ class SpecUpload{
 				$this->schemaName = $row->SchemaName;
 				$this->code = $row->code;
 				if(!$this->path) $this->path = $row->path;
-				$this->pKField = strtolower($row->pkfield);
+				$this->pKField = strtolower($row->pkfield ?? '');
 				$this->queryStr = $row->querystr;
 				$this->storedProcedure = $row->cleanupsp;
 				$this->lastUploadDate = $row->uploaddate;

--- a/collections/admin/specupload.php
+++ b/collections/admin/specupload.php
@@ -7,14 +7,8 @@ header('Content-Type: text/html; charset='.$CHARSET);
 if(!$SYMB_UID) header('Location: ../../profile/index.php?refurl=../collections/admin/specupload.php?'.htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES));
 
 $collid = filter_var($_REQUEST['collid'], FILTER_SANITIZE_NUMBER_INT);
-$uploadType = filter_var($_REQUEST['uploadtype'], FILTER_SANITIZE_NUMBER_INT);
-$uspid = array_key_exists('uspid', $_REQUEST) ? filter_var($_REQUEST['uspid'], FILTER_SANITIZE_NUMBER_INT) : '';
-
-if(strpos($uspid,'-')){
-	$tok = explode('-',$uspid);
-	$uspid = $tok[0];
-	$uploadType = $tok[1];
-}
+$uploadType = array_key_exists('uploadtype', $_REQUEST) ? filter_var($_REQUEST['uploadtype'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$uspid = array_key_exists('uspid', $_REQUEST) ? filter_var($_REQUEST['uspid'], FILTER_SANITIZE_NUMBER_INT) : 0;
 
 $DIRECTUPLOAD = 1; $SKELETAL = 7; $IPTUPLOAD = 8; $NFNUPLOAD = 9; $STOREDPROCEDURE = 4; $SCRIPTUPLOAD = 5; $SYMBIOTA = 13;
 
@@ -22,13 +16,14 @@ $duManager = new SpecUploadBase();
 
 $duManager->setCollId($collid);
 $duManager->setUspid($uspid);
-$duManager->setUploadType($uploadType);
+$duManager->readUploadParameters();
+if($uploadType) $duManager->setUploadType($uploadType);
+else $uploadType = $duManager->getUploadType();
 
 $isEditor = 0;
 if($IS_ADMIN || (array_key_exists('CollAdmin',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollAdmin']))){
 	$isEditor = 1;
 }
-$duManager->readUploadParameters();
 if($uploadType == $IPTUPLOAD || $uploadType == $SYMBIOTA){
 	if($duManager->getPath()) header('Location: specuploadmap.php?uploadtype='.$uploadType.'&uspid='.$uspid.'&collid='.$collid);
 }

--- a/collections/admin/specuploadmanagement.php
+++ b/collections/admin/specuploadmanagement.php
@@ -6,14 +6,9 @@ header('Content-Type: text/html; charset='.$CHARSET);
 
 if(!$SYMB_UID) header('Location: ../../profile/index.php?refurl=../collections/admin/specuploadmanagement.php?'.htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES));
 
+$collid = array_key_exists('collid',$_REQUEST) ? filter_var($_REQUEST['collid'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$uspid = array_key_exists('uspid',$_REQUEST) ? filter_var($_REQUEST['uspid'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $action = array_key_exists('action',$_REQUEST) ? $_REQUEST['action'] : '';
-$collid = array_key_exists('collid',$_REQUEST) ? $_REQUEST['collid'] : 0;
-$uspid = array_key_exists('uspid',$_REQUEST) ? $_REQUEST['uspid'] : 0;
-
-//Sanitation
-if(!is_numeric($collid)) $collid = 0;
-if(!is_numeric($uspid)) $uspid = 0;
-if($action && !preg_match('/^[a-zA-Z0-9\s_]+$/',$action)) $action = '';
 
 $DIRECTUPLOAD = 1; $FILEUPLOAD = 3; $STOREDPROCEDURE = 4; $SCRIPTUPLOAD = 5; $DWCAUPLOAD = 6; $SKELETAL = 7; $IPTUPLOAD = 8; $NFNUPLOAD = 9; $SYMBIOTA = 13;
 
@@ -164,7 +159,7 @@ $duManager->readUploadParameters();
 		if($collections_admin_specuploadCrumbs){
 			?>
 			<div class="navpath">
-				<a href="../../index.php"><?php echo htmlspecialchars((isset($LANG['HOME']) ? $LANG['HOME'] : 'Home'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+				<a href="../../index.php"><?= (isset($LANG['HOME']) ? $LANG['HOME'] : 'Home') ?></a> &gt;&gt;
 				<?php echo $collections_admin_specuploadCrumbs; ?>
 				<b><?php echo (isset($LANG['SPEC_LOADER']) ? $LANG['SPEC_LOADER'] : 'Specimen Loader'); ?></b>
 			</div>
@@ -174,8 +169,8 @@ $duManager->readUploadParameters();
 	else{
 		?>
 		<div class="navpath">
-			<a href="../../index.php"><?php echo htmlspecialchars((isset($LANG['HOME']) ? $LANG['HOME'] : 'Home'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
-			<a href="../misc/collprofiles.php?collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>&emode=1"><?php echo htmlspecialchars((isset($LANG['COL_MAN_PAN']) ? $LANG['COL_MAN_PAN'] : 'Collection Management Panel'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+			<a href="../../index.php"><?= (isset($LANG['HOME']) ? $LANG['HOME'] : 'Home') ?></a> &gt;&gt;
+			<a href="../misc/collprofiles.php?collid=<?= $collid ?>&emode=1"><?= (isset($LANG['COL_MAN_PAN']) ? $LANG['COL_MAN_PAN'] : 'Collection Management Panel') ?></a> &gt;&gt;
 			<b><?php echo (isset($LANG['SPEC_LOADER']) ? $LANG['SPEC_LOADER'] : 'Specimen Loader'); ?></b>
 		</div>
 		<?php
@@ -204,7 +199,7 @@ $duManager->readUploadParameters();
 						<legend style="font-weight:bold;font-size:120%;"><?php echo (isset($LANG['UP_OPT']) ? $LANG['UP_OPT'] : 'Upload Options'); ?></legend>
 						<div style="float:right;">
 							<?php
-							echo '<a href="specuploadmanagement.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '&action=addprofile"><img src="' . htmlspecialchars($CLIENT_ROOT, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '/images/add.png" style="width:1.5em;border:0px;" title="' . htmlspecialchars((isset($LANG['ADD_PROF']) ? $LANG['ADD_PROF'] : 'Add a New Upload Profile'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '" aria-label="' . htmlspecialchars((isset($LANG['ADD_PROF']) ? $LANG['ADD_PROF'] : 'Add a New Upload Profile'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '" /></a>';
+							echo '<a href="specuploadmanagement.php?collid=' . $collid . '&action=addprofile"><img src="' . $CLIENT_ROOT . '/images/add.png" style="width:1.5em;border:0px;" title="' . (isset($LANG['ADD_PROF']) ? $LANG['ADD_PROF'] : 'Add a New Upload Profile') . '" aria-label="' . (isset($LANG['ADD_PROF']) ? $LANG['ADD_PROF'] : 'Add a New Upload Profile') . '" /></a>';
 							?>
 						</div>
 						<?php
@@ -212,12 +207,11 @@ $duManager->readUploadParameters();
 						 	foreach($profileList as $id => $v){
 						 		?>
 						 		<div style="margin:10px;">
-									<input type="radio" id="uspid-<?php echo $id ?>" name="uspid-<?php echo $id ?>" value="<?php echo $id.'-'.$v['uploadtype'];?>" />
+									<input type="radio" id="uspid-<?= $id ?>" name="uspid" value="<?= $id ?>" />
 									<label for="uspid-<?php echo $id ?>"> <?php echo $v['title']; ?> </label>
-									<a href="specuploadmanagement.php?action=editprofile&collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '&uspid=' . htmlspecialchars($id, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" title="<?php echo htmlspecialchars((isset($LANG['VIEW_PARS']) ? $LANG['VIEW_PARS'] : 'View/Edit Parameters'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" aria-label="<?php echo htmlspecialchars((isset($LANG['VIEW_PARS']) ? $LANG['VIEW_PARS'] : 'View/Edit Parameters'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>">
-										<img src="../../images/edit.png" style="width:1.2em;" alt="<?php echo htmlspecialchars((isset($LANG['IMG_EDIT']) ? $LANG['IMG_EDIT'] : 'Edit Image'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>"/>
+									<a href="specuploadmanagement.php?action=editprofile&collid=<?= $collid . '&uspid=' . filter_var($id, FILTER_SANITIZE_NUMBER_INT); ?>" title="<?= (isset($LANG['VIEW_PARS']) ? $LANG['VIEW_PARS'] : 'View/Edit Parameters') ?>" aria-label="<?= (isset($LANG['VIEW_PARS']) ? $LANG['VIEW_PARS'] : 'View/Edit Parameters') ?>">
+										<img src="../../images/edit.png" style="width:1.2em;" alt="<?= (isset($LANG['IMG_EDIT']) ? $LANG['IMG_EDIT'] : 'Edit Image') ?>"/>
 									</a>
-									<input type="hidden" name="uploadtype" value="<?php echo $v['uploadtype']; ?>" />
 								</div>
 								<?php
 						 	}
@@ -232,7 +226,7 @@ $duManager->readUploadParameters();
 					 		?>
 							<div style="padding:30px;">
 								<?php echo (isset($LANG['NO_PROFS']) ? $LANG['NO_PROFS'] : 'There are no Upload Profiles associated with this collection'); ?>. <br />
-								<?php echo (isset($LANG['CLICK']) ? $LANG['CLICK'] : 'Click'); ?> <a href="specuploadmanagement.php?collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);?>&action=addprofile"><?php echo htmlspecialchars((isset($LANG['HERE']) ? $LANG['HERE'] : 'here'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> <?php echo htmlspecialchars((isset($LANG['TO_ADD']) ? $LANG['TO_ADD'] : 'to add a new profile'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>.
+								<?php echo (isset($LANG['CLICK']) ? $LANG['CLICK'] : 'Click'); ?> <a href="specuploadmanagement.php?collid=<?= $collid ?>&action=addprofile"><?= (isset($LANG['HERE']) ? $LANG['HERE'] : 'here') ?></a> <?= (isset($LANG['TO_ADD']) ? $LANG['TO_ADD'] : 'to add a new profile') ?>.
 							</div>
 							<?php
 					 	}
@@ -249,7 +243,7 @@ $duManager->readUploadParameters();
 						<legend><b><?php echo (isset($LANG['UPLOAD_PARS']) ? $LANG['UPLOAD_PARS'] : 'Upload Parameters'); ?></b></legend>
 						<div style="float:right;">
 							<?php
-							echo '<a href="specuploadmanagement.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">View All</a> ';
+							echo '<a href="specuploadmanagement.php?collid=' . $collid . '">View All</a> ';
 							?>
 						</div>
 						<form name="parameterform" action="specuploadmanagement.php" method="post" onsubmit="return checkParameterForm(this)">


### PR DESCRIPTION
- uspid (pk of saved input profile) input values sometimes contain uspid and upload type delimited by a dash, thus the sanitizing the value as an int would cause an issue. I resolved this by making sure that uspid was only submitted under that variable name. If uploadType is set via an import variable, the value is set using what was defined within the saved upload profile.
- specuploadmanagmenet.php line 215: $id was incorrectly being added to input name for uspid input element, which was causing failure of value to be transferred to specupload.php
- SpecUpload.php: avoid type warning error when db pkField value is NULL
- Removed unnecessary htmlspecialchars sanitation code on sanitized itegers, $LANG, and symbini constant variables Resolves GitHub issue: https://github.com/BioKIC/Symbiota/issues/1224

# Pull Request Checklist:

# Pre-Approval

- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
