### PR TITLE
Change the additional fields icons in occurrenceeditor

### DIFF
--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -949,8 +949,8 @@ else{
 													<a href="#" onclick="return dwcDoc('dateIdentified')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 													<input type="text" name="dateidentified" maxlength="45" value="<?php echo array_key_exists('dateidentified',$occArr)?$occArr['dateidentified']:''; ?>" onchange="fieldChanged('dateidentified');" />
 												</div>
-												<div id="idrefToggleDiv" onclick="toggle('idrefdiv');">
-													<img class="editimg" src="../../images/editplus.png">
+												<div id="idrefToggleDiv" onclick="toggle('idrefdiv');" title="<?php echo $LANG['TOGG_ADD_FIELDS'] ?>">
+													<img class="seemore" src="../../images/tochild.png" style="width:1.3em;height:1.3em">
 												</div>
 											</div>
 											<div  id="idrefdiv">
@@ -1036,8 +1036,8 @@ else{
 													<a href="#" onclick="return dwcDoc('locationID')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 													<br/>
 													<input type="text" id="locationid" name="locationid" value="<?php echo array_key_exists('locationid',$occArr)?$occArr['locationid']:''; ?>" onchange="fieldChanged('locationid');" autocomplete="off" />
-													<a id="geography1Toggle" onclick="toggle('geography1-div', 'flex');">
-														<img class="editimg" src="../../images/editplus.png">
+													<a id="geography1Toggle" onclick="toggle('geography1-div', 'flex');" title="<?php echo $LANG['TOGG_ADD_FIELDS'] ?>">
+														<img class="seemore" src="../../images/toparent.png" style="width:1.3em;height:1.3em">
 													</a>
 												</div>
 											</div>
@@ -1046,8 +1046,8 @@ else{
 												<a href="#" onclick="return dwcDoc('locality')" tabindex="-1"><img class="docimg" src="../../images/qmark.png"></a>
 												<br />
 												<textarea id="fflocality" name="locality" onchange="fieldChanged('locality');"><?php echo array_key_exists('locality',$occArr)?$occArr['locality']:''; ?></textarea>
-												<a id="localityExtraToggle" onclick="toggle('localityExtraDiv');">
-													<img class="editimg" src="../../images/editplus.png">
+												<a id="localityExtraToggle" onclick="toggle('localityExtraDiv');" title="<?php echo $LANG['TOGG_ADD_FIELDS'] ?>">
+													<img class="seemore" src="../../images/tochild.png" style="width:1.3em" />
 												</a>
 											</div>
 											<?php
@@ -1182,7 +1182,7 @@ else{
 													</div>
 												</div>
 												<div id="georefExtraToggleDiv" onclick="toggle('georefExtraDiv');">
-													<img class="editimg" src="../../images/editplus.png">
+													<img class="seemore" src="../../images/tochild.png" style="width:1.3em;height:1.3em" title="<?php echo $LANG['TOGG_ADD_FIELDS'] ?>" >
 												</div>
 											</div>
 											<?php
@@ -1301,8 +1301,8 @@ else{
 												<a href="#" onclick="return dwcDoc('occurrenceRemarks')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 												<br/>
 												<input type="text" name="occurrenceremarks" value="<?php echo array_key_exists('occurrenceremarks',$occArr)?$occArr['occurrenceremarks']:''; ?>" onchange="fieldChanged('occurrenceremarks');" title="<?php echo $LANG['OCC_REMARKS']; ?>" />
-												<span id="dynPropToggleSpan" onclick="toggle('dynamicPropertiesDiv');">
-													<img class="editimg" src="../../images/editplus.png">
+												<span id="dynPropToggleSpan" onclick="toggle('dynamicPropertiesDiv');" title="<?php echo $LANG['TOGG_ADD_FIELDS'] ?>" >
+													<img class="seemore" src="../../images/tochild.png" style="width:1.3em;height:1.3em">
 												</span>
 											</div>
 											<div id="dynamicPropertiesDiv" class="field-div" style="display:<?= empty($occArr['dynamicproperties']) ? 'none' : '' ?>">

--- a/content/lang/collections/editor/occurrenceeditor.en.php
+++ b/content/lang/collections/editor/occurrenceeditor.en.php
@@ -66,6 +66,7 @@ $LANG['LIMITED_EDITING'] = 'Limited editing rights: use determination tab to edi
 $LANG['NEED_FULL'] = 'Note: Full editing permissions are needed to edit an identification';
 $LANG['IDENTIFICATION_CONFIDENCE'] = 'ID Confidence';
 $LANG['UNDEFINED'] = 'Undefined';
+$LANG['TOGG_ADD_FIELDS'] = "Toggle Additional Field(s)";
 ///$LANG['ABSOLUTE'] = 'Absolute';
 ///$LANG['V_HIGH'] = 'Very High';
 ///$LANG['HIGH'] = 'High';

--- a/content/lang/collections/editor/occurrenceeditor.es.php
+++ b/content/lang/collections/editor/occurrenceeditor.es.php
@@ -66,6 +66,7 @@ $LANG['LIMITED_EDITING'] = 'Derechos de edición limitados: use la pestaña de d
 $LANG['NEED_FULL'] = 'Nota: Se necesitan permisos completos de edición para editar una identificación';
 $LANG['IDENTIFICATION_CONFIDENCE'] = 'ID Confidence';
 $LANG['UNDEFINED'] = 'No Identificado';
+$LANG['TOGG_ADD_FIELDS'] = "Alternar Campo(s) Adicional(es)";
 ///$LANG['ABSOLUTE'] = 'Absoluta';
 ///$LANG['V_HIGH'] = 'Muy Alta';
 ///$LANG['HIGH'] = 'Alta';

--- a/content/lang/collections/editor/occurrenceeditor.fr.php
+++ b/content/lang/collections/editor/occurrenceeditor.fr.php
@@ -66,6 +66,7 @@ $LANG['LIMITED_EDITING'] = 'Droits de modification limités: utilisez onglet de 
 $LANG['NEED_FULL'] = "Remarque: Des autorisations d'édition complètes sont nécessaires pour modifier une identification";
 $LANG['IDENTIFICATION_CONFIDENCE'] = 'Confiance du Identifié';
 $LANG['UNDEFINED'] = 'Indéfini';
+$LANG['TOGG_ADD_FIELDS'] = "Activer/Désactiver Champ(s) Supplémentaire(s)";
 ///$LANG['ABSOLUTE'] = 'Absolute';
 ///$LANG['V_HIGH'] = 'Very High';
 ///$LANG['HIGH'] = 'High';

--- a/ident/key.php
+++ b/ident/key.php
@@ -58,7 +58,7 @@ if($chars){
 <!DOCTYPE html>
 <html lang="<?php echo $LANG_TAG ?>">
 <head>
-	<title><?php echo htmlspecialchars($DEFAULT_TITLE . ' ' . $LANG['WEBKEY'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . htmlspecialchars(preg_replace('/\<[^\>]+\>/','',$dataManager->getClName()), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></title>
+	<title><?php echo htmlspecialchars($DEFAULT_TITLE . ' ' . $LANG['WEBKEY'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . ' '. htmlspecialchars(preg_replace('/\<[^\>]+\>/','',$dataManager->getClName()), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></title>
 	<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
 	include_once($SERVER_ROOT.'/includes/head.php');


### PR DESCRIPTION
# Pull Request Checklist:

The pencil and plus sign icons are not intuitive for showing more fields in the occurrence editor. I replaced them with the circle and caret icons and added titles that say they can toggle to show additional fields.

![image](https://github.com/BioKIC/Symbiota/assets/16688784/670b03a3-37a6-4e47-ac1b-1fab86086785)

In the future, I'd like these to be replaced with the opposite direction carets when the toggle is on, but that's beyond my current skill level.

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
