### PR TITLE
[3.1] - select collections from the url if present

### DIFF
--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -569,7 +569,7 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 		ul.outerWidth(this.element.outerWidth());
 	}
 	const collectionSource = <?php echo isset($collectionSource) ? json_encode($collectionSource) : 'null'; ?>;
-	const collIdsFromUrl = <?php echo isset($collIdsFromUrl) ? json_encode($collIdsFromUrl) : 'null'; ?>;
+	const collIdsFromUrl = <?php echo isset($collIdsFromUrl) ? json_encode($collIdsFromUrl) : []; ?>;
 	if (collIdsFromUrl.length > 0) {
 		uncheckEverything();
 		checkTheCollectionsThatShouldBeChecked(collIdsFromUrl);

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -12,7 +12,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/collections/search/index.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT.'/content/lang/collections/search/index.' . $LANG_TAG . '.php');
 else include_once($SERVER_ROOT . '/content/lang/collections/search/index.en.php');
 
-$catIdsFromUrl = array_key_exists("db",$_GET) ? explode(",", str_replace(array('[',']'), '', $_GET["db"])) : '';
+$collIdsFromUrl = array_key_exists("db",$_GET) ? explode(",", str_replace(array('[',']'), '', $_GET["db"])) : '';
 
 $collManager = new OccurrenceManager();
 $collectionSource = $collManager->getQueryTermStr();
@@ -569,10 +569,10 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 		ul.outerWidth(this.element.outerWidth());
 	}
 	const collectionSource = <?php echo isset($collectionSource) ? json_encode($collectionSource) : 'null'; ?>;
-	const catIdsFromUrl = <?php echo isset($catIdsFromUrl) ? json_encode($catIdsFromUrl) : 'null'; ?>;
-	if (catIdsFromUrl.length > 0) {
+	const collIdsFromUrl = <?php echo isset($collIdsFromUrl) ? json_encode($collIdsFromUrl) : 'null'; ?>;
+	if (collIdsFromUrl.length > 0) {
 		uncheckEverything();
-		checkTheCollectionsThatShouldBeChecked(catIdsFromUrl);
+		checkTheCollectionsThatShouldBeChecked(collIdsFromUrl);
 	}
 	const sanitizedCollectionSource = collectionSource.replace('db=','');
 	if (collectionSource) {

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -569,8 +569,8 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 		ul.outerWidth(this.element.outerWidth());
 	}
 	const collectionSource = <?php echo isset($collectionSource) ? json_encode($collectionSource) : 'null'; ?>;
-	const collIdsFromUrl = <?php echo isset($collIdsFromUrl) ? json_encode($collIdsFromUrl) : []; ?>;
-	if (collIdsFromUrl.length > 0) {
+	const collIdsFromUrl = <?php echo isset($collIdsFromUrl) ? json_encode($collIdsFromUrl) : 'null'; ?>;
+	if (collIdsFromUrl && Array.isArray(collIdsFromUrl) && collIdsFromUrl.length > 0) {
 		uncheckEverything();
 		checkTheCollectionsThatShouldBeChecked(collIdsFromUrl);
 	}

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -12,6 +12,8 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/collections/search/index.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT.'/content/lang/collections/search/index.' . $LANG_TAG . '.php');
 else include_once($SERVER_ROOT . '/content/lang/collections/search/index.en.php');
 
+$catIdsFromUrl = array_key_exists("db",$_GET) ? explode(",", str_replace(array('[',']'), '', $_GET["db"])) : '';
+
 $collManager = new OccurrenceManager();
 $collectionSource = $collManager->getQueryTermStr();
 
@@ -567,7 +569,19 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 		ul.outerWidth(this.element.outerWidth());
 	}
 	const collectionSource = <?php echo isset($collectionSource) ? json_encode($collectionSource) : 'null'; ?>;
+	const catIdsFromUrl = <?php echo isset($catIdsFromUrl) ? json_encode($catIdsFromUrl) : 'null'; ?>;
+	if (catIdsFromUrl.length > 0) {
+		uncheckEverything();
+		checkTheCollectionsThatShouldBeChecked(catIdsFromUrl);
+	}
 	const sanitizedCollectionSource = collectionSource.replace('db=','');
+	// if (sanitizedCollectionSource) {
+	// 	console.log('deleteMe sanitizedCollectionSource is: ');
+	// 	console.log(sanitizedCollectionSource);
+	// 	uncheckEverything();
+	// 	checkTheCollectionsThatShouldBeChecked(sanitizedCollectionSource);
+	// }
+
 
 	if(collectionSource){
 		// go through all collections and set them all to unchecked

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -575,37 +575,9 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 		checkTheCollectionsThatShouldBeChecked(catIdsFromUrl);
 	}
 	const sanitizedCollectionSource = collectionSource.replace('db=','');
-	// if (sanitizedCollectionSource) {
-	// 	console.log('deleteMe sanitizedCollectionSource is: ');
-	// 	console.log(sanitizedCollectionSource);
-	// 	uncheckEverything();
-	// 	checkTheCollectionsThatShouldBeChecked(sanitizedCollectionSource);
-	// }
-
-
-	if(collectionSource){
-		// go through all collections and set them all to unchecked
-		const collectionCheckboxes = document.querySelectorAll('input[id^="coll"]');
-		collectionCheckboxes.forEach(collection => {
-			collection.checked = false;
-		});
-
-		//go through all collections and set the parent collections to unchecked
-		const parentCollectionCheckboxes = document.querySelectorAll('input[id^="cat-"]');
-		parentCollectionCheckboxes.forEach(collection => {
-			collection.checked = false;
-		});
-
-		// set the one with collectionSource as checked
-		const targetCheckbox = document.querySelectorAll('input[id^="coll-' + sanitizedCollectionSource + '"]');
-		targetCheckbox.forEach(collection => {
-			collection.checked = true;
-		});
-		//do the same for collections with slightly different format
-		const targetCheckboxAlt = document.querySelectorAll('input[id^="collection-' + sanitizedCollectionSource + '"]');
-		targetCheckboxAlt.forEach(collection => {
-			collection.checked = true;
-		});
+	if (collectionSource) {
+		uncheckEverything();
+		checkTheCollectionsThatShouldBeChecked(sanitizedCollectionSource);
 		updateChip();
 	}
 


### PR DESCRIPTION
# Description

This PR addresses the issue brought up by James Mickley [here](https://github.com/BioKIC/Symbiota/issues/1302), where the collection IDs in the URL were not being respected on the new search page. Specifically it,

- Extracts collection IDs from the url if they exist
- Runs through the protocol of unselecting all collections and re-selecting only those in the extracted collection IDs. The methods `uncheckEverything` and `checkTheCollectionsThatShouldBeChecked` had already been created from a previous PR.
- As an aside (kind of unrelated to the issue at hand), also DRYs up the logic of `collectionSource`, which I realized contained largely the same logic as `uncheckEverything` and `checkTheCollectionsThatShouldBeChecked`.

# QA Notes

This is live in [https://dev001.symbiota.org/collections/search/index.php?db=[12,81]](https://dev001.symbiota.org/collections/search/index.php?db=[12,81]).

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/BioKIC/Symbiota/issues/1302](https://github.com/BioKIC/Symbiota/issues/1302)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A
# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
