### PR TITLE
[3.1] - burpsuite - take a stab at csrf fix in imagelib/search.php

### DIFF
--- a/classes/OpenIdProfileManager.php
+++ b/classes/OpenIdProfileManager.php
@@ -10,6 +10,7 @@ class OpenIdProfileManager extends ProfileManager{
 		$status = false;
 		unset($_SESSION['userrights']);
 		unset($_SESSION['userparams']);
+		unset($_SESSION['csrf']);
         $status = $this->authenticateUsingOidSub($sub, $provider);
         if($status){
             if(strlen($this->displayName) > 15) $this->displayName = $this->userName;

--- a/classes/ProfileManager.php
+++ b/classes/ProfileManager.php
@@ -5,6 +5,7 @@ use function PHPUnit\Framework\returnValue;
 include_once('Manager.php');
 include_once('Person.php');
 include_once('Encryption.php');
+include_once('UuidFactory.php');
 @include_once 'Mail.php';
 
 class ProfileManager extends Manager{
@@ -96,7 +97,11 @@ class ProfileManager extends Manager{
 				if($stmt->bind_param('sss', $pwdStr, $this->userName, $this->userName)){
 					$stmt->execute();
 					$stmt->bind_result($this->uid, $this->displayName, $this->userName);
-					if($stmt->fetch()) $status = true;
+					if($stmt->fetch()) {
+						$status = true;
+						$uf = new UuidFactory();
+						$_SESSION['csrf'] = $uf->getUuidV4();
+					}
 					$stmt->close();
 				}
 				else echo 'error binding parameters: '.$stmt->error;

--- a/classes/ProfileManager.php
+++ b/classes/ProfileManager.php
@@ -35,6 +35,7 @@ class ProfileManager extends Manager{
 		setcookie('SymbiotaCrumb', '', time() - 3600, ($GLOBALS['CLIENT_ROOT']?$GLOBALS['CLIENT_ROOT']:'/'));
 		unset($_SESSION['userrights']);
 		unset($_SESSION['userparams']);
+		unset($_SESSION['csrf']);
 	}
 
 	public function authenticate($pwdStr = ''){
@@ -99,8 +100,6 @@ class ProfileManager extends Manager{
 					$stmt->bind_result($this->uid, $this->displayName, $this->userName);
 					if($stmt->fetch()) {
 						$status = true;
-						$uf = new UuidFactory();
-						$_SESSION['csrf'] = $uf->getUuidV4();
 					}
 					$stmt->close();
 				}

--- a/classes/ProfileManager.php
+++ b/classes/ProfileManager.php
@@ -5,7 +5,6 @@ use function PHPUnit\Framework\returnValue;
 include_once('Manager.php');
 include_once('Person.php');
 include_once('Encryption.php');
-include_once('UuidFactory.php');
 @include_once 'Mail.php';
 
 class ProfileManager extends Manager{
@@ -98,9 +97,7 @@ class ProfileManager extends Manager{
 				if($stmt->bind_param('sss', $pwdStr, $this->userName, $this->userName)){
 					$stmt->execute();
 					$stmt->bind_result($this->uid, $this->displayName, $this->userName);
-					if($stmt->fetch()) {
-						$status = true;
-					}
+					if($stmt->fetch()) $status = true;
 					$stmt->close();
 				}
 				else echo 'error binding parameters: '.$stmt->error;

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -14,6 +14,7 @@ session_start(array('gc_maxlifetime'=>3600,'cookie_path'=>$CLIENT_ROOT,'cookie_s
 
 include_once($SERVER_ROOT.'/classes/Encryption.php');
 include_once($SERVER_ROOT.'/classes/ProfileManager.php');
+include_once($SERVER_ROOT.'/classes/UuidFactory.php');
 
 //Check session data to see if signed in
 $PARAMS_ARR = Array();				//params => 'un=egbot&dn=Edward&uid=301'
@@ -51,6 +52,12 @@ $USER_DISPLAY_NAME = (array_key_exists('dn',$PARAMS_ARR)?$PARAMS_ARR['dn']:'');
 $USERNAME = (array_key_exists('un',$PARAMS_ARR)?$PARAMS_ARR['un']:0);
 $SYMB_UID = (array_key_exists('uid',$PARAMS_ARR)?$PARAMS_ARR['uid']:0);
 $IS_ADMIN = (array_key_exists('SuperAdmin',$USER_RIGHTS)?1:0);
+
+
+// Prevent csrf attacks
+if(!isset($_SESSION['csrf'])){
+	$_SESSION['csrf'] = $uf->UuidFactory::getUuidV4();
+}
 
 //Temporarly needed so that old configuration will still work
 if(!isset($DEFAULT_LANG) && isset($defaultLang)) $DEFAULT_LANG = $defaultLang;

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -6,35 +6,20 @@ if($LANG_TAG != 'en' && !file_exists($SERVER_ROOT . '/content/lang/imagelib/sear
 include_once($SERVER_ROOT . '/content/lang/imagelib/search.' . $LANG_TAG . '.php');
 header('Content-Type: text/html; charset=' . $CHARSET);
 
-$keywords = '';
-$imageCount = 'all';
-$imageType = 0;
-$useThes = 0;
-$taxonType = 0;
-$taxaStr = '';
-$phUid = 0;
-$tagExistance = 1;
-$tag = '';
-$cntPerPage = 200;
-$action = '';
+$taxonType = isset($_REQUEST['taxontype']) ? filter_var($_REQUEST['taxontype'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$useThes = array_key_exists('usethes',$_REQUEST) ? filter_var($_REQUEST['usethes'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$taxaStr = isset($_REQUEST['taxa']) ? $_REQUEST['taxa'] : '';
+$phUid = array_key_exists('phuid',$_REQUEST) ? filter_var($_REQUEST['phuid'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$tagExistance = array_key_exists('tagExistance',$_REQUEST) ? filter_var($_REQUEST['tagExistance'], FILTER_SANITIZE_NUMBER_INT) : 1;
+$tag = array_key_exists('tag',$_REQUEST) ? $_REQUEST['tag'] : '';
+$keywords = array_key_exists('keywords',$_REQUEST) ? $_REQUEST['keywords'] : '';
+$imageCount = isset($_REQUEST['imagecount']) ? $_REQUEST['imagecount'] : 'all';
+$imageType = isset($_REQUEST['imagetype']) ? filter_var($_REQUEST['imagetype'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$pageNumber = array_key_exists('page', $_REQUEST) ? filter_var($_REQUEST['page'], FILTER_SANITIZE_NUMBER_INT) : 1;
+$cntPerPage = array_key_exists('cntperpage', $_REQUEST) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
+
+$action = $_REQUEST['submitaction'] ?? '';
 $localCsrfToken = UuidFactory::getUuidV4();
-
-
-// if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) && $_REQUEST['csrf'] == $_SESSION['csrf']){
-	$taxonType = isset($_REQUEST['taxontype']) ? filter_var($_REQUEST['taxontype'], FILTER_SANITIZE_NUMBER_INT) : 0;
-	$useThes = array_key_exists('usethes',$_REQUEST) ? filter_var($_REQUEST['usethes'], FILTER_SANITIZE_NUMBER_INT) : 0;
-	$taxaStr = isset($_REQUEST['taxa']) ? $_REQUEST['taxa'] : '';
-	$phUid = array_key_exists('phuid',$_REQUEST) ? filter_var($_REQUEST['phuid'], FILTER_SANITIZE_NUMBER_INT) : 0;
-	$tagExistance = array_key_exists('tagExistance',$_REQUEST) ? filter_var($_REQUEST['tagExistance'], FILTER_SANITIZE_NUMBER_INT) : 1;
-	$tag = array_key_exists('tag',$_REQUEST) ? $_REQUEST['tag'] : '';
-	$keywords = array_key_exists('keywords',$_REQUEST) ? $_REQUEST['keywords'] : '';
-	$imageCount = isset($_REQUEST['imagecount']) ? $_REQUEST['imagecount'] : 'all';
-	$imageType = isset($_REQUEST['imagetype']) ? filter_var($_REQUEST['imagetype'], FILTER_SANITIZE_NUMBER_INT) : 0;
-	$pageNumber = array_key_exists('page', $_REQUEST) ? filter_var($_REQUEST['page'], FILTER_SANITIZE_NUMBER_INT) : 1;
-	$cntPerPage = array_key_exists('cntperpage', $_REQUEST) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
-	
-	$action = $_REQUEST['submitaction'] ?? '';
-// }
 
 if(!$useThes && !$action) $useThes = 1;
 if(!$taxonType && isset($DEFAULT_TAXON_SEARCH)) $taxonType = $DEFAULT_TAXON_SEARCH;

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -1,23 +1,41 @@
 <?php
 include_once('../config/symbini.php');
 include_once($SERVER_ROOT . '/classes/ImageLibrarySearch.php');
+include_once($SERVER_ROOT.'/classes/UuidFactory.php');
 if($LANG_TAG != 'en' && !file_exists($SERVER_ROOT . '/content/lang/imagelib/search.' . $LANG_TAG . '.php')) $LANG_TAG = 'en';
 include_once($SERVER_ROOT . '/content/lang/imagelib/search.' . $LANG_TAG . '.php');
 header('Content-Type: text/html; charset=' . $CHARSET);
 
-$taxonType = isset($_REQUEST['taxontype']) ? filter_var($_REQUEST['taxontype'], FILTER_SANITIZE_NUMBER_INT) : 0;
-$useThes = array_key_exists('usethes',$_REQUEST) ? filter_var($_REQUEST['usethes'], FILTER_SANITIZE_NUMBER_INT) : 0;
-$taxaStr = isset($_REQUEST['taxa']) ? $_REQUEST['taxa'] : '';
-$phUid = array_key_exists('phuid',$_REQUEST) ? filter_var($_REQUEST['phuid'], FILTER_SANITIZE_NUMBER_INT) : 0;
-$tagExistance = array_key_exists('tagExistance',$_REQUEST) ? filter_var($_REQUEST['tagExistance'], FILTER_SANITIZE_NUMBER_INT) : 1;
-$tag = array_key_exists('tag',$_REQUEST) ? $_REQUEST['tag'] : '';
-$keywords = array_key_exists('keywords',$_REQUEST) ? $_REQUEST['keywords'] : '';
-$imageCount = isset($_REQUEST['imagecount']) ? $_REQUEST['imagecount'] : 'all';
-$imageType = isset($_REQUEST['imagetype']) ? filter_var($_REQUEST['imagetype'], FILTER_SANITIZE_NUMBER_INT) : 0;
-$pageNumber = array_key_exists('page', $_REQUEST) ? filter_var($_REQUEST['page'], FILTER_SANITIZE_NUMBER_INT) : 1;
-$cntPerPage = array_key_exists('cntperpage', $_REQUEST) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
+$keywords = '';
+$imageCount = 'all';
+$imageType = 0;
+$useThes = 0;
+$taxonType = 0;
+$taxaStr = '';
+$phUid = 0;
+$tagExistance = 1;
+$tag = '';
+$cntPerPage = 200;
+$action = '';
+$uf = new UuidFactory();
+$localCsrfToken = $uf->getUuidV4();
 
-$action = $_REQUEST['submitaction'] ?? '';
+
+if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) && $_REQUEST['csrf'] == $_SESSION['csrf']){
+	$taxonType = isset($_REQUEST['taxontype']) ? filter_var($_REQUEST['taxontype'], FILTER_SANITIZE_NUMBER_INT) : 0;
+	$useThes = array_key_exists('usethes',$_REQUEST) ? filter_var($_REQUEST['usethes'], FILTER_SANITIZE_NUMBER_INT) : 0;
+	$taxaStr = isset($_REQUEST['taxa']) ? $_REQUEST['taxa'] : '';
+	$phUid = array_key_exists('phuid',$_REQUEST) ? filter_var($_REQUEST['phuid'], FILTER_SANITIZE_NUMBER_INT) : 0;
+	$tagExistance = array_key_exists('tagExistance',$_REQUEST) ? filter_var($_REQUEST['tagExistance'], FILTER_SANITIZE_NUMBER_INT) : 1;
+	$tag = array_key_exists('tag',$_REQUEST) ? $_REQUEST['tag'] : '';
+	$keywords = array_key_exists('keywords',$_REQUEST) ? $_REQUEST['keywords'] : '';
+	$imageCount = isset($_REQUEST['imagecount']) ? $_REQUEST['imagecount'] : 'all';
+	$imageType = isset($_REQUEST['imagetype']) ? filter_var($_REQUEST['imagetype'], FILTER_SANITIZE_NUMBER_INT) : 0;
+	$pageNumber = array_key_exists('page', $_REQUEST) ? filter_var($_REQUEST['page'], FILTER_SANITIZE_NUMBER_INT) : 1;
+	$cntPerPage = array_key_exists('cntperpage', $_REQUEST) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
+	
+	$action = $_REQUEST['submitaction'] ?? '';
+}
 
 if(!$useThes && !$action) $useThes = 1;
 if(!$taxonType && isset($DEFAULT_TAXON_SEARCH)) $taxonType = $DEFAULT_TAXON_SEARCH;
@@ -34,7 +52,9 @@ $imgLibManager->setTag($tag);
 $imgLibManager->setKeywords($keywords);
 $imgLibManager->setImageCount($imageCount);
 $imgLibManager->setImageType($imageType);
-if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
+if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) &&  $_REQUEST['csrf'] == $_SESSION['csrf']){
+	if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
+}
 
 $statusStr = '';
 if($action == 'batchAssignTag'){
@@ -129,6 +149,7 @@ if($action == 'batchAssignTag'){
 	<div role="main" id="innertext">
 		<h1 class="page-heading"><?= $LANG['IMAGE_SEARCH']; ?></h1>
 		<form name="imagesearchform" id="imagesearchform" action="search.php?<?=$imgLibManager->getQueryTermStr()?>" method="post">
+			<input name="csrf" type="hidden" value="<?php echo $_SESSION['csrf'] ?? $localCsrfToken; ?>" />
 			<?php
 			if($statusStr){
 				echo '<div id="action-status-div">' . $statusStr . '</div>';

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -17,11 +17,11 @@ $tagExistance = 1;
 $tag = '';
 $cntPerPage = 200;
 $action = '';
-$uf = new UuidFactory();
-$localCsrfToken = $uf->getUuidV4();
+// $uf = new UuidFactory();
+$localCsrfToken = UuidFactory::getUuidV4();
 
 
-if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) && $_REQUEST['csrf'] == $_SESSION['csrf']){
+// if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) && $_REQUEST['csrf'] == $_SESSION['csrf']){
 	$taxonType = isset($_REQUEST['taxontype']) ? filter_var($_REQUEST['taxontype'], FILTER_SANITIZE_NUMBER_INT) : 0;
 	$useThes = array_key_exists('usethes',$_REQUEST) ? filter_var($_REQUEST['usethes'], FILTER_SANITIZE_NUMBER_INT) : 0;
 	$taxaStr = isset($_REQUEST['taxa']) ? $_REQUEST['taxa'] : '';
@@ -35,7 +35,7 @@ if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) && $_REQUEST['csrf'] == 
 	$cntPerPage = array_key_exists('cntperpage', $_REQUEST) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
 	
 	$action = $_REQUEST['submitaction'] ?? '';
-}
+// }
 
 if(!$useThes && !$action) $useThes = 1;
 if(!$taxonType && isset($DEFAULT_TAXON_SEARCH)) $taxonType = $DEFAULT_TAXON_SEARCH;
@@ -52,12 +52,12 @@ $imgLibManager->setTag($tag);
 $imgLibManager->setKeywords($keywords);
 $imgLibManager->setImageCount($imageCount);
 $imgLibManager->setImageType($imageType);
-if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) &&  $_REQUEST['csrf'] == $_SESSION['csrf']){
+// if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) &&  $_REQUEST['csrf'] == $_SESSION['csrf']){
 	if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
-}
+// }
 
 $statusStr = '';
-if($action == 'batchAssignTag'){
+if($action == 'batchAssignTag' && isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) &&  $_REQUEST['csrf'] == $_SESSION['csrf']){
 	$statusCnt = $imgLibManager->batchAssignImageTag($_POST);
 	$statusArr = explode('-', $statusCnt);
 	if(isset($statusArr[0]) && is_numeric($statusArr[0])){

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -36,9 +36,7 @@ $imgLibManager->setTag($tag);
 $imgLibManager->setKeywords($keywords);
 $imgLibManager->setImageCount($imageCount);
 $imgLibManager->setImageType($imageType);
-// if(isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) &&  $_REQUEST['csrf'] == $_SESSION['csrf']){
-	if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
-// }
+if(isset($_REQUEST['db'])) $imgLibManager->setCollectionVariables($_REQUEST);
 
 $statusStr = '';
 if($action == 'batchAssignTag' && isset($_REQUEST['csrf']) && isset($_SESSION['csrf']) &&  $_REQUEST['csrf'] == $_SESSION['csrf']){

--- a/imagelib/search.php
+++ b/imagelib/search.php
@@ -8,7 +8,7 @@ header('Content-Type: text/html; charset=' . $CHARSET);
 
 $taxonType = isset($_REQUEST['taxontype']) ? filter_var($_REQUEST['taxontype'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $useThes = array_key_exists('usethes',$_REQUEST) ? filter_var($_REQUEST['usethes'], FILTER_SANITIZE_NUMBER_INT) : 0;
-$taxaStr = isset($_REQUEST['taxa']) ? $_REQUEST['taxa'] : '';
+$taxaStr = isset($_REQUEST['taxa']) ? htmlspecialchars($_REQUEST['taxa'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) : '';
 $phUid = array_key_exists('phuid',$_REQUEST) ? filter_var($_REQUEST['phuid'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $tagExistance = array_key_exists('tagExistance',$_REQUEST) ? filter_var($_REQUEST['tagExistance'], FILTER_SANITIZE_NUMBER_INT) : 1;
 $tag = array_key_exists('tag',$_REQUEST) ? $_REQUEST['tag'] : '';
@@ -16,7 +16,7 @@ $keywords = array_key_exists('keywords',$_REQUEST) ? $_REQUEST['keywords'] : '';
 $imageCount = isset($_REQUEST['imagecount']) ? $_REQUEST['imagecount'] : 'all';
 $imageType = isset($_REQUEST['imagetype']) ? filter_var($_REQUEST['imagetype'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $pageNumber = array_key_exists('page', $_REQUEST) ? filter_var($_REQUEST['page'], FILTER_SANITIZE_NUMBER_INT) : 1;
-$cntPerPage = array_key_exists('cntperpage', $_REQUEST) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
+$cntPerPage = array_key_exists('cntperpage', $_REQUEST) && is_numeric($_REQUEST['cntperpage']) ? filter_var($_REQUEST['cntperpage'], FILTER_SANITIZE_NUMBER_INT) : 200;
 
 $action = $_REQUEST['submitaction'] ?? '';
 $localCsrfToken = UuidFactory::getUuidV4();

--- a/includes/header_template.php
+++ b/includes/header_template.php
@@ -4,10 +4,15 @@ else include_once($SERVER_ROOT . '/content/lang/header.' . $LANG_TAG . '.php');
 include_once($SERVER_ROOT . '/includes/head.php');
 
 include_once($SERVER_ROOT . '/classes/ProfileManager.php');
+include_once($SERVER_ROOT.'/classes/UuidFactory.php');
 $pHandler = new ProfileManager();
 $isAccessiblePreferred = $pHandler->getAccessibilityPreference($SYMB_UID);
 $SHOULD_USE_HARVESTPARAMS = $SHOULD_USE_HARVESTPARAMS ?? false;
 $collectionSearchPage = $SHOULD_USE_HARVESTPARAMS ? '/collections/index.php' : '/collections/search/index.php';
+$uf = new UuidFactory();
+if(!isset($_SESSION['csrf'])){
+	$_SESSION['csrf'] = $uf->getUuidV4();
+}
 ?>
 <div class="header-wrapper">
 	<header>

--- a/includes/header_template.php
+++ b/includes/header_template.php
@@ -4,15 +4,10 @@ else include_once($SERVER_ROOT . '/content/lang/header.' . $LANG_TAG . '.php');
 include_once($SERVER_ROOT . '/includes/head.php');
 
 include_once($SERVER_ROOT . '/classes/ProfileManager.php');
-include_once($SERVER_ROOT.'/classes/UuidFactory.php');
 $pHandler = new ProfileManager();
 $isAccessiblePreferred = $pHandler->getAccessibilityPreference($SYMB_UID);
 $SHOULD_USE_HARVESTPARAMS = $SHOULD_USE_HARVESTPARAMS ?? false;
 $collectionSearchPage = $SHOULD_USE_HARVESTPARAMS ? '/collections/index.php' : '/collections/search/index.php';
-$uf = new UuidFactory();
-if(!isset($_SESSION['csrf'])){
-	$_SESSION['csrf'] = $uf->getUuidV4();
-}
 ?>
 <div class="header-wrapper">
 	<header>


### PR DESCRIPTION
# Description

This PR attempts to address a Cross-site request forgery highlighted by burpsuite in /imagelib/search.php. I have to confess that I was quite unfamiliar with this vulnerability and its solution, but I've given it a shot. I suppose we'll know one way or the other whether it was successful after a fresh burpsuite run?

To offer more context, burpsuite recommended the following resolution, which I've tried to implement:

> The most effective way to protect against CSRF vulnerabilities is to include within relevant requests an additional token that is not transmitted in a cookie: for example, a parameter in a hidden form field. This additional token should contain sufficient entropy, and be generated using a cryptographic random number generator, such that it is not feasible for an attacker to determine or predict the value of any token that was issued to another user. The token should be associated with the user's session, and the application should validate that the correct token is received before performing any action resulting from the request.

Specifically, this PR:

- Establishes default values for the values extracted from the $_REQUEST object in imagelib/search.php, so that there are no errors even if the csrf equality criteria are not met.
- Extracts the "real" values (if they exist) from the $_REQUEST object in imagelib/search.php ONLY if the csrf token submitted with the form matches the one that currently exists for the user's session.
- Similarly, passes the $_REQUEST object to the setCollectionVariables method ONLY if the csrf token submitted with the form matches the one that currently exists for the user's session.
- Defaults to a random $localCsrfToken value in the hidden form field if the 'csrf' token is missing from the session (only to prevent it from being an easily guessable `''`).
- Sets a new csrf token to the user's session in the header if it's missing, so that even users using the image search without logging in can have a csfr token. 
- Removes the token when a user logs out.
- Removes the csrf token from the user's session when they're using openId, even if authentication is not successful per the existing pattern in classes/OpenIdProfileManager.php.


If this PR successfully resolves the vulnerability, other pages with the same vulnerability could be more easily resolved (by passing a csfr token in a hidden input field for the vulnerable pages/forms/$_REQUEST objects and then ensuring it matches the token in the user session before extracting values from the $_REQUEST object) with the already-established infrastructure herein.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=25403328](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=25403328)
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
