### PR TITLE
3.1 new search to list display

### DIFF
--- a/collections/list.php
+++ b/collections/list.php
@@ -181,6 +181,7 @@ $_SESSION['citationvar'] = $searchVar;
 						}
 						?>
 						<form action="listtabledisplay.php" method="post" style="float:left">
+							<input name="comingFrom" type="hidden" value="<?php echo $comingFrom; ?>" />
 							<button class="icon-button" aria-label="<?php echo (isset($LANG['TABLE_DISPLAY']) ? $LANG['TABLE_DISPLAY'] : 'Table Display'); ?>" title="<?php echo (isset($LANG['TABLE_DISPLAY']) ? $LANG['TABLE_DISPLAY'] : 'Table Display'); ?>">
 								<svg style="width:1.3em;height:1.3em" alt="<?php echo $LANG['IMG_TABLE_DISPLAY']; ?>" xmlns="http://www.w3.org/2000/svg" fill="var(--light-color)" height="24" viewBox="0 -960 960 960" width="24"><path d="M120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200q-33 0-56.5-23.5T120-200Zm80-400h560v-160H200v160Zm213 200h134v-120H413v120Zm0 200h134v-120H413v120ZM200-400h133v-120H200v120Zm427 0h133v-120H627v120ZM200-200h133v-120H200v120Zm427 0h133v-120H627v120Z"/></svg>
 							</button>

--- a/collections/listtabledisplay.php
+++ b/collections/listtabledisplay.php
@@ -160,8 +160,12 @@ $searchVar = $collManager->getQueryTermStr();
 			</div>
 			<div class="navpath">
 				<a href="../index.php"><?php echo htmlspecialchars((isset($LANG['NAV_HOME']) ? $LANG['NAV_HOME'] : 'Home'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
-				<a href="index.php"><?php echo htmlspecialchars((isset($LANG['NAV_COLLECTIONS']) ? $LANG['NAV_COLLECTIONS'] : 'Collections'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
-				<a href="<?php echo $actionPage ?>"><?php echo htmlspecialchars((isset($LANG['NAV_SEARCH']) ? $LANG['NAV_SEARCH'] : 'Search Criteria'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+				<?php if($comingFrom !== 'search/index.php'){ ?>
+					<a href="index.php"><?php echo htmlspecialchars((isset($LANG['NAV_COLLECTIONS']) ? $LANG['NAV_COLLECTIONS'] : 'Collections'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+					<a href="<?php echo $CLIENT_ROOT . '/collections/harvestparams.php' ?>"><?php echo htmlspecialchars((isset($LANG['NAV_SEARCH']) ? $LANG['NAV_SEARCH'] : 'Search Criteria'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+				<?php }else{ ?>
+					<a href="<?php echo $CLIENT_ROOT . '/collections/search/index.php' ?>"><?php echo htmlspecialchars((isset($LANG['NAV_SEARCH']) ? $LANG['NAV_SEARCH'] : 'Search Criteria'), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+				<?php } ?>
 				<b><?php echo (isset($LANG['SPEC_REC_TAB']) ? $LANG['SPEC_REC_TAB'] : 'Specimen Records Table'); ?></b>
 			</div>
 		</div>

--- a/collections/listtabledisplay.php
+++ b/collections/listtabledisplay.php
@@ -7,6 +7,7 @@ header("Content-Type: text/html; charset=".$CHARSET);
 $SHOULD_INCLUDE_CULTIVATED_AS_DEFAULT = $SHOULD_INCLUDE_CULTIVATED_AS_DEFAULT ?? false;
 $SHOULD_USE_HARVESTPARAMS = $SHOULD_USE_HARVESTPARAMS ?? false;
 $actionPage = $SHOULD_USE_HARVESTPARAMS ? "harvestparams.php" : "./search/index.php";
+$comingFrom = array_key_exists('comingFrom', $_REQUEST) ? htmlspecialchars($_REQUEST['comingFrom'], HTML_SPECIAL_CHARS_FLAGS) : '';
 
 $page = array_key_exists('page',$_REQUEST) ? $_REQUEST['page'] : 1;
 $tableCount= array_key_exists('tablecount',$_REQUEST) ? $_REQUEST['tablecount'] : 1000;
@@ -67,7 +68,8 @@ $searchVar = $collManager->getQueryTermStr();
 				</div>
 				-->
 				<form action="list.php" method="post" style="float:left">
-					<button class="ui-button ui-widget ui-corner-all" style="margin:5px;padding:5px;" title="<?php echo (isset($LANG['LIST_DISPLAY']) ? $LANG['LIST_DISPLAY'] : 'List Display'); ?>"  aria-label="<?php echo (isset($LANG['LIST_DISPLAY']) ? $LANG['LIST_DISPLAY'] : 'List Display'); ?>">
+					<input name="comingFrom" type="hidden" value="<?php echo $comingFrom; ?>" />
+					<button type="submit" class="ui-button ui-widget ui-corner-all" style="margin:5px;padding:5px;" title="<?php echo (isset($LANG['LIST_DISPLAY']) ? $LANG['LIST_DISPLAY'] : 'List Display'); ?>"  aria-label="<?php echo (isset($LANG['LIST_DISPLAY']) ? $LANG['LIST_DISPLAY'] : 'List Display'); ?>">
 						<img src="<?php echo $CLIENT_ROOT; ?>/images/list_FILL0_wght400_GRAD0_opsz24.svg" style="width:1.3em" alt="<?php echo (isset($LANG['LIST_DISPLAY']) ? $LANG['LIST_DISPLAY'] : 'List Display'); ?>"/>
 					</button>
 					<input name="searchvar" type="hidden" value="<?php echo $searchVar; ?>" />

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -530,6 +530,19 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 
 			<!-- Criteria panel -->
 			<div id="criteria-panel" style="position: sticky; top: 0; height: 100vh">
+			<fieldset class="bottom-breathing-room-rel">
+				<legend>
+					<?php echo $LANG['DISPLAY_FORMAT']; ?>
+				</legend>
+				<div style="display: flex; align-items: center;" class="bottom-breathing-room-rel">
+					<input style="margin-bottom:0; margin-right: 0.5rem;" name="display-format-pref" id="list-button" type="radio" value="list" checked />
+					<label for="list-button"><?php echo $LANG['LIST'] ?></label>
+				</div>
+				<div style="display: flex; align-items: center;">
+					<input style="margin-bottom:0; margin-right: 0.5rem;" name="display-format-pref" id="table-button" type="radio" value="table" /> 	
+					<label for="table-button"><?php echo $LANG['TABLE'] ?></label>
+				</div>
+			</fieldset>
 				<button id="search-btn" onclick="simpleSearch()"><?php echo $LANG['SEARCH'] ?></button>
 				<button id="reset-btn"><?php echo $LANG['RESET'] ?></button>
 				<h2><?php echo $LANG['CRITERIA'] ?></h2>

--- a/collections/search/js/searchform.js
+++ b/collections/search/js/searchform.js
@@ -568,7 +568,6 @@ function getSearchUrl() {
     formatPreference === "list" ? "list.php" : "listtabledisplay.php";
 
   const baseUrl = new URL(harvestUrl + urlSuffix);
-  console.log("deleteMe baseUrl is: " + baseUrl);
 
   // Clears array temporarily to avoid redundancy
   paramsArr = [];
@@ -708,7 +707,7 @@ function simpleSearch() {
   let isValid = errors.length == 0;
   if (isValid) {
     let searchUrl = getSearchUrl();
-    window.location = searchUrl; // @TODO comment back in
+    window.location = searchUrl;
   } else {
     handleValErrors(errors);
   }

--- a/collections/search/js/searchform.js
+++ b/collections/search/js/searchform.js
@@ -560,8 +560,15 @@ function getParam(paramName) {
  * Define parameters to be looked for in `paramNames` array
  */
 function getSearchUrl() {
+  const formatPreference = document.getElementById("list-button").checked
+    ? "list"
+    : "table";
   const harvestUrl = location.href.slice(0, location.href.indexOf("search"));
-  const baseUrl = new URL(harvestUrl + "list.php");
+  const urlSuffix =
+    formatPreference === "list" ? "list.php" : "listtabledisplay.php";
+
+  const baseUrl = new URL(harvestUrl + urlSuffix);
+  console.log("deleteMe baseUrl is: " + baseUrl);
 
   // Clears array temporarily to avoid redundancy
   paramsArr = [];
@@ -701,7 +708,7 @@ function simpleSearch() {
   let isValid = errors.length == 0;
   if (isValid) {
     let searchUrl = getSearchUrl();
-    window.location = searchUrl;
+    window.location = searchUrl; // @TODO comment back in
   } else {
     handleValErrors(errors);
   }

--- a/content/lang/collections/sharedterms.en.php
+++ b/content/lang/collections/sharedterms.en.php
@@ -26,4 +26,7 @@ $LANG['COPY_TO_CLIPBOARD'] = 'Copy URL to Clipboard';
 
 $LANG['BUTTON_RESET'] = 'Reset Form';
 $LANG['SEARCH'] = 'Search';
+$LANG['DISPLAY_FORMAT'] = 'Results Display Format';
+$LANG['LIST'] = 'List';
+$LANG['TABLE'] = 'Table';
 ?>

--- a/content/lang/collections/sharedterms.es.php
+++ b/content/lang/collections/sharedterms.es.php
@@ -26,4 +26,7 @@ $LANG['COPY_TO_CLIPBOARD'] = 'Copia URL al Portapapeles';
 
 $LANG['BUTTON_RESET'] = 'Restablecer';
 $LANG['SEARCH'] = 'Buscar';
+$LANG['DISPLAY_FORMAT'] = 'Formato de Visualización de Resultados';
+$LANG['LIST'] = 'Lista';
+$LANG['TABLE'] = 'Tabla de Datos';
 ?>

--- a/content/lang/collections/sharedterms.fr.php
+++ b/content/lang/collections/sharedterms.fr.php
@@ -26,4 +26,7 @@ $LANG['COPY_TO_CLIPBOARD'] = "Copier l'URL dans le presse-papiers";
 
 $LANG['BUTTON_RESET'] = 'Réinitialiser Formulaire';
 $LANG['SEARCH'] = 'Rechercher';
+$LANG['DISPLAY_FORMAT'] = 'Format d\'Affichage des Résultats';
+$LANG['LIST'] = 'Liste';
+$LANG['TABLE'] = 'Tableau de Données';
 ?>

--- a/content/lang/collections/sharedterms.pt.php
+++ b/content/lang/collections/sharedterms.pt.php
@@ -28,5 +28,8 @@ $LANG['COPY_TO_CLIPBOARD'] = 'Copiar URL para Área de Transferência';
 
 $LANG['BUTTON_RESET'] = 'Redefinir Formulário';
 $LANG['SEARCH'] = 'Pesquisar';
+$LANG['DISPLAY_FORMAT'] = 'Formato de Exibição de Resultados';
+$LANG['LIST'] = 'Lista';
+$LANG['TABLE'] = 'Tabela de Dados';
 
 ?>


### PR DESCRIPTION
# Description

This PR adds radio buttons on the new search page that allow the end user to express a preference between list display or table display for their results. It also handles an edge case I found where the page flow and breadcrumbs were misbehaving when a user toggles between those two result views from their respective result pages. Specifically, it:

- Fixes bug in an edge case where the user navigates from list view to table view or vice versa but they're coming from the new search page. Previously, the breadcrumbs would take them back to harvestparams, but this fixes that misbehavior.
- Adds a section above the search and reset buttons that contains a set of radio buttons for result display format preference.
- Handles the logic of whichever above radio button is selected.
- Adds some translations.

# Before

<img width="1552" alt="Screenshot 2024-06-05 at 1 53 17 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/335a8e36-5b4e-4c4b-90db-2bdcd583715b">

# After

<img width="1552" alt="Screenshot 2024-06-05 at 1 46 18 PM" src="https://github.com/BioKIC/Symbiota/assets/2775448/e8d95047-7d29-45c6-9ef7-a433562f7f91">


# QA notes

This is deployed live on [https://dev001.symbiota.org/](https://dev001.symbiota.org/)

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/BioKIC/Symbiota/issues/1364](https://github.com/BioKIC/Symbiota/issues/1364)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
