### PR TITLE
USDA header text change

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -128,7 +128,7 @@ $actionPage = $SHOULD_USE_HARVESTPARAMS ? "harvestparams.php" : "./search/index.
             </g>
           </svg>
           <div class="site-branding__text">
-            <div class="site-branding__site-name" style="display:flex;"><a href="https://ars.usda.gov" title="ARS Homepage" rel="home" style="min-height:24px;">Agricultural Research Service</a></div>
+            <div class="site-branding__site-name" style="display:flex;"><a href="https://ars.usda.gov" title="ARS Homepage" rel="home" style="min-height:24px;">Biocollections of the USDA Agricultural Research Service</a></div>
               <div class="site-branding__usda" style="margin-top: 0.3rem; padding-top:0.1rem;"><a href="https://www.usda.gov">U.S. Department of Agriculture</a></div>
               </div>
             </div>


### PR DESCRIPTION
# Before:
<img width="1425" alt="Screenshot 2024-07-02 at 6 08 56 PM" src="https://github.com/BioKIC/Symbiota/assets/86389284/3c37a806-667c-4b2b-9e97-3d921d6ef25f">

# After:
<img width="1496" alt="Screenshot 2024-07-02 at 4 34 50 PM" src="https://github.com/BioKIC/Symbiota/assets/86389284/f94b9333-b5d8-4a59-9068-35913b9eda12">
<img width="581" alt="Screenshot 2024-07-02 at 4 35 10 PM" src="https://github.com/BioKIC/Symbiota/assets/86389284/f4ec4749-a135-4f79-b3eb-d5fdbb8005d5">

# Changes made:

- set text to required. Didn't do the lines separation due to text wrapping on different screen sizes not looking good.


# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address:
https://github.com/BioKIC/Symbiota/issues/1459
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
