### PR TITLE
adding variable to control menu font-size for easy customization

### DIFF
--- a/css/v202209/symbiota/header.css
+++ b/css/v202209/symbiota/header.css
@@ -327,7 +327,8 @@ ul.menu > ul li{
   }
 
   ul.menu * {
-    vertical-align: middle;
+	vertical-align: middle;
+	font-size: var(--menu-font-size);
   }
 
   ul.menu > li {

--- a/css/v202209/symbiota/header.css
+++ b/css/v202209/symbiota/header.css
@@ -155,6 +155,10 @@ header a:hover {
   display: none;
 }
 
+.menu {
+  font-size: var(--menu-font-size);
+}
+
 ul.menu,
 ul.menu ul {
   list-style: none;
@@ -328,7 +332,6 @@ ul.menu > ul li{
 
   ul.menu * {
 	vertical-align: middle;
-	font-size: var(--menu-font-size);
   }
 
   ul.menu > li {

--- a/css/v202209/symbiota/variables.css
+++ b/css/v202209/symbiota/variables.css
@@ -17,6 +17,7 @@
   --title-font-family: "Averia Serif Libre", serif;
   --logo-width: 120px;
   --menu-top-bg-color: #1b3d2f;
+  --menu-font-size: 1rem;
   --body-bg-color: #fafafa;
   --body-text-color: #000000;
   --body-font-size: 1rem;


### PR DESCRIPTION
# Issue #1530 
# Summary
Adds `--menu-font-size` variable to `variables.css` and to the menu class so that customizing portals is easier
 
# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
