### PR TITLE
change button stylings in taxonomydisplay.php

### DIFF
--- a/css/symbiota/main.css
+++ b/css/symbiota/main.css
@@ -371,6 +371,11 @@ button.icon-button:hover {
   background: var(--medium-color);
 }
 
+button.inverse-color {
+    background-color: var(--light-color);
+    color: var(--darkest-color);
+}
+
 .button {
   border: none;
   border-radius: 5px;

--- a/taxa/taxonomy/taxonomydisplay.php
+++ b/taxa/taxonomy/taxonomydisplay.php
@@ -149,12 +149,12 @@ if($IS_ADMIN || array_key_exists('Taxonomy', $USER_RIGHTS)){
 						</div>
 					</div>
 					<div class="flex-form" style="margin: 10px">
+						<div>
+							<button class="inverse-color" name="tdsubmit" type="submit" value="displayTaxonTree"><?= $LANG['DISP_TAX_TREE'] ?></button>
+							<input name="taxauthid" type="hidden" value="<?= $taxAuthId; ?>" />
+						</div>
 						<div style="float: right">
 							<button name="tdsubmit" type="submit" value="exportTaxonTree"><?= $LANG['EXPORT_TREE'] ?></button>
-						</div>
-						<div>
-							<button name="tdsubmit" type="submit" value="displayTaxonTree"><?= $LANG['DISP_TAX_TREE'] ?></button>
-							<input name="taxauthid" type="hidden" value="<?= $taxAuthId; ?>" />
 						</div>
 					</div>
 				</fieldset>


### PR DESCRIPTION
# Before:

## Condensed:
<img width="674" alt="Screenshot 2024-08-01 at 12 51 43 PM" src="https://github.com/user-attachments/assets/b6711234-c79b-473c-8e40-6b42ab5bae33">

## Accessibility:
<img width="674" alt="Screenshot 2024-08-01 at 12 51 54 PM" src="https://github.com/user-attachments/assets/97d75b10-fb64-49ef-b92e-b117c600120a">

# After:

## Condensed:
<img width="674" alt="Screenshot 2024-08-01 at 12 51 06 PM" src="https://github.com/user-attachments/assets/4201d28c-8286-4ac9-83b6-e17c0902a5a7">

## Accessibility:
<img width="674" alt="Screenshot 2024-08-01 at 12 50 51 PM" src="https://github.com/user-attachments/assets/17fed180-8880-4277-9d15-5c83e472ee78">


# Changes Made:

- created css class for button with inverted colors 
- switched location of buttons in taxonomydisplay.php

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [X] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address:
https://github.com/BioKIC/Symbiota/issues/1552
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
