### PR TITLE
Fix redundant map icon on checklist project list

### DIFF
--- a/checklists/index.php
+++ b/checklists/index.php
@@ -65,15 +65,12 @@ $clManager->setProj($pid);
 						if($pid) echo '</a>';
 						if(!empty($projArr['displayMap'])){
 							?>
-							<a href="<?php echo "clgmap.php?pid=" . $pid; ?>" title='<?= $LANG['SHOW_MAP'] ?>'>
-								<img src='../images/world.png' style='width:10px;border:0' />
+							<a class="button button-tertiary btn-medium-font" style="gap:0.5rem" href="<?= "clgmap.php?pid=" . $pid ?>" title='<?= $LANG['SHOW_MAP'] ?>'>
+								<?= $LANG['MAP'] ?> <img src='../images/world.png' style='width:1em;border:0' alt='<?= $LANG['IMG_OF_GLOBE'] ?>' />
 							</a>
 							<?php
 						}
 						?>
-						<a class="button button-tertiary btn-medium-font" style="gap:0.5rem" href="<?= "clgmap.php?pid=" . $pid ?>" title='<?= $LANG['SHOW_MAP'] ?>'>
-							<?= $LANG['MAP'] ?> <img src='../images/world.png' style='width:1em;border:0' alt='<?= $LANG['IMG_OF_GLOBE'] ?>' />
-						</a>
 					</h2>
 					<ul class="checklist-ul">
 						<?php


### PR DESCRIPTION
That also wasn't reading projArr['displayMap'] variable

See the problem as viewed on this issue: https://github.com/BioKIC/Symbiota/issues/1662

The second button was ignoring whether there were coordinates for the checklists

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] There are no linter errors
- [z] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] Comment which GitHub issue(s), if any does this PR address

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
