### PR TITLE
Upload Spec Encoding Issue

### DIFF
--- a/classes/SpecUploadBase.php
+++ b/classes/SpecUploadBase.php
@@ -1806,6 +1806,7 @@ class SpecUploadBase extends SpecUpload{
 	protected function loadRecord($recMap){
 		//Only import record if at least one of the minimal fields have data
 		$recMap = OccurrenceUtilities::occurrenceArrayCleaning($recMap);
+
 		//Prime the targetFieldArr
 		if(!$this->targetFieldArr) $this->targetFieldArr = $this->getOccurrenceFieldArr(array_keys($recMap));
 		$loadRecord = false;
@@ -2542,7 +2543,7 @@ class SpecUploadBase extends SpecUpload{
 					}
 				}
 				else{
-					$retStr = mb_convert_encoding($inStr, 'UTF-8', mb_detect_encoding($inStr));
+					$retStr = mb_convert_encoding($inStr, 'UTF-8', mb_detect_encoding($inStr, "UTF-8, ISO-8859-1, ISO-8859-15", true));
 				}
 			}
 			elseif($this->targetCharset == "ISO-8859-1"){


### PR DESCRIPTION
# Summary
Uploads from `specuploadprocessor` are encountering issues with `mb_detect_encoding` function. This seems to be an issue with differences between 8.2 and 7.3 having different default encoding lists to search through but the result is 8.2 portals will have this issue with detecting encodings. This solution works for both 7.3 and 8.2 (Did not test any others). I suspect this fall auto detect list will have to be curated some more to accommodate other potential encodings.

The problem string in question was from `verbatimcoordinates` when it was generated with the degree symbol via `char(176)` and that was confusing the encoding auto detect for some reason.

No issue but here is ticket https://help.symbiota.org/scp/tickets.php?id=4462 
# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and **squash and merged** back into the `master` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a hotfix into the `master` branch, a subsequent PR from `master` into `Development` should be made **merge** option (i.e., no squash).
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
