### PR TITLE
Occurrence Association Form Validation bug

### DIFF
--- a/collections/editor/includes/resourcetab.php
+++ b/collections/editor/includes/resourcetab.php
@@ -121,12 +121,27 @@ $dupClusterArr = $dupManager->getClusterArr($occid);
 	}
 
 	function validateAssocForm(f){
-		if(f.relationship.value == ""){
-			alert("<?php echo $LANG['DEFINE_REL']; ?>");
-			return false;
+		if(f.associationType.value == "internalOccurrence"){
+			let occidAssocChecked = false;
+			if(f.occidAssociate){
+				let assocRadios = document.querySelector('input[name = "occidAssociate"]:checked');
+				if(assocRadios != null){
+					occidAssocChecked = true;
+				}
+			}
+			if(!occidAssocChecked){
+				alert("<?= $LANG['SELECT_INTERNAL_REL'] ?>");
+				return false;
+			}
 		}
-		else if(f.resourceurl.value == "" && f.objectid.value == "" && f.verbatimsciname.value == "" && (!f.occidAssociate || f.occidAssociate.value == "")){
-			alert("<?php echo $LANG['REL_NOT_DEFINED']; ?>");
+		else if(f.associationType.value == "observational"){
+			if(f.verbatimsciname.value == ""){
+				alert("<?= $LANG['VERB_SCINAME_EMPTY'] ?>");
+				return false;
+			}
+		}
+		else if(f.resourceurl.value == ""){
+			alert("<?= $LANG['RESOURCE_EMPTY'] ?>");
 			return false;
 		}
 		return true;

--- a/content/lang/collections/editor/includes/resourcetab.en.php
+++ b/content/lang/collections/editor/includes/resourcetab.en.php
@@ -7,8 +7,9 @@ Language: English
 
 $LANG['NO_RESULTS'] = 'No results returned';
 $LANG['ERROR_UNABLE_RESULTS'] = 'ERROR: Unable to get results';
-$LANG['DEFINE_REL'] = 'Relationship needs to be defined';
-$LANG['REL_NOT_DEFINED'] = 'Related occurrence is not defined!';
+$LANG['SELECT_INTERNAL_REL'] = 'You need to search for an select an internal occurrence instance';
+$LANG['VERB_SCINAME_EMPTY'] = 'Verbatim Scientific Name needs a value';
+$LANG['RESOURCE_EMPTY'] = 'Resource URL needs needs a value';
 $LANG['SELECT_CHECKLIST'] = 'Select a checklist to which you want to link the voucher';
 $LANG['VOUCHER_CANNOT_LINK'] = 'Voucher cannot be linked to a checklist until the taxonomic name has been resolved (e.g. name not linked to taxonomic thesaurus';
 $LANG['SURE_UNLINK'] = 'Are you sure you want to unlink the record as a duplicate?';

--- a/content/lang/collections/editor/includes/resourcetab.es.php
+++ b/content/lang/collections/editor/includes/resourcetab.es.php
@@ -2,15 +2,14 @@
 /*
 ------------------
 Language: Español (Spanish)
-Translated by: Samanta Orellana
-Date Translated: 2021-10-29
+Translated by: Samanta Orellana (2021-10-29)
 ------------------
 */
-
 $LANG['NO_RESULTS'] = 'Sin resultados';
 $LANG['ERROR_UNABLE_RESULTS'] = 'ERROR: No fue posible obtener resultados';
-$LANG['DEFINE_REL'] = 'Relaciones necesitan ser definidas';
-$LANG['REL_NOT_DEFINED'] = '¡Ocurrencia relacionada no está definida!';
+$LANG['SELECT_INTERNAL_REL'] = 'Debe buscar y seleccionar una instancia de ocurrencia interna';
+$LANG['VERB_SCINAME_EMPTY'] = 'Nombre Científico Literal necesita un valor';
+$LANG['RESOURCE_EMPTY'] = 'URL del Recurso necesita un valor';
 $LANG['SELECT_CHECKLIST'] = 'Seleccionar un listado de especies al que quiera enlazar el voucher';
 $LANG['VOUCHER_CANNOT_LINK'] = 'El voucher no puede ser vinculado a un listado de especies hasta que el nombre taxonómico haya sido resuelto (e.g. nombre no vinculado al tesauro taxonómico';
 $LANG['SURE_UNLINK'] = '¿Está seguro que quiere desvincular el registro como duplicado?';

--- a/content/lang/collections/editor/includes/resourcetab.fr.php
+++ b/content/lang/collections/editor/includes/resourcetab.fr.php
@@ -7,8 +7,9 @@ Language: Français (French)
 
 $LANG['NO_RESULTS'] = 'Aucun résultat renvoyé';
 $LANG['ERROR_UNABLE_RESULTS'] ="'ERREUR: Impossible d'obtenir résultats";
-$LANG['DEFINE_REL'] = 'Relation doit être définie';
-$LANG['REL_NOT_DEFINED'] = "Occurrence associée n'est pas définie!";
+$LANG['SELECT_INTERNAL_REL'] = "Vous devez rechercher et sélectionner une instance d'occurrence interne";
+$LANG['VERB_SCINAME_EMPTY'] = 'Le nom scientifique verbatim nécessite une valeur';
+$LANG['RESOURCE_EMPTY'] = "L'URL de la ressource a besoin d'une valeur";
 $LANG['SELECT_CHECKLIST'] = 'Sélectionnez une liste à laquelle vous souhaitez lier le échantillon';
 $LANG['VOUCHER_CANNOT_LINK'] = "Le échantillon ne peut pas être lié à une liste tant que le nom taxonomique n'a pas été résolu (par exemple, le nom n'est pas lié au thésaurus taxonomique";
 $LANG['SURE_UNLINK'] = 'Voulez-vous vraiment dissocier enregistrement en tant que doublon?';


### PR DESCRIPTION
- Fix issue with internal association form validation failing and allowing for creation of an association without an internal occurrence being defined
- Add form validation for external resource and general observation
- Expand and improved language translation terms 
Addresses issue: https://github.com/BioKIC/Symbiota/issues/1852


# Pull Request Checklist:
# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
