### PR TITLE
Remove redundant css variable

### DIFF
--- a/css/symbiota/main.css
+++ b/css/symbiota/main.css
@@ -526,7 +526,7 @@ table.styledtable tr.alt td {
 ========================================================================== */
 .text-huge {
   font-size: 4rem;
-  font-family: var(--title-font-family);
+  font-family: var(--heading-font-family);
   margin: 0;
 }
 
@@ -609,7 +609,7 @@ table.styledtable tr.alt td {
 @media screen and (min-width: 2560px) {
   .text-huge {
     font-size: 5rem;
-    font-family: var(--title-font-family);
+    font-family: var(--heading-font-family);
     margin: 0;
   }
 

--- a/css/symbiota/variables.css
+++ b/css/symbiota/variables.css
@@ -5,7 +5,6 @@
   --header-bg-color: #2f6e5378; /** Transparent color if adding header bg-image **/
   --header-font-color: #fff;
   --brand-font-size: 1.5rem;
-  --title-font-family: "Open Sans", serif;
   --logo-width: 120px;
   --menu-top-bg-color: #1b3d2f;
   --menu-font-size: 1rem;


### PR DESCRIPTION
# Pull Request Checklist:
Fixes: https://github.com/BioKIC/Symbiota/issues/1583

The variable `--title-font-family` is only used for the following css (in main.css):
```
.text-huge {
font-size: 4rem;
font-family: var(--title-font-family);
margin: 0;
}

.text-huge {
font-size: 5rem;
font-family: var(--title-font-family);
margin: 0;
}
```

I couldn't find any elements with the `text-huge` class throughout the code, so it might be delete-able, but just in case it's still desired somewhere, I left it.

However, I don't see why the size of the screen should change the font of the headers (all other headers, and even the brand name, uses `--heading-font-family`. So, I changed the huge font-family to `--heading-font-family`), which is actually used throughout the code.

Alternatively, we could switch the brand name to use `--title-font-family`, which I could see being useful.



# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] Comment which GitHub issue(s), if any does this PR address

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.