### PR TITLE
Improved regex for parsing verbatim elevation values

### DIFF
--- a/classes/utilities/OccurrenceUtil.php
+++ b/classes/utilities/OccurrenceUtil.php
@@ -195,7 +195,18 @@ class OccurrenceUtil {
 			$max_elev = $m[3];
 			$unit = $m[4];
 
-			$meter_conversion = in_array($unit,['ft', 'ft.', 'feet', "'"])? 0.3048: 1;
+			$feet = ['ft', 'ft.', 'feet', 'foot' ,"'"];
+			$meter = ['meter', 'meters', 'm', 'm.'];
+
+			$meter_conversion = 0;
+
+			if(in_array($unit, $feet)) {
+				$meter_conversion = 0.3048;
+			} else if (in_array($unit, $meter)) {
+				$meter_conversion = 1;
+			} else {
+				return $retArr;
+			}
 
 			$min_elev = str_replace(',', '', $min_elev);
 			$max_elev = str_replace(',', '', $max_elev);

--- a/classes/utilities/OccurrenceUtil.php
+++ b/classes/utilities/OccurrenceUtil.php
@@ -180,41 +180,37 @@ class OccurrenceUtil {
 	 *         Keys: minelev, maxelev
 	 */
 	public static function parseVerbatimElevation($inStr){
-		$retArr = array();
-		//Start parsing
-		if(preg_match('/([\.\d]+)\s*-\s*([\.\d]+)\s*meter/i',$inStr,$m)){
-			$retArr['minelev'] = $m[1];
-			$retArr['maxelev'] = $m[2];
-		}
-		elseif(preg_match('/([\.\d]+)\s*-\s*([\.\d]+)\s*m./i',$inStr,$m)){
-			$retArr['minelev'] = $m[1];
-			$retArr['maxelev'] = $m[2];
-		}
-		elseif(preg_match('/([\.\d]+)\s*-\s*([\.\d]+)\s*m$/i',$inStr,$m)){
-			$retArr['minelev'] = $m[1];
-			$retArr['maxelev'] = $m[2];
-		}
-		elseif(preg_match('/([\.\d]+)\s*meter/i',$inStr,$m)){
-			$retArr['minelev'] = $m[1];
-		}
-		elseif(preg_match('/([\.\d]+)\s*m./i',$inStr,$m)){
-			$retArr['minelev'] = $m[1];
-		}
-		elseif(preg_match('/([\.\d]+)\s*m$/i',$inStr,$m)){
-			$retArr['minelev'] = $m[1];
-		}
-		elseif(preg_match('/([\.\d]+)[fet\']{,4}\s*-\s*([\.\d]+)\s{,1}[f\']{1}/i',$inStr,$m)){
-			if(is_numeric($m[1])) $retArr['minelev'] = (round($m[1]*.3048));
-			if(is_numeric($m[2])) $retArr['maxelev'] = (round($m[2]*.3048));
-		}
-		elseif(preg_match('/([\.\d]+)\s*[f\']{1}/i',$inStr,$m)){
-			if(is_numeric($m[1])) $retArr['minelev'] = (round($m[1]*.3048));
-		}
-		//Clean
-		if($retArr){
-			if(array_key_exists('minelev',$retArr) && ($retArr['minelev'] > 8000 || $retArr['minelev'] < 0)) unset($retArr['minelev']);
-			if(array_key_exists('maxelev',$retArr) && ($retArr['maxelev'] > 8000 || $retArr['maxelev'] < 0)) unset($retArr['maxelev']);
-		}
+		$retArr = [];
+
+		/*
+		 *	Supported Formats
+		 *	Space must exist between units and numbers. 
+		 *	No units assumes meters.
+		 *
+		 *	Numbers: 100, 100-200, 1,000-2,000
+		 *	Feet: ft, ft., feet, '
+		 */
+		if(preg_match('/([\.,\d]+)(\s*-\s*([\.,\d]+))?\s?(\D+)/i', $inStr, $m)) {
+			$min_elev = $m[1];
+			$max_elev = $m[3];
+			$unit = $m[4];
+
+			$meter_conversion = in_array($unit,['ft', 'ft.', 'feet', "'"])? 0.3048: 1;
+
+			$min_elev = str_replace(',', '', $min_elev);
+			$max_elev = str_replace(',', '', $max_elev);
+
+			if(is_numeric($min_elev)) {
+				$retArr['minelev'] = round($min_elev * $meter_conversion); 
+			}
+			if(is_numeric($max_elev)) {
+				$retArr['maxelev'] = round($max_elev * $meter_conversion); 
+			}
+		} 
+
+		if(array_key_exists('minelev',$retArr) && ($retArr['minelev'] > 8000 || $retArr['minelev'] < 0)) unset($retArr['minelev']);
+		if(array_key_exists('maxelev',$retArr) && ($retArr['maxelev'] > 8000 || $retArr['maxelev'] < 0)) unset($retArr['maxelev']);
+	
 		return $retArr;
 	}
 


### PR DESCRIPTION
# Issue #1150 

# Summary
Generalized regex to capture any unit an range or not range with optional capture group. Should make maintaining and testing this feature easier and allow for easier expansion of accepted formats

# Side Note
This would be an amazing thing to have under unit testing to ensure there aren't regressions when we change this.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
