### PR TITLE
Update db_schema_patch-3.1.sql

### DIFF
--- a/config/schema/3.0/patches/db_schema_patch-3.1.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.1.sql
@@ -194,7 +194,7 @@ ALTER TABLE `omoccurrences`
   ADD INDEX `IX_occurrences_stateProvince` (`stateProvince` ASC),
   ADD INDEX `IX_occurrences_county` (`county` ASC),
   ADD INDEX `IX_occurrences_municipality` (`municipality` ASC),
-  ADD INDEX `IX_occurrences_locality` (`locality` ASC),
+  ADD INDEX `IX_occurrences_locality` (`locality`(100) ASC),
   ADD INDEX `IX_occurrences_locationID` (`locationID` ASC),
   ADD INDEX `IX_occurrences_localitySecurity` (`localitySecurity` ASC),
   ADD INDEX `IX_occurrences_elevMin` (`minimumElevationInMeters` ASC),


### PR DESCRIPTION
- Explicitly set the index for omoccurrences.locality to a length of 100, thus avoid DB setting it to a default larger length that is beyond what is needed nor practical. This issue will be resolved within 3.2 update due to that index being replaced with a FULLTEXT index. 
- Addresses issue: https://github.com/BioKIC/Symbiota/issues/2050


