### PR TITLE
Print errors from buildHierarchyEnumTree during taxonomy upload

### DIFF
--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -834,7 +834,10 @@ class TaxonomyUpload{
 		}while($loopCnt < 30);
 
 		$this->outputMsg('House cleaning... ');
-		TaxonomyUtil::buildHierarchyEnumTree($this->conn, $this->taxAuthId);
+		$enumTreeStatus = TaxonomyUtil::buildHierarchyEnumTree($this->conn, $this->taxAuthId);
+		if (is_string($enumTreeStatus)) {
+			$this->outputMsg($enumTreeStatus);
+		}
 
 		//Update occurrences with new tids
 		$occurMaintenance = new OccurrenceMaintenance($this->conn);


### PR DESCRIPTION
We ran into an issue where taxa were not getting indexed into `taxaenumtree` during batch uploads because there were some older rows in `taxstatus` that were missing parenttid, which caused a SQL error. Since the UI just showed "House cleaning..." followed by "Taxa upload appears to have been successful" I had to add additional logging to figure out where it was failing. 

This PR surfaces the return value of buildHierarchyEnumTree, which is a string when there's an error and `true` otherwise.

Also, this is my first PR as I've recently started supporting the University of Minnesota's Symbiota instance. I think I've followed the guidelines for this relatively small change but let me know if I've missed anything!