### PR TITLE
Closes #2231 Fixes sort sequence being overwritten default being overwritten by empty form value

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -924,7 +924,7 @@ class Media {
 				//Check if file exists
 				if($storage->file_exists($file)) {
 					//Add mediaID onto end of file name which should be unique within portal
-					$file['name'] = self::addToFilename($file['name'], '_' . $mediaID);
+					$file['name'] = self::addToFilename($file['name'], '_' . $media_id);
 
 					//Fail case the appended mediaID is taken stops after 10
 					$cnt = 1;

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -848,7 +848,7 @@ class Media {
 			[$clean_post_arr['occid']]
 		);
 
-		if(!isset($clean_post_arr['tid']) && $clean_post_arr['tid'] && $row = $taxon_result->fetch_object()) {
+		if(!isset($clean_post_arr['tid']) && $row = $taxon_result->fetch_object()) {
 			$clean_post_arr['tid'] = $row->tidinterpreted;
 		}
 
@@ -893,6 +893,7 @@ class Media {
 		if(array_key_exists('sortsequence', $clean_post_arr) && is_numeric($clean_post_arr['sortsequence'])) {
 			$keyValuePairs["sortsequence"] = $clean_post_arr['sortsequence'];
 		}
+
 		//What is url for files
 		if($isRemoteMedia) {
 			//Required to exist

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -877,7 +877,6 @@ class Media {
 			"anatomy" => $clean_post_arr["anatomy"] ?? null,
 			"notes" => $clean_post_arr["notes"] ?? null,
 			"username" => Sanitize::in($GLOBALS['USERNAME']),
-			"sortsequence" => array_key_exists('sortsequence', $clean_post_arr) && is_numeric($clean_post_arr['sortsequence']) ? $clean_post_arr['sortsequence'] : null,
 			// check if its is_numeric?
 			"sortOccurrence" => $clean_post_arr['sortOccurrence'] ?? null,
 			"sourceIdentifier" => $clean_post_arr['sourceIdentifier'] ?? ('filename: ' . $file['name']),
@@ -891,6 +890,9 @@ class Media {
 			"mediaType" => $media_type_str,
 		];
 
+		if(array_key_exists('sortsequence', $clean_post_arr) && is_numeric($clean_post_arr['sortsequence'])) {
+			$keyValuePairs["sortsequence"] = $clean_post_arr['sortsequence'];
+		}
 		//What is url for files
 		if($isRemoteMedia) {
 			//Required to exist


### PR DESCRIPTION
# Issue #2231

# Summary
I suspect this was a regression cause by the schema change alteration where the old media table did not have a not null enforcement on sortSequence so the issue never came up

Also fixed some misc issues with some keys being undefined and a variable being undefined do to the `media_id`
 to `mediaID` swap and an undefined array key `tid` being used after a `!isset()` check which will always have the array key not exist.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
