### PR TITLE
Fix Google Maps JS URL

### DIFF
--- a/includes/googleMap.php
+++ b/includes/googleMap.php
@@ -1,6 +1,6 @@
 <!-- Importing google api -->
 <script
-   src="//maps.googleapis.com/maps/api/js?v=3.exp&libraries=drawing<?= (!empty($GOOGLE_MAP_KEY) && $GOOGLE_MAP_KEY != 'DEV' ? 'key=' . $GOOGLE_MAP_KEY : '') ?>">
+   src="//maps.googleapis.com/maps/api/js?v=3.exp&libraries=drawing<?= (!empty($GOOGLE_MAP_KEY) && $GOOGLE_MAP_KEY != 'DEV' ? '&key=' . $GOOGLE_MAP_KEY : '') ?>">
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/OverlappingMarkerSpiderfier/1.0.3/oms.min.js"></script>
 


### PR DESCRIPTION
When a GOOGLE_MAP_KEY is present, the map search breaks with a "no API key" message. This is because the query params get serialized as `&libraries=drawingkey=mykey`.

We will likely be switching to Leaflet since this ~1 year old bug suggests not many Symbiota instances are using Google Maps. But I figured it should still be fixed upstream as long as Google Maps are supposed to be supported.