### PR TITLE
Fix non audio media rendering as audio

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -360,8 +360,8 @@ class Media {
 
 			return $html;
 		} else {
-			return '<div style="width: 200px; height:242px; border: solid black 1px; display: flex; align-items: center; justify-content:center">
-				Unknown Media Type
+			global $LANG;
+			return '<div style="width: 200px; height:242px; border: solid black 1px; display: flex; align-items: center; justify-content:center">' . $LANG['UNKNOWN_MEDIA_TYPE_MSG'] . '
 			</div>';
 		}
 	}

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -328,7 +328,7 @@ class Media {
 	 * @param mixed $thumbnail
 	 */
 	public static function render_media_item(array $media_arr, $thumbnail=false) {
-		if($media_arr['mediaType'] !== 'image' && !$thumbnail) {
+		if($media_arr['mediaType'] == MediaType::Audio && !$thumbnail) {
 			$src = $media_arr['url'];
 			$format = $media_arr['format'];
 			$html = <<< HTML
@@ -339,7 +339,7 @@ class Media {
 			HTML;
 
 			return $html;
-		} else {
+		} else if($media_arr['mediaType'] == MediaType::Image || ($media_arr['tnurl']?? $media_arr['thumbnailUrl'])) {
 			$thumbnail = $media_arr['tnurl']?? $media_arr['thumbnailUrl'];
 			$url = $media_arr['url'];
 			$caption = $media_arr['caption'];
@@ -354,12 +354,15 @@ class Media {
 				border="1" 
 				src="$thumbnail" 
 				title="$caption" 
-				style="max-width:21.9rem;" 
 				alt="Thumbnail image of current specimen" 
 			/>
 			HTML;
 
 			return $html;
+		} else {
+			return '<div style="width: 200px; height:242px; border: solid black 1px; display: flex; align-items: center; justify-content:center">
+				Unknown Media Type
+			</div>';
 		}
 	}
 	/**

--- a/content/lang/classes/Media.en.php
+++ b/content/lang/classes/Media.en.php
@@ -10,5 +10,6 @@ $LANG['INVALID_MEDIA_TYPE'] = 'Invalid Media Type';
 $LANG['DUPLICATE_MEDIA_FILE'] = 'Duplicate Media File';
 $LANG['FILE_DOES_NOT_EXIST'] = 'File does not exist';
 $LANG['FILE_ALREADY_EXISTS'] = 'File already exists';
+$LANG['UNKNOWN_MEDIA_TYPE_MSG'] = 'Unknown Media Type';
 
 ?>

--- a/content/lang/classes/Media.es.php
+++ b/content/lang/classes/Media.es.php
@@ -10,5 +10,6 @@ $LANG['INVALID_MEDIA_TYPE'] = 'Tipo de medio no válido';
 $LANG['DUPLICATE_MEDIA_FILE'] = 'Archivo medio duplicado';
 $LANG['FILE_DOES_NOT_EXIST'] = 'El archivo no existe';
 $LANG['FILE_ALREADY_EXISTS'] = 'El archivo ya existe';
+$LANG['UNKNOWN_MEDIA_TYPE_MSG'] = 'Tipo de medio desconocido';
 
 ?>

--- a/content/lang/classes/Media.fr.php
+++ b/content/lang/classes/Media.fr.php
@@ -10,5 +10,6 @@ $LANG['INVALID_MEDIA_TYPE'] = 'Type de média invalide';
 $LANG['DUPLICATE_MEDIA_FILE'] = 'Fichier multimédia en double';
 $LANG['FILE_DOES_NOT_EXIST'] = 'Le fichier n\'existe pas';
 $LANG['FILE_ALREADY_EXISTS'] = 'Le fichier existe déjà';
+$LANG['UNKNOWN_MEDIA_TYPE_MSG'] = 'Type de support inconnu';
 
 ?>

--- a/content/lang/classes/Media.pt.php
+++ b/content/lang/classes/Media.pt.php
@@ -10,5 +10,6 @@ $LANG['INVALID_MEDIA_TYPE'] = 'Tipo de mídia inválido';
 $LANG['DUPLICATE_MEDIA_FILE'] = 'Arquivo de mídia duplicado';
 $LANG['FILE_DOES_NOT_EXIST'] = 'O arquivo não existe';
 $LANG['FILE_ALREADY_EXISTS'] = 'O arquivo já existe';
+$LANG['UNKNOWN_MEDIA_TYPE_MSG'] = 'Unknown Media Type';
 
 ?>


### PR DESCRIPTION
# Issue Closes #2278

# Summary
- Changes audio rendering to only occur if type is explicitly MediaType::Audio
- Image rendering will occur if audio failed the above new audio check and is MediaType::Image or has a thumbnailUrl Present.
- Add a failure else case that will render that the type is unknown and could not be rendered

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
