### PR TITLE
Occurrence controller record id accommodation

### DIFF
--- a/api/app/Http/Controllers/OccurrenceController.php
+++ b/api/app/Http/Controllers/OccurrenceController.php
@@ -740,9 +740,13 @@ class OccurrenceController extends Controller{
 	}
 
 	private function getOccurrence($id){
-		$occurrence = Occurrence::where('occid', $id)
-			->orWhere('recordID', (string)$id)
-			->orWhere('occurrenceID', (string)$id)
+		$decodedId = urldecode($id);
+		$occurrence = Occurrence::where('occid', $decodedId)
+			->orWhere('recordID', (string)$decodedId)
+			->orWhere('occurrenceID', (string)$decodedId)
+			// ->orWhere('recordID', (string)$id)
+			// ->orWhere('occurrenceID', (string)$id)
+			// ->orWhereRaw("LOWER(occurrenceID) = LOWER(?)", [$id])
 			->first();
 		return $occurrence;
 	}

--- a/api/app/Http/Controllers/OccurrenceController.php
+++ b/api/app/Http/Controllers/OccurrenceController.php
@@ -226,7 +226,7 @@ class OccurrenceController extends Controller{
 	 *	 @OA\Parameter(
 	 *		 name="includeMedia",
 	 *		 in="query",
-	 *		 description="Whether to include media within output",
+	 *		 description="Whether (1) or not (0) to include media within output",
 	 *		 required=false,
 	 *		 @OA\Schema(type="integer")
 	 *	 ),

--- a/api/app/Http/Controllers/OccurrenceController.php
+++ b/api/app/Http/Controllers/OccurrenceController.php
@@ -228,7 +228,11 @@ class OccurrenceController extends Controller{
 	 *		 in="query",
 	 *		 description="Whether (1) or not (0) to include media within output",
 	 *		 required=false,
-	 *		 @OA\Schema(type="integer")
+	 *		 @OA\Schema(
+	 *			type="integer",
+	 *			default="0",
+	 *			enum={0, 1}
+	 *		)
 	 *	 ),
 	 *	 @OA\Parameter(
 	 *		 name="includeIdentifications",

--- a/api/storage/api-docs/api-docs.json
+++ b/api/storage/api-docs/api-docs.json
@@ -1446,7 +1446,12 @@
                         "description": "Whether (1) or not (0) to include media within output",
                         "required": false,
                         "schema": {
-                            "type": "integer"
+                            "type": "integer",
+                            "default": "0",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
                     },
                     {

--- a/api/storage/api-docs/api-docs.json
+++ b/api/storage/api-docs/api-docs.json
@@ -1434,7 +1434,7 @@
                     {
                         "name": "identifier",
                         "in": "path",
-                        "description": "occid or specimen GUID (occurrenceID) associated with target occurrence",
+                        "description": "occid or specimen GUID (occurrenceID) or recordID associated with target occurrence",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -1443,7 +1443,7 @@
                     {
                         "name": "includeMedia",
                         "in": "query",
-                        "description": "Whether to include media within output",
+                        "description": "Whether (1) or not (0) to include media within output",
                         "required": false,
                         "schema": {
                             "type": "integer"
@@ -1484,7 +1484,7 @@
                     {
                         "name": "identifier",
                         "in": "path",
-                        "description": "occid or specimen GUID (occurrenceID) associated with target occurrence",
+                        "description": "occid or specimen GUID (occurrenceID) or recordID associated with target occurrence",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -1516,7 +1516,7 @@
                     {
                         "name": "identifier",
                         "in": "path",
-                        "description": "occid or specimen GUID (occurrenceID) associated with target occurrence",
+                        "description": "occid or specimen GUID (occurrenceID) or recordID associated with target occurrence",
                         "required": true,
                         "schema": {
                             "type": "string"


### PR DESCRIPTION
# Description

This PR addresses the following in the [API Audit doc](https://docs.google.com/document/d/1CNffkCLw6U6xoHn0DAQ7VhPozswAXFdFpPYYT0A_41s/edit?tab=t.0#heading=h.hue35f9a2wg9): 

> In the OccurrenceController, I have a method that translates the identifier into the primary key (aka occid) if it is a UUID. This was done because recordID used to be stored within a separate table, but now it is stored directly within the omoccurrences table. This can, and probably should be changed so that: 1) if identifier is an integer, if queries occurrence via occid, 2) if it is a UUID, if queries records via the recordID field.

The occurrence/foo endopoints now accommodate occid, occurrenceID, and recordID as identifier inputs.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
    - N/A
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=89420487](https://github.com/orgs/BioKIC/projects/6/views/10?pane=issue&itemId=89420487)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
