### PR TITLE
Add Syncing Behavior Between Verbatim Coordinates and Latitude and Longitude

### DIFF
--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -1193,7 +1193,7 @@ else{
 													<?php echo $LANG['VERBATIM_COORDINATES']; ?>
 													<a href="#" onclick="return dwcDoc('verbatimCoordinates')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 													<br/>
-													<input type="text" name="verbatimcoordinates" maxlength="255" value="<?php echo array_key_exists('verbatimcoordinates',$occArr)?$occArr['verbatimcoordinates']:''; ?>" onchange="verbatimCoordinatesChanged(this.form);" title="" />
+												<input type="text" data-lat-lng-sync="" name="verbatimcoordinates" maxlength="255" value="<?= $occArr['verbatimcoordinates'] ?? '' ?>" onchange="verbatimCoordinatesChanged(this.form);" title="" />
 												</div>
 											</div>
 										</div>

--- a/js/symb/collections.editor.main.js
+++ b/js/symb/collections.editor.main.js
@@ -402,6 +402,33 @@ function coordinatesChanged(f, client_root) {
 	verifyCoordinates(f, client_root);
 	fieldChanged('decimallatitude');
 	fieldChanged('decimallongitude');
+	trySyncingVerbatimCoordinates(f);
+}
+
+function trySyncingVerbatimCoordinates(f) {
+	try {
+		if(f.verbatimcoordinates && f.decimallatitude && f.decimallatitude.value && f.decimallongitude && f.decimallongitude.value) {
+
+			if(f.verbatimcoordinates.value && !f.verbatimcoordinates.getAttribute('data-lat-lng-sync')) {
+				const parts = f.verbatimcoordinates.value.split(',');
+				if(parts.length == 2) {
+					const lat = parseFloat(f.decimallatitude);
+					const lng = parseFloat(f.decimallongitude);
+
+					if(lat === parseFloat(parts[0]) && lng === parseFloat(parse[1])) {
+						f.verbatimcoordinates.setAttribute('data-lat-lng-sync', true);
+					}
+				}
+			}
+
+			if(!f.verbatimcoordinates.value || f.verbatimcoordinates.getAttribute('data-lat-lng-sync')) {
+				f.verbatimcoordinates.setAttribute('data-lat-lng-sync', true);
+				f.verbatimcoordinates.value = f.decimallatitude.value.trim() +	',' + f.decimallongitude.value.trim();
+			}
+		}
+	} catch(e) {
+		console.error('Error occured while trying to sync decimallatitude and decimallongitude with verbatimcoordinates')
+	}
 }
 
 function decimalLatitudeChanged(f) {


### PR DESCRIPTION
# Issue Closes #666

# Summary
Users desired for coordinates to not be truncated on input and due to the limitations of storing decimal numbers in the database we settle for automatically syncing them to the database.

There are other ways to tackle this issue that revolve around changing the latitude and longitude fields into strings. However, that change will likely have rippling effects on other parts of the code assuming this is a number so further discussion will needed if these changes do not suffice.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
