### PR TITLE
Bug - Linked Resources tab overwrites occurrenceeditor styling 

### DIFF
--- a/collections/editor/includes/resourcetab.php
+++ b/collections/editor/includes/resourcetab.php
@@ -213,17 +213,17 @@ $dupClusterArr = $dupManager->getClusterArr($occid);
 	}
 </script>
 <style type="text/css">
-	fieldset{ clear:both; margin:10px; padding:10px; }
-	legend{ font-weight: bold }
-	label{ font-weight: bold; }
-	.formRow-div{ clear:both; margin: 2px 10px; }
-	.field-div{ float:left; margin: 2px 10px 2px 0px; }
-	.field-div label{ display: block; }
-	.field-div button{ margin-top: 10px; }
-	.assoc-div{ margin-bottom: 10px; }
-	.icon-img{ width: 1.2em }
-	#subType-div select{ min-width: 130px; }
-	#taxonomy-fieldset{ display: none; }
+	.resourceTab fieldset{ clear:both; margin:10px; padding:10px; }
+	.resourceTab legend{ font-weight: bold }
+	.resourceTab label{ font-weight: bold; }
+	.resourceTab .formRow-div{ clear:both; margin: 2px 10px; }
+	.resourceTab .field-div{ float:left; margin: 2px 10px 2px 0px; }
+	.resourceTab .field-div label{ display: block; }
+	.resourceTab .field-div button{ margin-top: 10px; }
+	.resourceTab .assoc-div{ margin-bottom: 10px; }
+	.resourceTab .icon-img{ width: 1.2em }
+	.resourceTab #subType-div select{ min-width: 130px; }
+	.resourceTab #taxonomy-fieldset{ display: none; }
 </style>
 <div id="voucherdiv" style="width:795px;">
 	<?php
@@ -231,7 +231,7 @@ $dupClusterArr = $dupManager->getClusterArr($occid);
 	$basisOfRecordArr = array('HumanObservation' => $LANG['HUMAN_OBS'], 'LivingSpecimen' => $LANG['LIVING_SPEC'], 'MachineObservation' => $LANG['MACHINE_OBS'],
 		'MaterialSample' => $LANG['MAT_SAMPLE'], 'PreservedSpecimen' => $LANG['PRES_SAMPLE'], 'ReferenceCitation' => $LANG['REF_CITATION']);
 	?>
-	<fieldset>
+	<fieldset class="resourceTab">
 		<legend><?php echo $LANG['ASSOC_OCC']; ?></legend>
 		<div style="float:right;margin-right:10px;">
 			<a href="#" onclick="toggle('new-association');return false;" title="<?php echo $LANG['CREATE_NEW_ASSOC']; ?>" ><img class="icon-img" src="../../images/add.png" /></a>


### PR DESCRIPTION
# Changes Made:

- internal css in resourcetab.php overwrites the occurrenceeditor page's styling -> scope the internal css to resourcetab by adding a class.

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [X] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address:
https://github.com/Symbiota/Symbiota/issues/2352
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
