### PR TITLE
Adds Better error handling and Memory settings for resizing images

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -764,7 +764,7 @@ class Media {
 	public static function getMaximumFileUploadSize(): int {
 		return min(
 			self::size_2_bytes(ini_get('post_max_size')),
-			self::size_2_bytes(ini_get('upload_max_filesize'))
+			self::size_2_bytes(ini_get('upload_max_filesize')),
 		);
 	}
 
@@ -834,6 +834,7 @@ class Media {
 	**/
 	public static function add(array $post_arr, $storage = null, $file = null): void {
 		$clean_post_arr = Sanitize::in($post_arr);
+		unset($post_arr);
 
 		$copy_to_server = $clean_post_arr['copytoserver']?? false;
 		$mapLargeImg = !($clean_post_arr['nolgimage']?? true);
@@ -857,7 +858,7 @@ class Media {
 		}
 
 		//If file being uploaded is too big throw error
-		else if($should_upload_file && self::getMaximumFileUploadSize() < intval($file['size'])) {
+		else if($should_upload_file && self::getMaximumFileUploadSize() - memory_get_usage() < intval($file['size'])) {
 			throw new Exception('Error: File is to large to upload');
 		}
 
@@ -975,6 +976,9 @@ class Media {
 
 				//Generate Deriatives if needed
 				if($media_type === MediaType::Image) {
+					// Update mem limit for image resizing
+					ini_set('memory_limit', '256M');
+
 					//Will download file if its remote.
 					//This is a naive solution assuming we are upload to our server
 					$size = getimagesize($storage->getDirPath($file));
@@ -991,7 +995,7 @@ class Media {
 						$thumb_name = self::addToFilename($file['name'], '_tn');
 						self::create_image(
 							$file['name'],
-							self::addToFilename($file['name'], '_tn'),
+							$thumb_name,
 							$storage,
 							$GLOBALS['IMG_TN_WIDTH']?? 200,
 							0
@@ -1037,6 +1041,7 @@ class Media {
 			0
 		);
 	}
+
 	/**
 	 * @return void
 	 */
@@ -1329,9 +1334,14 @@ class Media {
 		}
 
 		$size = getimagesize($src_path);
+
 		$width = $size[0];
 		$height = $size[1];
 		$mime_type = $size['mime'];
+
+		if(!self::enough_memory_gd($size[0], $size[1])) {
+			throw new Exception('Not enough memory to create image: ' . $new_file);
+		}
 
 		$orig_width = $width;
 		$orig_height = $height;
@@ -1346,9 +1356,6 @@ class Media {
 			$width = $new_width;
 		}
 
-
-		$new_image = imagecreatetruecolor($width, $height);
-
 		$image = match($mime_type) {
 			'image/jpeg' => imagecreatefromjpeg($src_path),
 			'image/png' => imagecreatefrompng($src_path),
@@ -1357,6 +1364,8 @@ class Media {
 				'Mime Type: ' . $mime_type . ' not supported for creation'
 			)
 		};
+
+		$new_image = imagecreatetruecolor($width, $height);
 
 		//This is need to maintain transparency if this is here
 		if($mime_type === 'image/png') {
@@ -1374,6 +1383,11 @@ class Media {
 		}
 
 		imagedestroy($image);
+	}
+
+	private static function enough_memory_gd($x, $y, $rgb = 3) {
+		// 1.7 is some coef related to gd or overhead not entirely sure
+		return  ($x * $y * 1.7 * $rgb) < (self::size_2_bytes(ini_get('memory_limit')) - memory_get_usage());
 	}
 
 	/**

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -976,8 +976,11 @@ class Media {
 
 				//Generate Deriatives if needed
 				if($media_type === MediaType::Image) {
-					// Update mem limit for image resizing
-					ini_set('memory_limit', '256M');
+					$start_mem_limit = ini_get('memory_limit');
+					// Update mem limit if not set to 256M already
+					if(self::size_2_bytes(ini_get('memory_limit')) < self::size_2_bytes('256M')) {
+						ini_set('memory_limit', '256M');
+					}
 
 					//Will download file if its remote.
 					//This is a naive solution assuming we are upload to our server

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -249,11 +249,13 @@ if($SYMB_UID){
 						$occur_map['collectioncode'],
 						$occur_map['catalognumber']
 					);
+
 					Media::add(
 						$_POST,
 						new LocalStorage($path),
 						$_FILES['imgfile'] ?? null
 					);
+
 					if($errors = Media::getErrors()) {
 						$statusStr = "ERROR: " . array_pop($errors);
 					} else {


### PR DESCRIPTION
# Summary
Their is a memory issue with `gd` implementation of `create_image` for the media class where an image has enough memory to be uploaded but not to create it's derivatives. The long term solution would to to make some memory optimizations or ditch gd entirely for image magic, which does not have the same memory issues. However, this pr just addresses the immediate lack of user status when an image cannot be create because a lack of memory and the increase of allowed memory prior.

If we have enough memory for one image should we still upload that one regardless of whether the derivatives failed?

# Pull Request Checklist:

# Pre-Approval

- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
