### PR TITLE
Deprecate the old image URL mapping tools, add note

### DIFF
--- a/collections/specprocessor/imageprocessor.php
+++ b/collections/specprocessor/imageprocessor.php
@@ -312,12 +312,16 @@ if($spprid) $specManager->setProjVariables($spprid);
 									else{
 										?>
 										<div>
+											<div>
+												<?= $LANG['IMG_PROC_CHANGE_EXPLAIN'] ?>
+											</div>
+											<br>
 											<label><?php echo $LANG['PROC_TYPE']; ?>:</label>
 											<div style="float:left;">
 												<select name="projecttype" id="projecttype" onchange="uploadTypeChanged(this.form)" <?php echo ($spprid?'DISABLED':'');?>>
 													<option value="">----------------------</option>
 													<option value="local"><?php echo $LANG['MAP_FROM_SERVER']; ?></option>
-													<option value="file"><?php echo $LANG['URL_MAP_FILE']; ?></option>
+													<!--<option value="file"><?php echo $LANG['URL_MAP_FILE']; ?></option>-->
 													<!-- <option value="iplant">iPlant Image Harvest</option> -->
 												</select>
 											</div>

--- a/content/lang/collections/specprocessor/specprocessor_tools.en.php
+++ b/content/lang/collections/specprocessor/specprocessor_tools.en.php
@@ -70,6 +70,8 @@ $LANG['EDIT'] = 'Edit';
 $LANG['NEW'] = 'New';
 $LANG['PROFILE'] = 'Profile';
 $LANG['CLOSE_EDITOR'] = 'Close Editor';
+$LANG['IMG_PROC_CHANGE_EXPLAIN'] = '<b>Tools to upload image URL files have moved!</b> You can now upload files of media URLs through the Extended Data Importer 
+	(Administration Control Panel > Import/Update Specimen Records > Extended Data Import';
 $LANG['PROC_TYPE'] = 'Processing Type';
 $LANG['MAP_FROM_SERVER'] = 'Map Images from a Local or Remote Server';
 $LANG['URL_MAP_FILE'] = 'Image URL Mapping File';

--- a/content/lang/collections/specprocessor/specprocessor_tools.es.php
+++ b/content/lang/collections/specprocessor/specprocessor_tools.es.php
@@ -73,6 +73,7 @@ $LANG['NEW'] = 'Nuevo';
 $LANG['PROFILE'] = 'Perfil';
 $LANG['CLOSE_EDITOR'] = 'Cerrar editor';
 $LANG['PROC_TYPE'] = 'Tipo de procesamiento';
+$LANG['IMG_PROC_CHANGE_EXPLAIN'] = '<b>¡Las herramientas para cargar archivos URL de imágenes se han movido!</b> Ahora puede cargar archivos URL de medios a través del Importador de Datos Extendido (Panel de Control de Administración > Importar/Actualizar Registros de Especímenes > Datos Extendidos Importación)';
 $LANG['MAP_FROM_SERVER'] = 'Imágenes de mapa desde un servidor local o remoto';
 $LANG['URL_MAP_FILE'] = 'Archivo de mapeo de URL de imagen';
 $LANG['TITLE'] = 'Título';

--- a/content/lang/collections/specprocessor/specprocessor_tools.fr.php
+++ b/content/lang/collections/specprocessor/specprocessor_tools.fr.php
@@ -73,6 +73,7 @@ $LANG['NEW'] = 'Nouveau';
 $LANG['PROFILE'] = 'Profil';
 $LANG['CLOSE_EDITOR'] = 'Fermer l\'éditeur';
 $LANG['PROC_TYPE'] = 'Type de traitement';
+$LANG['IMG_PROC_CHANGE_EXPLAIN'] = "<b>Les outils de téléchargement des fichiers URL d'images ont été déplacés!</b> Vous pouvez désormais télécharger des fichiers d'URL de médias via l'importateur de données étendues (Panneau de Configuration d'Administration > Importer/Mettre à Jour Enregistrements de Spécimens > Importation Données Etendues)";
 $LANG['MAP_FROM_SERVER'] = 'Mapper des images à partir d\'un serveur local ou distant';
 $LANG['URL_MAP_FILE'] = 'Fichier de mappage d\'URL d\'image';
 $LANG['TITLE'] = 'Titre';


### PR DESCRIPTION
# Pull Request Checklist:
Based on this issue: https://github.com/Symbiota/Symbiota/issues/2447

We decided the easiest way to fix the problem was to just deprecate this old URL mapping method in deference for the new one.

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [3.3_rc] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] Comment which GitHub issue(s), if any does this PR address

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.
