### PR TITLE
Add "last updated" date to collection stats

### DIFF
--- a/classes/OccurrenceCollectionProfile.php
+++ b/classes/OccurrenceCollectionProfile.php
@@ -390,11 +390,7 @@ class OccurrenceCollectionProfile extends OmCollections{
 				$retArr['dynamicProperties'] = $row->dynamicProperties;
 				$mDate = "";
 				if($row->datelastmodified){
-					$mDate = $row->datelastmodified;
-					$month = substr($mDate,5,2);
-					$day = substr($mDate,8,2);
-					$year = substr($mDate,0,4);
-					$mDate = date("j F Y",mktime(0,0,0,$month,$day,$year));
+					$mDate = date("j F Y", strtotime($row->datelastmodified));
 				}
 				$retArr['datelastmodified'] = $mDate;
 			}

--- a/classes/OccurrenceCollectionProfile.php
+++ b/classes/OccurrenceCollectionProfile.php
@@ -370,7 +370,7 @@ class OccurrenceCollectionProfile extends OmCollections{
 	public function getBasicStats(){
 		$retArr = array();
 		if($this->collid){
-			$sql = 'SELECT uploaddate, recordcnt, georefcnt, familycnt, genuscnt, speciescnt, dynamicProperties FROM omcollectionstats WHERE collid = '.$this->collid;
+			$sql = 'SELECT uploaddate, recordcnt, georefcnt, familycnt, genuscnt, speciescnt, dynamicProperties, datelastmodified FROM omcollectionstats WHERE collid = '.$this->collid;
 			$rs = $this->conn->query($sql);
 			if($row = $rs->fetch_object()){
 				$uDate = "";
@@ -388,6 +388,15 @@ class OccurrenceCollectionProfile extends OmCollections{
 				$retArr['genuscnt'] = $row->genuscnt;
 				$retArr['speciescnt'] = $row->speciescnt;
 				$retArr['dynamicProperties'] = $row->dynamicProperties;
+				$mDate = "";
+				if($row->datelastmodified){
+					$mDate = $row->datelastmodified;
+					$month = substr($mDate,5,2);
+					$day = substr($mDate,8,2);
+					$year = substr($mDate,0,4);
+					$mDate = date("j F Y",mktime(0,0,0,$month,$day,$year));
+				}
+				$retArr['datelastmodified'] = $mDate;
 			}
 			$rs->free();
 		}

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -781,6 +781,7 @@ if ($SYMB_UID) {
 						//if($extrastatsArr&&$extrastatsArr['TypeCount']) echo '<li>'.number_format($extrastatsArr['TypeCount']) . ' ' . $LANG['TYPE_SPECIMENS'] . '</li>';
 						?>
 					</ul>
+					<p style="margin-left:3em"><?= '(' . $LANG['LAST_UPDATED'] . ' ' . $statsArr['datelastmodified'] . ')'?></p>
 				</div>
 			</section>
 			<section class="fieldset-like no-left-margin">

--- a/content/lang/collections/misc/collprofiles.en.php
+++ b/content/lang/collections/misc/collprofiles.en.php
@@ -96,6 +96,7 @@ $LANG['GENERA'] = 'genera';
 $LANG['SPECIES'] = 'species';
 $LANG['TOTAL_TAXA'] = 'total taxa (including subsp. and var.)';
 $LANG['TYPE_SPECIMENS'] = 'type specimens';
+$LANG['LAST_UPDATED'] = 'last updated';
 $LANG['EXTRA_STATS'] = 'Extra Statistics';
 $LANG['SHOW_FAMILY_DIST'] = 'Show Family Distribution';
 $LANG['HIDE_FAMILY_DIST'] = 'Hide Family Distribution';

--- a/content/lang/collections/misc/collprofiles.es.php
+++ b/content/lang/collections/misc/collprofiles.es.php
@@ -96,6 +96,7 @@ $LANG['GENERA'] = 'géneros';
 $LANG['SPECIES'] = 'especies';
 $LANG['TOTAL_TAXA'] = 'total taxa (including subsp. and var.)';
 $LANG['TYPE_SPECIMENS'] = 'especímenes tipo';
+$LANG['LAST_UPDATED'] = 'última puesta en marcha del día';
 $LANG['EXTRA_STATS'] = 'Estadísticas Extras';
 $LANG['SHOW_FAMILY_DIST'] = 'Mostrar Distribución por Familia';
 $LANG['HIDE_FAMILY_DIST'] = 'Ocultar Distribución por Familia';

--- a/content/lang/collections/misc/collprofiles.fr.php
+++ b/content/lang/collections/misc/collprofiles.fr.php
@@ -96,6 +96,7 @@ $LANG['GENERA'] = 'genres';
 $LANG['SPECIES'] = 'espèce';
 $LANG['TOTAL_TAXA'] = 'taxons totaux (y compris subsp. et var.)';
 $LANG['TYPE_SPECIMENS'] = 'spécimens types';
+$LANG['LAST_UPDATED'] = 'dernière mise à jour';
 $LANG['EXTRA_STATS'] = 'Statistiques Supplémentaires';
 $LANG['SHOW_FAMILY_DIST'] = 'Afficher Distribution Familiale';
 $LANG['HIDE_FAMILY_DIST'] = 'Masquer Distribution Familiale';

--- a/content/lang/collections/misc/collprofiles.pt.php
+++ b/content/lang/collections/misc/collprofiles.pt.php
@@ -96,6 +96,7 @@ $LANG['GENERA'] = 'gêneros';
 $LANG['SPECIES'] = 'espécies';
 $LANG['TOTAL_TAXA'] = 'táxons totais (incluindo subsp. e var.)';
 $LANG['TYPE_SPECIMENS'] = 'espécimes de tipo';
+$LANG['LAST_UPDATED'] = 'última atualização do dia';
 $LANG['EXTRA_STATS'] = 'Estatísticas extras';
 $LANG['SHOW_FAMILY_DIST'] = 'Mostrar distribuição familiar';
 $LANG['HIDE_FAMILY_DIST'] = 'Ocultar distribuição familiar';


### PR DESCRIPTION
We often get questions about why someone's stats don't match their expectations, and the problem is usually that they have not manually refreshed their statistics. This addition attempts to clarify the timestamp of the stamps so that users are prompted to update their statistics. https://github.com/Symbiota/Symbiota/issues/2454

Here is a visual of the addition:
![image](https://github.com/user-attachments/assets/a148a0ed-5920-4a1a-b109-19e6ff9f78f6)

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] Comment which GitHub issue(s), if any does this PR address

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.