### PR TITLE
Allow for observational associations to be accommodated in public view

### DIFF
--- a/classes/OccurrenceIndividual.php
+++ b/classes/OccurrenceIndividual.php
@@ -397,9 +397,9 @@ class OccurrenceIndividual extends Manager{
 	private function setOccurrenceRelationships(){
 		$relOccidArr = array();
 		$sql = 'SELECT a.assocID, a.occid, a.occidAssociate, a.relationship, a.subType, a.resourceUrl, a.objectID, a.dynamicProperties, a.verbatimSciname, a.tid
-			FROM omoccurassociations a INNER JOIN omoccurrences o ON a.occidAssociate = o.occid
-			WHERE a.occid = ? OR a.occidAssociate = ? ';
-		$sql .= OccurrenceUtil::appendFullProtectionSQL();
+			FROM omoccurassociations a LEFT JOIN omoccurrences o ON a.occidAssociate = o.occid
+			WHERE (a.occid = ? OR a.occidAssociate = ?) ';
+		$sql .= OccurrenceUtil::appendFullProtectionSQL(true);
 		if($stmt = $this->conn->prepare($sql)){
 			$stmt->bind_param('ii', $this->occid, $this->occid);
 			$stmt->execute();

--- a/classes/utilities/OccurrenceUtil.php
+++ b/classes/utilities/OccurrenceUtil.php
@@ -1111,15 +1111,17 @@ class OccurrenceUtil {
 		return $retStr;
 	}
 
-	public static function appendFullProtectionSQL(){
+	public static function appendFullProtectionSQL($relaxForObservational=false){
 		//Protect by default
-		$retStr = 'AND (o.recordSecurity != 5 ';
+		$observationalClause = "AND (a.associationType = 'observational' OR (o.recordSecurity != 5 ";
+		$retStr = $relaxForObservational ? $observationalClause : 'AND (o.recordSecurity != 5 ';
 		//User needs Collection Admin or Collection Editor status to view full hidden records
 		$collStr = self::getFullProtectionPermission();
 		if($collStr){
 			$retStr .= 'OR o.collid IN(' . $collStr . ')';
 		}
 		$retStr .= ') ';
+		if($relaxForObservational) $retStr .= ') ';
 		return $retStr;
 	}
 

--- a/classes/utilities/OccurrenceUtil.php
+++ b/classes/utilities/OccurrenceUtil.php
@@ -1111,17 +1111,16 @@ class OccurrenceUtil {
 		return $retStr;
 	}
 
-	public static function appendFullProtectionSQL($relaxForObservational=false){
+	public static function appendFullProtectionSQL($allowNull=false){
 		//Protect by default
-		$observationalClause = "AND (a.associationType = 'observational' OR (o.recordSecurity != 5 ";
-		$retStr = $relaxForObservational ? $observationalClause : 'AND (o.recordSecurity != 5 ';
+		$retStr = 'AND (o.recordSecurity != 5 ';
+		if($allowNull) $retStr .= 'OR o.recordSecurity IS NULL ';
 		//User needs Collection Admin or Collection Editor status to view full hidden records
 		$collStr = self::getFullProtectionPermission();
 		if($collStr){
 			$retStr .= 'OR o.collid IN(' . $collStr . ')';
 		}
 		$retStr .= ') ';
-		if($relaxForObservational) $retStr .= ') ';
 		return $retStr;
 	}
 


### PR DESCRIPTION
# Description

This PR makes two changes to recent code involving security/redaction fixes in order to allow public display pages to show observational associations.

The previous security/redaction code limits the potential results in `setOccurrenceRelationships` by only occurrences that had associations with a valid occidAssociate: `FROM omoccurassociations a INNER JOIN omoccurrences o ON a.occidAssociate = o.occid`. I changed that to a left join.

The results were further limited by `o.recordSecurity != 5`, which can't be true if the observation--which is not an occurrence--doesn't have any o.* values. So, I added an optional boolean parameter to the `appendFullProtectionSQL` method that allows the bypass of this security criterion if and only if `a.associationType = 'observational'`.


# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
    - N/A
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
    - N/A
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
    - N/A
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
    - N/A
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
    - N/A
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/Symbiota/Symbiota/issues/2500#event-17562350269](https://github.com/Symbiota/Symbiota/issues/2500#event-17562350269)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).
    - N/A

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
