### PR TITLE
restore button font color to original behavior

### DIFF
--- a/css/symbiota/collections/editor/editormain.css
+++ b/css/symbiota/collections/editor/editormain.css
@@ -217,6 +217,7 @@ select{
 /* Button Controls */
 .button {
 	background-color: var(--darkest-color);
+	color: #fff;
 	border: none;
 	border-radius: 5px;
 	padding: 0.5rem 1rem;


### PR DESCRIPTION
# Description

In the Development branch, I noticed a reversion in the font color of certain buttons in the occurrence editor and the association creation pages:

<img width="1582" alt="Screenshot 2025-06-09 at 10 47 40 AM" src="https://github.com/user-attachments/assets/8fc1bad4-acd6-4940-9070-93cf5f990659" />

<img width="1582" alt="Screenshot 2025-06-09 at 10 14 46 AM" src="https://github.com/user-attachments/assets/7fb4c4e8-968a-4461-a7e3-2866d986b5d1" />

In Ecdysis, which very recently had the 3.3.1 release, occurrenceeditor.php references a css file called occurrenceeditor.css. In the Development branch, this reference is replaced by editorfulldisplay.css. This change was made by @egbot seven days ago in the following PR: https://github.com/Symbiota/Symbiota/pull/2549/files#diff-812cfd4dcdeef5af2b23e692f53d289416a18b31eb8197f4f3a3645f10241919. 

The description of that PR also includes "Remove duplicate styling sheets" and "Merge head stylings into main CSS file". 

It looks like the newly-created css/symbiota/collections/editor/editormain.css contains a definition of `.button` (editorfulldisplay.css does not), but it doesn't include any reference to the color attribute that used to exist in occurrenceeditor.css (see https://github.com/Symbiota/Symbiota/pull/2569).

This PR adds the `color` attribute back in to the `.button` definition.

## After

<img width="1582" alt="Screenshot 2025-06-09 at 11 29 47 AM" src="https://github.com/user-attachments/assets/59651786-1923-4d37-b4d0-554f366dd3f6" />

<img width="1582" alt="Screenshot 2025-06-09 at 11 29 42 AM" src="https://github.com/user-attachments/assets/615ff8fc-e579-4adb-a8fd-9a01623d5209" />

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - #2358 
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
