### PR TITLE
Remove excess colon from sitemap list when collection code doesn't exist

### DIFF
--- a/classes/SiteMapManager.php
+++ b/classes/SiteMapManager.php
@@ -16,7 +16,7 @@ class SiteMapManager extends Manager{
 		$retArr = array();
 		$adminArr = array();
 		$editorArr = array();
-		$sql = 'SELECT collid, CONCAT_WS(":", institutioncode, collectioncode) AS ccode, collectionname, colltype FROM omcollections ';
+		$sql = 'SELECT collid, institutioncode, collectioncode, collectionname, colltype FROM omcollections ';
 		if(!$IS_ADMIN){
 			if(array_key_exists('CollAdmin', $USER_RIGHTS)){
 				$adminArr = $USER_RIGHTS['CollAdmin'];
@@ -37,7 +37,12 @@ class SiteMapManager extends Manager{
 			if($rs){
 				while($row = $rs->fetch_object()){
 					$name = $row->collectionname;
-					if($row->ccode) $name .= ' (' . $row->ccode . ')';
+					if ($row->collectioncode){ // If there's a collection code add it after institution code
+						$name .= ' (' . $row->institutioncode . ':' . $row->collectioncode . ')';
+					}
+					else{
+						$name .= ' (' . $row->institutioncode . ')';
+					}
 					$isCollAdmin = 0;
 					if($IS_ADMIN || in_array($row->collid, $adminArr)) $isCollAdmin = 0;
 					if($row->colltype == 'Observations'){


### PR DESCRIPTION
# Description:
Removes excess colon that shows up in sitemap when displaying a Collection/Observation that has no collection code.
Issue #1430 : Empty collection codes cause erroneous colon in sitemap

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
