### PR TITLE
Closes #1367 Adds eventDate2 to dup search

### DIFF
--- a/classes/OccurrenceDuplicate.php
+++ b/classes/OccurrenceDuplicate.php
@@ -349,7 +349,7 @@ class OccurrenceDuplicate {
 		if($occidQuery){
 			$targetFields = array('family', 'sciname', 'scientificNameAuthorship',
 				'identifiedBy', 'dateIdentified', 'identificationReferences', 'identificationRemarks', 'taxonRemarks', 'identificationQualifier',
-				'recordedBy', 'recordNumber', 'associatedCollectors', 'eventDate', 'verbatimEventDate',
+				'recordedBy', 'recordNumber', 'associatedCollectors', 'eventDate', 'eventDate2', 'verbatimEventDate',
 				'country', 'stateProvince', 'county', 'municipality', 'locality', 'locationID', 'decimalLatitude', 'decimalLongitude', 'geodeticDatum',
 				'coordinateUncertaintyInMeters', 'verbatimCoordinates', 'georeferencedBy', 'georeferenceProtocol',
 				'georeferenceSources', 'georeferenceVerificationStatus', 'georeferenceRemarks',

--- a/collections/editor/dupesearch.php
+++ b/collections/editor/dupesearch.php
@@ -261,15 +261,21 @@ if(!$IS_ADMIN){
 							<?php
 							echo '<span title="recordedby">'.($occObj['recordedBy']?$occObj['recordedBy']:'Collector field empty').'</span>';
 							if($occObj['recordNumber']) echo '<span style="margin-left:20px;" title="recordnumber">'.$occObj['recordNumber'].'</span>';
-							if($occObj['eventDate']){
-								echo '<span style="margin-left:20px;" title="eventdate">'.$occObj['eventDate'].'</span>';
+
+							$dateTitle = 'eventDate';
+
+							if(!$occObj['eventDate'] && $occObj['verbatimEventDate']) {
+								$dateTitle = 'verbatimeventdate';
 							}
-							elseif($occObj['verbatimEventDate']){
-								echo '<span style="margin-left:20px;" title="verbatimeventdate">'.$occObj['verbatimEventDate'].'</span>';
+
+							$dateDisplay = $occObj['eventDate'] ?? $occObj['verbatimEventDate'] ?? $LANG['DATE_EMPTY'];
+							echo '<span style="margin-left:20px;">';
+							echo '<span style="margin-left:20px;" title="' . $dateTitle.'">'. $dateDisplay .'</span>';
+							if($occObj['eventDate2']) {
+								echo ' - <span title="eventDate2">' . $occObj['eventDate2'] . '<span>';
 							}
-							else{
-								echo '<span style="margin-left:20px;" title="eventdate">'.$LANG['DATE_EMPTY'].'</span>';
-							}
+							echo '</span>';
+
 							if($occObj['associatedCollectors']) echo '<div style="margin-left:10px;" title="associatedCollectors">'.$LANG['ASSOC_COLL'].': '.$occObj['associatedCollectors'].'</div>';
 							?>
 						</div>


### PR DESCRIPTION
# Issue #1367

# Summary
Adds eventDate2 to display when searching for duplicates if eventDate2 is available.

Current Rendering:

If eventDate but no eventDate2
`eventDate`

If eventDate and eventDate2
`eventDate - eventDate2`

If no eventDate and a present eventDate2
`[Date Empty Lang tag] - eventDate2`
or if verbatimEventDate is available
`verbatimEventDate - eventDate2`

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
