### PR TITLE
Fixes for swap_wkt_coords in 3.2 schema migration

### DIFF
--- a/config/schema/3.0/patches/db_schema_patch-3.2.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.2.sql
@@ -400,7 +400,7 @@ CREATE FUNCTION `swap_wkt_coords`(str TEXT) RETURNS text
               SUBSTRING(str, lngStart, CASE WHEN lngStart = lngEnd THEN 1 ELSE lngEnd - lngStart END),
               " ", 
               SUBSTRING(str, latStart, CASE WHEN latStart = latEnd THEN 1 ELSE latEnd - latStart END)
-			      );
+	    );
             SET flipped = CONCAT(flipped, flippedPoint);
 
             IF firstPt is null THEN


### PR DESCRIPTION
I'm migrating the MN Biodiversity Atlas from 3.1 to 3.3 and I ran into some issues with the conversion from WKT to GeoJSON, which manifested as "Invalid GIS data provided to function st_geomfromtext" error messages when running the 3.2 migration file.

1. `SET cha = SUBSTRING(...)` [trims trailing spaces](https://dev.mysql.com/doc/refman/8.4/en/char.html), at least with some collations/charsets. This prevents the `ELSEIF cha = " "` branch from ever matching. I saw this behavior on both `11.7.2-MariaDB` and `8.0.42-commercial` with default collations for utf8mb3 and utf8mb4. I was able to fix this by using a BINARY type for the `cha` variable. This was a little baffling, but I isolated the behavior as follows: 
```sql
DELIMITER |
CREATE FUNCTION `repro`() RETURNS text 
  BEGIN 
    DECLARE cha CHAR;
    DECLARE chaBin BINARY;

    SET cha = SUBSTRING(' ', 1, 1);
    SET chaBin = SUBSTRING(' ', 1, 1);

    RETURN concat('char length: ', LENGTH(cha), ', binary length: ', LENGTH(chaBin));
  END |
DELIMITER ;

SELECT repro(), @@CHARACTER_SET_CLIENT, @@CHARACTER_SET_SERVER, @@COLLATION_CONNECTION, @@VERSION;
+----------------------------------+------------------------+------------------------+------------------------+----------------+
| repro()                          | @@CHARACTER_SET_CLIENT | @@CHARACTER_SET_SERVER | @@COLLATION_CONNECTION | @@VERSION      |
+----------------------------------+------------------------+------------------------+------------------------+----------------+
| char length: 0, binary length: 1 | utf8mb4                | utf8mb4                | utf8mb4_uca1400_ai_ci  | 11.7.2-MariaDB |
+----------------------------------+------------------------+------------------------+------------------------+----------------+
```

2. We had some non-closed polygons in footprintWKT, I'm not sure how common that is or how they got there, but I was able to fix it in the function. Note that this may break the conversion if there are shapes other than POLYGONs being converted.

Presumably all your managed portals were able to migrate without these issues, so I'm not sure how generally applicable these fixes are. I still figured I would open the PR for the benefit of anyone migrating after us who may hit these errors if they search GitHub for a fix.


# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
