### PR TITLE
Fix Symbiota Docs links with recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Symbiota Software Project is building a library of webtools to aid biologist
 
 More information about this project can be accessed through [https://symbiota.org](https://symbiota.org).
 
-For documentation and user guides please visit [Symbiota Docs](https://docs.symbiota.org/docs/about/).
+For documentation and user guides please visit [Symbiota Docs](https://docs.symbiota.org/).
 
 ## ACKNOWLEDGEMENTS
 

--- a/classes/SpecUploadBase.php
+++ b/classes/SpecUploadBase.php
@@ -409,7 +409,7 @@ class SpecUploadBase extends SpecUpload{
 		}
 		//Output table rows for source data
 		echo '<table class="styledtable" style="width:600px;font-size:12px;">';
-		echo '<tr><th>Source Field</th><th>Target Field ' . '<a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Importing_Uploading/data_import_fields" target="_blank"><img src="../../images/info.png" style="width:1.2em;" alt="More about Symbiota Data Fields" title="More about Symbiota Data Fields" aria-label="more info"/></a></th></tr>'."\n";
+		echo '<tr><th>Source Field</th><th>Target Field ' . '<a href="https://docs.symbiota.org/Collection_Manager_Guide/Importing_Uploading/data_import_fields" target="_blank"><img src="../../images/info.png" style="width:1.2em;" alt="More about Symbiota Data Fields" title="More about Symbiota Data Fields" aria-label="more info"/></a></th></tr>'."\n";
 		foreach($sourceArr as $fieldName){
 			if($fieldName == 'coreid') continue;
 			$diplayFieldName = $fieldName;

--- a/collections/admin/importextended.php
+++ b/collections/admin/importextended.php
@@ -226,9 +226,9 @@ if ($IS_ADMIN || (array_key_exists('CollAdmin', $USER_RIGHTS) && in_array($colli
 		<div class="pageDescription-div">
 			<?= $LANG['INSTRUCTIONS'] ?>:
 			<ul>
-				<li><a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Importing_Uploading/linked_resources" target="_blank"><?= $LANG['ASSOCIATIONS'] ?></a></li>
-				<?php if ($IS_ADMIN) echo '<li><a href="https://docs.symbiota.org/docs/Portal_Manager_Guide/importing_determinations" target="_blank">' . $LANG['DETERMINATIONS'] . '</a></li>'; ?>
-				<li><a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Images/media_upload_url" target="_blank"><?= $LANG['IMAGE_URLS'] ?></a></li>
+				<li><a href="https://docs.symbiota.org/Collection_Manager_Guide/Importing_Uploading/linked_resources" target="_blank"><?= $LANG['ASSOCIATIONS'] ?></a></li>
+				<?php if ($IS_ADMIN) echo '<li><a href="https://docs.symbiota.org/Portal_Manager_Guide/importing_determinations" target="_blank">' . $LANG['DETERMINATIONS'] . '</a></li>'; ?>
+				<li><a href="https://docs.symbiota.org/Collection_Manager_Guide/Images/media_upload_url" target="_blank"><?= $LANG['IMAGE_URLS'] ?></a></li>
 			</ul>
 		</div>
 		<?php

--- a/collections/datasets/datapublisher.php
+++ b/collections/datasets/datapublisher.php
@@ -235,8 +235,8 @@ if ($isEditor) {
 				<?php
 				echo $LANG['DWCA_EXPLAIN_1'] . ' <a href="https://en.wikipedia.org/wiki/Darwin_Core_Archive" target="_blank">' . $LANG['DWCA'] . '</a> ' . $LANG['DWCA_EXPLAIN_2'] .
 					' <a href="http://rs.tdwg.org/dwc/terms/" target="_blank">' . $LANG['DWC'] . '</a> ' . $LANG['DWCA_EXPLAIN_3'] .
-					' <a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Data_Publishing/publishing_idigbio" target="_blank"> ' . $LANG['PUBLISH_IDIGBIO'] . '</a> &amp;' .
-					' <a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Data_Publishing/publishing_gbif" target="_blank"> ' . $LANG['PUBLISH_GBIF'] . '</a>.';
+					' <a href="https://docs.symbiota.org/Collection_Manager_Guide/Data_Publishing/publishing_idigbio" target="_blank"> ' . $LANG['PUBLISH_IDIGBIO'] . '</a> &amp;' .
+					' <a href="https://docs.symbiota.org/Collection_Manager_Guide/Data_Publishing/publishing_gbif" target="_blank"> ' . $LANG['PUBLISH_GBIF'] . '</a>.';
 				?>
 			</div>
 			<?php

--- a/collections/editor/dupesearch.php
+++ b/collections/editor/dupesearch.php
@@ -383,7 +383,7 @@ if(!$IS_ADMIN){
 										</a>
 									</div>
 									<div style="margin-left:5px;float:left;">
-										<a href="https://docs.symbiota.org/docs/Editor_Guide/Editing_Searching_Records/duplicate_matching#merge-records" target="_blank" id="mergeduplicateinfo" style="text-decoration:none;">
+										<a href="https://docs.symbiota.org/Editor_Guide/Editing_Searching_Records/duplicate_matching#merge-records" target="_blank" id="mergeduplicateinfo" style="text-decoration:none;">
 											<img src="../../images/info.png" style="width:1.3em;" alt="<?php echo $LANG['MORE_INFO_ALT']; ?>" title="<?php echo $LANG['MORE_INFO']; ?>" aria-label="<?php echo $LANG['MORE_INFO']; ?>"/>
 										</a>
 									</div>

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -471,7 +471,7 @@ if ($SYMB_UID) {
 									<a href="#" onclick="$('li.importItem').show(); return false;">
 										<?= $LANG['IMPORT_SPECIMEN'] ?>
 									</a>
-									<a id="importinfo" href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Importing_Uploading/" target="_blank" title="<?php echo $LANG['MORE_INFO']; ?>" aria-label="<?php echo $LANG['MORE_INFO']; ?>">
+									<a id="importinfo" href="https://docs.symbiota.org/Collection_Manager_Guide/Importing_Uploading/" target="_blank" title="<?php echo $LANG['MORE_INFO']; ?>" aria-label="<?php echo $LANG['MORE_INFO']; ?>">
 											<img src="../../images/info.png" style="width:13px;" alt="<?= $LANG['INFO_ALT'] ?>" />
 									</a><br/>
 								</li>

--- a/content/lang/collections/specprocessor/crowdsource/controlpanel.en.php
+++ b/content/lang/collections/specprocessor/crowdsource/controlpanel.en.php
@@ -8,7 +8,7 @@ Language: English
 $LANG['CROWDSOURCING_ADMIN'] = 'Crowdsourcing Administration';
 $LANG['CROWDSOURCE_EXPLAIN'] = 'This module can be used to submit and manage records for data entry by the
 							general public. For more information, see the 
-							<a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Crowdsourcing/adding_crowdsourcing" target="_blank">
+							<a href="https://docs.symbiota.org/Collection_Manager_Guide/Crowdsourcing/adding_crowdsourcing" target="_blank">
 							Symbiota documentation on crowdsourcing</a>';
 $LANG['EDIT_PROJECT'] = 'Edit Project';
 $LANG['GENERAL_INSTRUCTIONS'] = 'General Instructions';

--- a/content/lang/collections/specprocessor/crowdsource/controlpanel.es.php
+++ b/content/lang/collections/specprocessor/crowdsource/controlpanel.es.php
@@ -7,7 +7,7 @@ Language: Español
 $LANG['CROWDSOURCING_ADMIN'] = 'Administración de Crowdsourcing';
 $LANG['CROWDSOURCE_EXPLAIN'] = 'Esta herramienta es para entregar y gestionar registros para el ingreso de datos por
 							el publico general. Por más información revisa a
-							<a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Crowdsourcing/adding_crowdsourcing" target="_blank">
+							<a href="https://docs.symbiota.org/Collection_Manager_Guide/Crowdsourcing/adding_crowdsourcing" target="_blank">
 							Documentación de Symbiota para Crowdsourcing</a>';
 $LANG['EDIT_PROJECT'] = 'Editar el Proyecto';
 $LANG['GENERAL_INSTRUCTIONS'] = 'Instrucciones Generales';

--- a/content/lang/collections/specprocessor/crowdsource/controlpanel.fr.php
+++ b/content/lang/collections/specprocessor/crowdsource/controlpanel.fr.php
@@ -9,7 +9,7 @@ Translated by: Google Translate
 $LANG['CROWDSOURCING_ADMIN'] = 'Administración de Crowdsourcing';
 $LANG['CROWDSOURCE_EXPLAIN'] = 'Ce module peut être utilisé pour soumettre et gérer des enregistrements pour la saisie de données par le
 			grand public. Pour plus d\'informations, consultez le
-			<a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Crowdsourcing/adding_crowdsourcing" target="_blank">
+			<a href="https://docs.symbiota.org/Collection_Manager_Guide/Crowdsourcing/adding_crowdsourcing" target="_blank">
 			Documentation Symbiota sur le crowdsourcing</a>';
 $LANG['EDIT_PROJECT'] = 'Modifier le projet';
 $LANG['GENERAL_INSTRUCTIONS'] = 'Instructions générales';

--- a/content/lang/collections/specprocessor/specprocessor_tools.en.php
+++ b/content/lang/collections/specprocessor/specprocessor_tools.en.php
@@ -52,7 +52,7 @@ $LANG['MUST_MAP_CATNUM'] = 'Catalog Number or Other Catalog Numbers must be mapp
 $LANG['LARGE_URL_MAPPED'] = 'Large Image URL must both be mapped to an import field';
 $LANG['IMG_PROCESSOR_EXPLAIN'] = 'These tools are designed to aid collection managers in batch processing specimen images. Contact portal manager for help in setting up a new workflow.
 				 Once a profile is established, the collection manager can use this form to manually trigger image processing. For more information, see the Symbiota documentation for
-				 <b><a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Images/batch_adding" target="_blank">recommended practices</a></b> for integrating images.';
+				 <b><a href="https://docs.symbiota.org/Collection_Manager_Guide/Images/batch_adding" target="_blank">recommended practices</a></b> for integrating images.';
 $LANG['IMG_FILE_UPLOAD_MAP'] = 'Image File Upload Map';
 $LANG['SOURCE_FIELD'] = 'Source Field';
 $LANG['TARGET_FIELD'] = 'Target Field';

--- a/content/lang/collections/specprocessor/specprocessor_tools.es.php
+++ b/content/lang/collections/specprocessor/specprocessor_tools.es.php
@@ -54,7 +54,7 @@ $LANG['MUST_MAP_CATNUM'] = 'El número de catálogo u otros números de catálog
 $LANG['LARGE_URL_MAPPED'] = 'La URL de imagen grande debe estar asignada a un campo de importación';
 $LANG['IMG_PROCESSOR_EXPLAIN'] = 'Estas herramientas están diseñadas para ayudar a los administradores de colecciones en el procesamiento por lotes de imágenes de muestras. Póngase en contacto con el administrador del portal para obtener ayuda para configurar un nuevo flujo de trabajo.
 			Una vez que se establece un perfil, el administrador de la colección puede usar este formulario para activar manualmente el procesamiento de imágenes. Para obtener más información, consulte la documentación de Symbiota para
-			<b><a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Images/batch_adding" target="_blank">prácticas recomendadas</a></b> para integrar imágenes.' ;
+			<b><a href="https://docs.symbiota.org/Collection_Manager_Guide/Images/batch_adding" target="_blank">prácticas recomendadas</a></b> para integrar imágenes.' ;
 $LANG['IMG_FILE_UPLOAD_MAP'] = 'Mapa de carga de archivos de imagen';
 $LANG['SOURCE_FIELD'] = 'Campo de origen';
 $LANG['TARGET_FIELD'] = 'Campo de destino';

--- a/content/lang/collections/specprocessor/specprocessor_tools.fr.php
+++ b/content/lang/collections/specprocessor/specprocessor_tools.fr.php
@@ -54,7 +54,7 @@ $LANG['MUST_MAP_CATNUM'] = "Le numéro de catalogue ou d'autres numéros de cata
 $LANG['LARGE_URL_MAPPED'] = "L'URL des grandes images doit être mappée à un champ d'importation";
 $LANG['IMG_PROCESSOR_EXPLAIN'] = 'Ces outils sont conçus pour aider les gestionnaires de collections dans le traitement par lots d\'images d\'échantillons. Contactez le gestionnaire de portail pour obtenir de l\'aide sur la configuration d\'un nouveau flux de travail.
 			Une fois le profil établi, le gestionnaire de collection peut utiliser ce formulaire pour déclencher manuellement le traitement des images. Pour plus d\'informations, consultez la documentation Symbiota pour
-			<b><a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Images/batch_adding" target="_blank">pratiques recommandées</a></b> pour l\'intégration d\'images.' ;
+			<b><a href="https://docs.symbiota.org/Collection_Manager_Guide/Images/batch_adding" target="_blank">pratiques recommandées</a></b> pour l\'intégration d\'images.' ;
 $LANG['IMG_FILE_UPLOAD_MAP'] = 'Carte de téléchargement de fichier image';
 $LANG['SOURCE_FIELD'] = 'Champ source';
 $LANG['TARGET_FIELD'] = 'Champ cible';

--- a/includes/footer_template.php
+++ b/includes/footer_template.php
@@ -20,7 +20,7 @@
 		<?= $LANG['F_NSF_AWARDS'] ?> <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=" target="_blank">#------</a>.
 	</p>
 	<p>
-		<?= $LANG['F_MORE_INFO'] ?>, <a href="https://docs.symbiota.org/docs/about/" target="_blank" rel="noopener noreferrer"><?= $LANG['F_READ_DOCS'] ?></a> <?= $LANG['F_CONTACT'] ?>
+		<?= $LANG['F_MORE_INFO'] ?>, <a href="https://docs.symbiota.org/about/" target="_blank" rel="noopener noreferrer"><?= $LANG['F_READ_DOCS'] ?></a> <?= $LANG['F_CONTACT'] ?>
 		<a href="https://symbiota.org/contact-the-support-hub/" target="_blank" rel="noopener noreferrer"><?= $LANG['F_SSH'] ?></a>.
 	</p>
 	<p>

--- a/includes/header_template.php
+++ b/includes/header_template.php
@@ -91,7 +91,7 @@ $collectionSearchPage = !empty($SHOULD_USE_HARVESTPARAMS) ? '/collections/index.
 						</a>
 					</li>
 					<li>
-						<a href="https://docs.symbiota.org/docs/about/" target="_blank" rel="noopener noreferrer">
+						<a href="https://docs.symbiota.org/about/" target="_blank" rel="noopener noreferrer">
 							<?= $LANG['H_HELP'] ?>
 						</a>
 					</li>

--- a/includes/minimalheader_template.php
+++ b/includes/minimalheader_template.php
@@ -43,7 +43,7 @@ $collectionSearchPage = !empty($SHOULD_USE_HARVESTPARAMS) ? '/collections/index.
 						</a>
 					</li>
 					<li>
-						<a href="https://docs.symbiota.org/docs/about/" target="_blank" rel="noopener noreferrer">
+						<a href="https://docs.symbiota.org/about/" target="_blank" rel="noopener noreferrer">
 							<?= $LANG['H_HELP'] ?>
 						</a>
 					</li>

--- a/js/symb/collections.imageoccursubmit.js
+++ b/js/symb/collections.imageoccursubmit.js
@@ -85,7 +85,7 @@ function validateImgOccurForm(f){
 
 //Misc
 function dwcDoc(dcTag){
-	dwcWindow=open("https://docs.symbiota.org/docs/Editor_Guide/Editing_Searching_Records/symbiota_data_fields#"+dcTag,"dwcaid","width=1250,height=300,left=20,top=20,scrollbars=1");
+	dwcWindow=open("https://docs.symbiota.org/Editor_Guide/Editing_Searching_Records/symbiota_data_fields#"+dcTag,"dwcaid","width=1250,height=300,left=20,top=20,scrollbars=1");
 	//dwcWindow=open("http://rs.tdwg.org/dwc/terms/index.htm#"+dcTag,"dwcaid","width=1250,height=300,left=20,top=20,scrollbars=1");
 	if(dwcWindow.opener == null) dwcWindow.opener = self;
 	dwcWindow.focus();

--- a/sitemap.php
+++ b/sitemap.php
@@ -253,7 +253,7 @@ if(!$schemaVersion){
 					<div id="images">
 						<p class="description">
 							<?= $LANG['SEESYMBDOC'] ?>
-							<a href="https://docs.symbiota.org/docs/Collection_Manager_Guide/Images" target="_blank"><?= $LANG['IMGSUB'] ?></a>
+							<a href="https://docs.symbiota.org/Collection_Manager_Guide/Images" target="_blank"><?= $LANG['IMGSUB'] ?></a>
 							<?= $LANG['FORANOVERVIEW'] ?>
 						</p>
 					</div>
@@ -440,7 +440,7 @@ if(!$schemaVersion){
 					</h2>
 					<p class="description">
 						<?= $LANG['PARA2'] ?>
-						<a href="https://docs.symbiota.org/docs/Collector_Observer_Guide/" target="_blank"><?= $LANG['SYMBDOCU'] ?></a> <?= $LANG['FORMOREINFO'] ?>.
+						<a href="https://docs.symbiota.org/Collector_Observer_Guide/" target="_blank"><?= $LANG['SYMBDOCU'] ?></a> <?= $LANG['FORMOREINFO'] ?>.
 					<p class="description">
 					<h3 class="subheader">
 						<span>

--- a/taxa/taxonomy/batchloader.php
+++ b/taxa/taxonomy/batchloader.php
@@ -195,7 +195,7 @@ if($isEditor){
 		<div style="margin:30px;">
 			<div style="margin-bottom:30px;">
 				<?php echo $LANG['TAX_UPLOAD_EXPLAIN1'] . ' '; ?>
-				<a href="https://docs.symbiota.org/docs/Portal_Manager_Guide/Taxonomic_Thesaurus/batch_loading"><?php echo $LANG['SYMB_DOC']; ?></a>
+				<a href="https://docs.symbiota.org/Portal_Manager_Guide/Taxonomic_Thesaurus/batch_loading"><?php echo $LANG['SYMB_DOC']; ?></a>
 				<?php echo $LANG['TAX_UPLOAD_EXPLAIN2'] ?>
 			</div>
 			<?php


### PR DESCRIPTION
# Pull Request Checklist:
Due to changes in Symbiota Docs, we no longer need /docs/ in any of the links.

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [branched off of Hotfix] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.