### PR TITLE
Bugfix: a locale without an iso code becomes the default for vernacular imports

### DIFF
--- a/classes/TPEditorManager.php
+++ b/classes/TPEditorManager.php
@@ -315,7 +315,9 @@ class TPEditorManager extends Manager {
 		$rs = $this->conn->query($sql);
 		while($r = $rs->fetch_object()){
 			$retArr[$r->langname] = $r->langid;
-			$retArr[$r->iso639_1] = $r->langid;
+			if (!empty($r->iso639_1)) {
+				$retArr[$r->iso639_1] = $r->langid;
+			}
 		}
 		$rs->free();
 		return $retArr;

--- a/classes/TaxonProfile.php
+++ b/classes/TaxonProfile.php
@@ -1037,7 +1037,9 @@ class TaxonProfile extends Manager {
 		$rs = $this->conn->query($sql);
 		while($r = $rs->fetch_object()){
 			$this->langArr[strtolower($r->langname)] = $r->langid;
-			$this->langArr[strtolower($r->iso639_1)] = $r->langid;
+			if (!empty($r->iso639_1)) {
+				$this->langArr[strtolower($r->iso639_1)] = $r->langid;
+			}
 		}
 		$rs->free();
 	}

--- a/classes/TaxonomyHarvester.php
+++ b/classes/TaxonomyHarvester.php
@@ -1625,7 +1625,9 @@ class TaxonomyHarvester extends Manager{
 			$rs = $this->conn->query($sql);
 			while($r = $rs->fetch_object()){
 				$this->langArr[$r->langname] = $r->langid;
-				$this->langArr[$r->iso639_1] = $r->langid;
+				if (!empty($r->iso639_1)) {
+					$this->langArr[$r->iso639_1] = $r->langid;
+				}
 			}
 			$rs->free();
 		}

--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -1043,7 +1043,9 @@ class TaxonomyUpload{
 			$rs = $this->conn->query($sql);
 			while($r = $rs->fetch_object()){
 				$this->langArr[$r->langname] = $r->langid;
-				$this->langArr[$r->iso639_1] = $r->langid;
+				if (!empty($r->iso639_1)) {
+					$this->langArr[$r->iso639_1] = $r->langid;
+				}
 			}
 			$rs->free();
 		}


### PR DESCRIPTION
We have several indigenous languages in our `adminlanguages` table, some of which do not have an ISO 639-1 code. When we uploaded a taxonomy file via the batch loader that contained a 'vernacular' column with no explicit 'vernlang', we encountered unexpected behavior where the taxavernaculars were added with the langid of one of those indigenous languages, rather than the expected default of English (langid 1). This was because the `array_key_exists` [here](https://github.com/Symbiota/Symbiota/blob/master/classes/TaxonomyUpload.php#L872) matched the `null` key set via setLangArr(). 

I found a couple other instances in the code where the same pattern could cause similar unexpected behavior. I haven't tested these other classes but I think it should be safe to add this guard. I used `empty()` so it could handle both NULL and empty string ISO codes.


# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
