### PR TITLE
Enhancement/required red asterisk

### DIFF
--- a/collections/editor/batchdeterminations.php
+++ b/collections/editor/batchdeterminations.php
@@ -428,11 +428,12 @@ if($isEditor){
 									<a href="../reports/annotationmanager.php?collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" target="_blank"><img src="../../images/list.png" style="width:1.2em" title="<?php echo htmlspecialchars($LANG['DISPLAY_QUEUE'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" /></a>
 								</div>
 								<div style='margin:15px;'>
-									<div style="float:left;">
+									<div>
 										<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
 										<input name="tabtarget" type="hidden" value="0" />
 										<button type="submit" name="formsubmit" value="Add New Determinations"><?php echo $LANG['ADD_DETERS']; ?></button>
 									</div>
+									<p><?php include('includes/requiredFieldInstruction.php')?></p>
 								</div>
 							</fieldset>
 						</div>

--- a/collections/editor/batchdeterminations.php
+++ b/collections/editor/batchdeterminations.php
@@ -387,8 +387,8 @@ if($isEditor){
 									<input type="text" name="identificationqualifier" title="e.g. cf, aff, etc" />
 								</div>
 								<div style='margin:3px;'>
-									<b><?php echo $LANG['SCINAME']; ?>:</b>
-									<input type="text" id="dafsciname" name="sciname" style="background-color:lightyellow;width:350px;" onfocus="initDetAutocomplete(this.form)" />
+									<label for="dafsciname"><b><?= $LANG['SCINAME']; ?></b></label>:
+									<input type="text" id="dafsciname" name="sciname" required style="width:350px;" onfocus="initDetAutocomplete(this.form)" />
 									<input type="hidden" id="daftidtoadd" name="tidtoadd" value="" />
 									<input type="hidden" name="family" value="" />
 								</div>
@@ -405,12 +405,12 @@ if($isEditor){
 									</select>
 								</div>
 								<div id="identifiedByDiv" style='margin:3px;'>
-									<b><?php echo $LANG['DETERMINER']; ?>:</b>
-									<input type="text" name="identifiedby" id="identifiedby" style="background-color:lightyellow;width:200px;" />
+									<label for="identifiedby"><b><?= $LANG['DETERMINER']; ?></b></label>:
+									<input type="text" name="identifiedby" id="identifiedby" required style="width:200px;" />
 								</div>
 								<div id="dateIdentifiedDiv" style='margin:3px;'>
-									<b><?php echo $LANG['DATE']; ?>:</b>
-									<input type="text" name="dateidentified" id="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
+									<label for="dateidentified"><b><?= $LANG['DATE']; ?></b></label>:
+									<input type="text" name="dateidentified" id="dateidentified" required onchange="detDateChanged(this.form);" />
 								</div>
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['REFERENCE']; ?>:</b>

--- a/collections/editor/includes/determinationtab.php
+++ b/collections/editor/includes/determinationtab.php
@@ -206,7 +206,7 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 							<input type="hidden" name="catalognumber" value="<?php echo $catalognumber; ?>" />
 							<input type="hidden" name="institutioncode" value="<?php echo $institutioncode; ?>" />
 							<input type="hidden" name="csmode" value="<?php echo $crowdSourceMode; ?>" />
-							<div style="float:left;">
+							<div>
 								<button type="submit" name="submitaction" class="button" value="submitDetermination" ><?php echo $LANG['SUBMIT_DET']; ?></button>
 							</div>
 						</div>

--- a/collections/editor/includes/determinationtab.php
+++ b/collections/editor/includes/determinationtab.php
@@ -159,14 +159,14 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 							<input type="text" name="identificationqualifier" title="e.g. cf, aff, etc" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['SCI_NAME']; ?>:</b>
-							<input type="text" id="dafsciname" name="sciname" style="background-color:lightyellow;width:350px;" onfocus="initDetAutocomplete(this.form)" />
+							<label for="dafsciname"><b><?= $LANG['SCI_NAME']; ?></b></label>:
+							<input type="text" id="dafsciname" name="sciname" required style="width:350px;" onfocus="initDetAutocomplete(this.form)" />
 							<input type="hidden" id="daftidtoadd" name="tidtoadd" value="" />
 							<input type="hidden" name="family" value="" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['AUTHOR']; ?>:</b>
-							<input type="text" name="scientificnameauthorship" style="width:200px;" />
+							<label for="add_scientificnameauthorship"><b><?= $LANG['AUTHOR']; ?></b></label>:
+							<input id="add_scientificnameauthorship" type="text" name="scientificnameauthorship" style="width:200px;" />
 						</div>
 						<div style='margin:3px;'>
 							<b><?php echo $LANG['CONFIDENCE_IN_DET']; ?>:</b>
@@ -177,12 +177,12 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 							</select>
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['DETERMINER']; ?>:</b>
-							<input type="text" name="identifiedby" style="background-color:lightyellow;width:200px;" />
+							<label for="add_identifiedby"><b><?= $LANG['DETERMINER']; ?></b></label>:
+							<input id="add_identifiedby" type="text" name="identifiedby" required style="width:200px;" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['DATE']; ?>:</b>
-							<input type="text" name="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
+							<label for="add_dateidentified"><b><?= $LANG['DATE']; ?></b></label>:
+							<input id="add_dateidentified" type="text" name="dateidentified" required onchange="detDateChanged(this.form);" />
 						</div>
 						<div style='margin:3px;'>
 							<b><?php echo $LANG['REFERENCE']; ?>:</b>
@@ -287,8 +287,8 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 									<input type="text" name="identificationqualifier" value="<?php echo $detRec['identificationqualifier']; ?>" title="e.g. cf, aff, etc" />
 								</div>
 								<div style='margin:3px;'>
-									<b><?php echo $LANG['SCI_NAME']; ?>:</b>
-									<input type="text" id="defsciname-<?php echo $detId;?>" name="sciname" value="<?php echo $detRec['sciname']; ?>" style="background-color:lightyellow;width:350px;" onfocus="initDetAutocomplete(this.form)" />
+									<label for="defsciname"><b><?= $LANG['SCI_NAME']; ?></b></label>:
+									<input type="text" id="defsciname-<?php echo $detId;?>" name="sciname" value="<?php echo $detRec['sciname']; ?>" required style="width:350px;" onfocus="initDetAutocomplete(this.form)" />
 									<input type="hidden" id="deftidtoadd" name="tidtoadd" value="" />
 									<input type="hidden" name="family" value="" />
 								</div>
@@ -297,12 +297,12 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 									<input type="text" name="scientificnameauthorship" value="<?php echo $detRec['scientificnameauthorship']; ?>" style="width:200px;" />
 								</div>
 								<div style='margin:3px;'>
-									<b><?php echo $LANG['DETERMINER']; ?>:</b>
-									<input type="text" name="identifiedby" value="<?php echo $detRec['identifiedby']; ?>" style="background-color:lightyellow;width:200px;" />
+									<label for="edit_identifiedby"><b><?= $LANG['DETERMINER']; ?></b></label>:
+									<input id="edit_identifiedby" type="text" name="identifiedby" value="<?php echo $detRec['identifiedby']; ?>" required style="width:200px;" />
 								</div>
 								<div style='margin:3px;'>
-									<b><?php echo $LANG['DATE']; ?>:</b>
-									<input type="text" name="dateidentified" value="<?php echo $detRec['dateidentified']; ?>" style="background-color:lightyellow;" />
+									<label for="edit_identifiedby"><b><?= $LANG['DATE']; ?></b></label>:
+									<input id="edit_identifiedby" type="text" name="dateidentified" value="<?php echo $detRec['dateidentified']; ?>" required />
 								</div>
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['REFERENCE']; ?>:</b>

--- a/collections/editor/includes/determinationtab.php
+++ b/collections/editor/includes/determinationtab.php
@@ -209,6 +209,7 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 							<div>
 								<button type="submit" name="submitaction" class="button" value="submitDetermination" ><?php echo $LANG['SUBMIT_DET']; ?></button>
 							</div>
+							<p><?php include('requiredFieldInstruction.php') ?></p>
 						</div>
 					</fieldset>
 				</form>
@@ -325,6 +326,7 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 									<input type="hidden" name="occindex" value="<?php echo $occIndex; ?>" />
 									<input type="hidden" name="csmode" value="<?php echo $crowdSourceMode; ?>" />
 									<button type="submit" name="submitaction" class="button" value="submitDeterminationEdit"><?php echo $LANG['SUBMIT_DET_EDITS']; ?></button>
+									<p><?php include('requiredFieldInstruction.php') ?></p>
 								</div>
 							</form>
 							<?php

--- a/collections/editor/includes/requiredFieldInstruction.php
+++ b/collections/editor/includes/requiredFieldInstruction.php
@@ -1,0 +1,6 @@
+<?php global $LANG, $LANG_TAG, $SERVER_ROOT;
+
+include_once($SERVER_ROOT . '/content/lang/collections/editor/includes/requiredFieldInstruction.' . ($LANG_TAG ?? 'en') . '.php');
+?>
+
+<span style="color:red;">*</span> <?= $LANG['REQUIRED_FIELD'] ?>

--- a/collections/loans/specimentab.php
+++ b/collections/loans/specimentab.php
@@ -340,8 +340,8 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 						<input type="text" name="identificationqualifier" title="<?php echo $LANG['ID_QUALIFIER_EX']; ?>" />
 					</div>
 					<div style='margin:3px;'>
-						<b><?php echo $LANG['SCI_NAME']; ?>:</b>
-						<input type="text" id="dafsciname" name="sciname" style="background-color:lightyellow;width:350px;" onfocus="initLoanDetAutocomplete(this.form)" />
+						<label for="dafsciname"><b><?php echo $LANG['SCI_NAME']; ?></b></label>:
+						<input type="text" id="dafsciname" name="sciname" required style="width:350px;" onfocus="initLoanDetAutocomplete(this.form)" />
 						<input type="hidden" id="daftidtoadd" name="tidtoadd" value="" />
 						<input type="hidden" name="family" value="" />
 					</div>
@@ -358,12 +358,12 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 						</select>
 					</div>
 					<div style='margin:3px;'>
-						<b><?php echo $LANG['DETERMINER']; ?>:</b>
-						<input type="text" name="identifiedby" id="identifiedby" style="background-color:lightyellow;width:200px;" />
+						<label for="identifiedby"><b><?php echo $LANG['DETERMINER']; ?></b></label>:
+						<input type="text" name="identifiedby" id="identifiedby" required style="width:200px;" />
 					</div>
 					<div style='margin:3px;'>
-						<b><?php echo $LANG['DATE']; ?>:</b>
-						<input type="text" name="dateidentified" id="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
+						<label for="dateidentified"><b><?php echo $LANG['DATE']; ?></b></label>:
+						<input type="text" name="dateidentified" id="dateidentified" required onchange="detDateChanged(this.form);" />
 					</div>
 					<div style='margin:3px;'>
 						<b><?php echo $LANG['REFERENCE']; ?>:</b>

--- a/content/lang/collections/editor/includes/requiredFieldInstruction.en.php
+++ b/content/lang/collections/editor/includes/requiredFieldInstruction.en.php
@@ -1,0 +1,8 @@
+<?php global $LANG;
+/*
+------------------
+Language: English
+------------------
+*/
+
+$LANG['REQUIRED_FIELD'] = 'Required Field';

--- a/content/lang/collections/editor/includes/requiredFieldInstruction.es.php
+++ b/content/lang/collections/editor/includes/requiredFieldInstruction.es.php
@@ -1,0 +1,9 @@
+<?php global $LANG;
+/*
+------------------
+Language: Español (Spanish)
+Translated by: Google Translate
+------------------
+*/
+
+$LANG['REQUIRED_FIELD'] = 'Campo obligatorio';

--- a/content/lang/collections/editor/includes/requiredFieldInstruction.fr.php
+++ b/content/lang/collections/editor/includes/requiredFieldInstruction.fr.php
@@ -1,0 +1,9 @@
+<?php global $LANG;
+/*
+------------------
+Language: Français (French)
+Translated by: Google Translate (2025-8-13)
+------------------
+*/
+
+$LANG['REQUIRED_FIELD'] = 'Champ obligatoire';

--- a/css/symbiota/collections/editor/editormain.css
+++ b/css/symbiota/collections/editor/editormain.css
@@ -382,4 +382,9 @@ img[id^="activeimg-"] {
 
 button.icon-button svg {
 	fill: var(--light-color);
-  }
+}
+
+form label:has(+ input[required]):after {
+	color: red;
+	content: '*';
+}

--- a/css/symbiota/main.css
+++ b/css/symbiota/main.css
@@ -334,6 +334,11 @@ fieldset {
   border-image: initial;
 }
 
+form label:has(+ input[required]):after {
+  color: red;
+  content: '*';
+}
+
 /* Base Button Button CSS
 ========================================================================== */
 button {


### PR DESCRIPTION
# Issue #2711

# Summary
Changes yellow require fields to use red asterisk instead of yellow background.
Note this only changes it in the places where the yellow background occurs. More specification on the issue and what the required fields are in different pages will be need to progress this further.

Options: 
<img width="527" height="50" alt="asterisk_before" src="https://github.com/user-attachments/assets/10dcd3cb-4c3d-4619-82df-3bf515e21e26" />
or
<img width="511" height="38" alt="asterisk_after" src="https://github.com/user-attachments/assets/bae65695-a4d2-4913-968f-7a2e6eeb5c49" />

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
