### PR TITLE
Hotfix 3.3.6 fixup (#2810)

### DIFF
--- a/classes/ImageLibrarySearch.php
+++ b/classes/ImageLibrarySearch.php
@@ -208,7 +208,7 @@ class ImageLibrarySearch extends OccurrenceTaxaManager{
 			//Note mediaType is cleaned to only be 'image' and 'audio' strings
 			$sqlWhere .= 'AND (m.mediaType = "' . $this->mediaType . '") ';
 		}
-		$sqlWhere .= OccurrenceUtil::appendFullProtectionSQL(true);
+		//$sqlWhere .= OccurrenceUtil::appendFullProtectionSQL(true);
 		if(strpos($sqlWhere,'ts.taxauthid')) $sqlWhere = str_replace('m.tid', 'ts.tid', $sqlWhere);
 		if($sqlWhere) $this->sqlWhere = 'WHERE '.substr($sqlWhere,4);
 	}

--- a/classes/OccurrenceEditorResource.php
+++ b/classes/OccurrenceEditorResource.php
@@ -91,7 +91,7 @@ class OccurrenceEditorResource extends OccurrenceEditorManager {
 			$rs = $this->conn->query($sql);
 			while($r = $rs->fetch_object()){
 				$catNum = '';
-				if(strpos($r->catalogNumber,$r->collcode) === false) $catNum = $r->collcode.':';
+				if(!empty($r->catalogNumber) && strpos($r->catalogNumber,$r->collcode) === false) $catNum = $r->collcode.':';
 				$catNum .= $r->catalogNumber;
 				if($r->otherCatalogNumbers){
 					if($catNum) $catNum .= ' ('.$r->otherCatalogNumbers.')';

--- a/classes/OmAssociations.php
+++ b/classes/OmAssociations.php
@@ -18,7 +18,7 @@ class OmAssociations extends Manager{
 		parent::__construct(null, 'write', $conn);
 		$this->schemaMap = array('associationType' => 's', 'occidAssociate' => 'i', 'relationship' => 's', 'relationshipID' => 's', 'subType' => 's', 'objectID' => 's',
 			'basisOfRecord' => 's', 'resourceUrl' => 's', 'verbatimSciname' => 's', 'tid' => 'i', 'locationOnHost' => 's', 'conditionOfAssociate' => 's', 'establishedDate' => 's',
-			'imageMapJSON' => 's', 'dynamicProperties' => 's', 'notes' => 's', 'accordingTo' => 's', 'instanceID' => 's', 'recordID' => 's');
+			'imageMapJSON' => 's', 'dynamicProperties' => 's', 'notes' => 's', 'accordingTo' => 's', 'instanceID' => 's', 'recordID' => 's', 'createdUid' => 's');
 	}
 
 	public function __destruct(){

--- a/collections/editor/includes/resourcetab.php
+++ b/collections/editor/includes/resourcetab.php
@@ -366,6 +366,7 @@ $dupClusterArr = $dupManager->getClusterArr($occid);
 						<input name="occid" type="hidden" value="<?php echo $occid; ?>" />
 						<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
 						<input name="occindex" type="hidden" value="<?php echo $occIndex ?>" />
+						<input name="createdUid" type="hidden" value="<?php echo $GLOBALS['SYMB_UID'] ?>" />
 						<button name="submitaction" type="submit" class="button" value="createAssociation"><?php echo $LANG['CREATE_ASSOC']; ?></button>
 					</div>
 				</div>

--- a/profile/index.php
+++ b/profile/index.php
@@ -1,5 +1,7 @@
 <?php
 include_once('../config/symbini.php');
+include_once('../classes/utilities/GeneralUtil.php');
+
 if(!empty($THIRD_PARTY_OID_AUTH_ENABLED)){
 	include_once($SERVER_ROOT . '/config/auth_config.php');
 	require_once($SERVER_ROOT . '/vendor/autoload.php');
@@ -15,7 +17,7 @@ if($SYMB_UID){
 		header("Location:" . $_REQUEST['refurl']);
 	}
 	else{
-		header("Location:" . $CLIENT_ROOT . '/profile/viewprofile.php');
+		header("Location:" . GeneralUtil::getDomain() . $CLIENT_ROOT . '/profile/viewprofile.php');
 	}
 }
 
@@ -90,7 +92,7 @@ if($action == 'logout'){
 	}
 	else{
 		$pHandler->reset();
-		header('Location: '  . ($CLIENT_ROOT? '/' . $CLIENT_ROOT: '') . '/index.php');
+		header('Location: ' . GeneralUtil::getDomain() . $CLIENT_ROOT . '/index.php');
 	}
 }
 elseif($action == 'login'){


### PR DESCRIPTION
* Use bycrpt only when flag is enabled
* Add absolute paths to logout
* add reset connection to password update
* cherry pick 066e6fe9e fix bug where strpos of null is deprecated and add createdUid OmAssociations schema map, where it was missing, and add a value as a hidden input to the association creation form (#2811)

---------

Co-authored-by: MuchQuak loganpwilt@gmail.com

