### PR TITLE
Remove css elements that were causing 404 & 403 errors

### DIFF
--- a/collections/search/css/searchStylesInner.css
+++ b/collections/search/css/searchStylesInner.css
@@ -23,18 +23,6 @@
   font-size: 1.1rem !important;
 }
 
-@font-face {
-  font-family: "Material Icons";
-  font-style: normal;
-  font-weight: 400;
-  src: url(../fonts/MaterialIcons-Regular.eot);
-  src: local("Material Icons");
-  src: local("MaterialIcons-Regular");
-  src: url(../fonts/MaterialIcons-Regular.woff2) format("woff2");
-  src: url(../fonts/MaterialIcons-Regular.woff) format("woff");
-  src: url(../fonts/MaterialIcons-Regular.ttf) format("truetype");
-}
-
 .inner-search .material-icons {
   font-family: "Material Icons";
   font-weight: normal;

--- a/css/jquery-ui.css
+++ b/css/jquery-ui.css
@@ -1065,36 +1065,22 @@ a.ui-button:active,
 }
 .ui-icon,
 .ui-widget-content .ui-icon {
-	background-image: url("images/ui-icons_444444_256x240.png");
-	background-image: url("../../images/css/images/ui-icons_454545_256x240.png");
+	background-image: url("../images/css/images/ui-icons_454545_256x240.png");
 }
 .ui-widget-header .ui-icon {
-	background-image: url("images/ui-icons_444444_256x240.png");
-	background-image: url("../../images/css/images/ui-icons_454545_256x240.png");
+	background-image: url("../images/css/images/ui-icons_454545_256x240.png");
 }
 .ui-state-hover .ui-icon,
 .ui-state-focus .ui-icon,
 .ui-button:hover .ui-icon,
 .ui-button:focus .ui-icon {
-	background-image: url("images/ui-icons_555555_256x240.png");
-	background-image: url("../../images/css/images/ui-icons_454545_256x240.png");
+	background-image: url("../images/css/images/ui-icons_454545_256x240.png");
 }
 .ui-state-active .ui-icon,
 .ui-button:active .ui-icon {
-	background-image: url("images/ui-icons_ffffff_256x240.png");
-	background-image: url("../../images/css/images/ui-icons_454545_256x240.png");
+	background-image: url("../images/css/images/ui-icons_454545_256x240.png");
 }
-.ui-state-highlight .ui-icon,
-.ui-button .ui-state-highlight.ui-icon {
-	background-image: url("images/ui-icons_777620_256x240.png");
-}
-.ui-state-error .ui-icon,
-.ui-state-error-text .ui-icon {
-	background-image: url("images/ui-icons_cc0000_256x240.png");
-}
-.ui-button .ui-icon {
-	background-image: url("images/ui-icons_777777_256x240.png");
-}
+.ui-state-highlight .ui-icon
 
 /* positioning */
 /* Three classes needed to override `.ui-button:hover .ui-icon` */


### PR DESCRIPTION
Post, Gregory and I isolated an issue that was causing people to be banned erroneously by fail2ban. On collections/misc/collprofiles.php, there was a call to a file in the "collections/search/fonts" directory, which doesn't exist. This led us to wonder why collections/search has its own css and js subdirectories in the first place (everything should get consolidated in the main css and js folders), but that's a problem for another day (logged in this [GH issue](https://github.com/Symbiota/Symbiota/issues/2827)).

When we commented out lines 26-36 of collections/search/css/searchStylesInner.css, this fixed the problem. So, we went ahead and did this in all production portals. We will also put this in the next hotfix, but be advised that this will cause another merge conflict in the future.

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] Comment which GitHub issue(s), if any does this PR address

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.