### PR TITLE
Fix bug where desired processing status is not respected in tesseract workflow

### DIFF
--- a/classes/SpecProcessorOcr.php
+++ b/classes/SpecProcessorOcr.php
@@ -267,7 +267,7 @@ class SpecProcessorOcr extends Manager{
 					'WHERE (o.collid = '.$collid.') AND r.prlid IS NULL ';
 				if($procStatus){
 					if($procStatus == 'null') $sql .= 'AND processingstatus IS NULL';
-					else $sql .= 'AND o.processingstatus = "' . $procStatus . '" ';
+					else $sql .= 'AND o.processingstatus = "' . $this->cleanInStr($procStatus) . '" ';
 				} 
 				if($limit) $sql .= 'LIMIT '.$limit;
 				if($rs = $this->conn->query($sql)){

--- a/classes/SpecProcessorOcr.php
+++ b/classes/SpecProcessorOcr.php
@@ -265,7 +265,10 @@ class SpecProcessorOcr extends Manager{
 					'FROM omoccurrences o INNER JOIN media m ON o.occid = m.occid '.
 					'LEFT JOIN specprocessorrawlabels r ON m.mediaID = r.mediaID '.
 					'WHERE (o.collid = '.$collid.') AND r.prlid IS NULL ';
-				if($procStatus) $sql .= 'AND o.processingstatus = "' . $procStatus . '" ';
+				if($procStatus){
+					if($procStatus == 'null') $sql .= 'AND processingstatus IS NULL';
+					else $sql .= 'AND o.processingstatus = "' . $procStatus . '" ';
+				} 
 				if($limit) $sql .= 'LIMIT '.$limit;
 				if($rs = $this->conn->query($sql)){
 					$recCnt = 1;

--- a/classes/SpecProcessorOcr.php
+++ b/classes/SpecProcessorOcr.php
@@ -233,7 +233,7 @@ class SpecProcessorOcr extends Manager{
 			}
 			//Set temp folder path and file names
 			$ts = time();
-			$this->imgUrlLocal = $this->tempPath.$ts.'_img.jpg';
+			$this->imgUrlLocal = $this->tempPath.$ts.'_img.jpg'; // @TODO is it intentional that it is always .jpg?
 
 			//Copy image to temp folder
 			$status = copy($imgUrl,$this->imgUrlLocal);
@@ -265,7 +265,7 @@ class SpecProcessorOcr extends Manager{
 					'FROM omoccurrences o INNER JOIN media m ON o.occid = m.occid '.
 					'LEFT JOIN specprocessorrawlabels r ON m.mediaID = r.mediaID '.
 					'WHERE (o.collid = '.$collid.') AND r.prlid IS NULL ';
-				if($procStatus) $sql .= 'AND o.processingstatus = "unprocessed" ';
+				if($procStatus) $sql .= 'AND o.processingstatus = "' . $procStatus . '" ';
 				if($limit) $sql .= 'LIMIT '.$limit;
 				if($rs = $this->conn->query($sql)){
 					$recCnt = 1;

--- a/collections/specprocessor/processor.php
+++ b/collections/specprocessor/processor.php
@@ -129,6 +129,7 @@ $statusStr = "";
 					$batchLimit = 100;
 					if(array_key_exists('batchlimit',$_POST)) $batchLimit = $_POST['batchlimit'];
 					echo '<ul>';
+					if($procStatus == "null") $procStatus = null;
 					$ocrManager->batchOcrUnprocessed($collid,$procStatus,$batchLimit,0);
 					echo '</ul>';
 				}

--- a/collections/specprocessor/processor.php
+++ b/collections/specprocessor/processor.php
@@ -129,7 +129,6 @@ $statusStr = "";
 					$batchLimit = 100;
 					if(array_key_exists('batchlimit',$_POST)) $batchLimit = $_POST['batchlimit'];
 					echo '<ul>';
-					if($procStatus == "null") $procStatus = null;
 					$ocrManager->batchOcrUnprocessed($collid,$procStatus,$batchLimit,0);
 					echo '</ul>';
 				}


### PR DESCRIPTION
# Description

In the process of drafting specs for the voucher vision batch run, I tried to understand how batch OCR works with tesseract. I noticed that when I did not set a processing status, `$procStatus` got set to the string `"null"`. Boolean checks subsequently evaluated as true. When they did, processing status got hard-coded to "unprocessed" anyway, which is possibly another bug.

I added a line to convert $procStatus to `null` if it's value is `"null"` before being passed to `batchOcrUnprocessed`. I also made the sql statement respect the end-user desired $procStatus.

Should that whole sql statement be made using prepared statements and the new QueryUtil? Probably. Is there a more elegant way to fix the `"null"` -> `null` bug? Also probably. 

I'll do it if y'all think it's worth it.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
