### PR TITLE
Add missing cultivation status translations

### DIFF
--- a/content/lang/collections/individual/index.en.php
+++ b/content/lang/collections/individual/index.en.php
@@ -170,5 +170,6 @@ $LANG['REPORTED_AS_INAPPROPRIATE'] = 'The following comment has been reported as
 $LANG['EMAIL_NOT_DEFINED'] = 'ERROR: Portal admin email not defined in central configuration file';
 $LANG['UNABLE_TO_VERIFY_TARGET'] = 'ERROR deleting voucher: unable to verify target checklist for voucher';
 $LANG['PERMISSION_ERROR'] = 'ERROR deleting voucher: permission error';
-
+$LANG['CULT_STATUS'] = 'Cultivation Status';
+$LANG['CULTIVATED'] = 'Cultivated';
 ?>

--- a/content/lang/collections/individual/index.es.php
+++ b/content/lang/collections/individual/index.es.php
@@ -171,5 +171,6 @@ $LANG['REPORTED_AS_INAPPROPRIATE'] = 'El siguiente comentario ha sido eliminado 
 $LANG['EMAIL_NOT_DEFINED'] = 'ERROR: El correo electrónico del administrador del portal no está definido en el archivo de configuración central';
 $LANG['UNABLE_TO_VERIFY_TARGET'] = 'ERROR al eliminar el cupón: no se puede verificar la lista de verificación objetivo del cupón';
 $LANG['PERMISSION_ERROR'] = 'ERROR al eliminar el comprobante: error de permiso';
-
+$LANG['CULT_STATUS'] = 'Estado de Cultivo';
+$LANG['CULTIVATED'] = 'Cultivado';
 ?>

--- a/content/lang/collections/individual/index.fr.php
+++ b/content/lang/collections/individual/index.fr.php
@@ -170,5 +170,6 @@ $LANG['REPORTED_AS_INAPPROPRIATE'] = 'Le commentaire suivant a été enregistré
 $LANG['EMAIL_NOT_DEFINED'] = 'ERREUR : adresse e-mail de l\'administrateur du portail non définie dans le fichier de configuration central';
 $LANG['UNABLE_TO_VERIFY_TARGET'] = 'ERREUR lors de la suppression du bon : impossible de vérifier la liste de contrôle cible pour le bon';
 $LANG['PERMISSION_ERROR'] = 'ERREUR lors de la suppression du bon : erreur d\'autorisation';
-
+$LANG['CULT_STATUS'] = 'Statut de Culture';
+$LANG['CULTIVATED'] = 'Cultivé';
 ?>


### PR DESCRIPTION
# Description

Fixes an issue on the usda branch where translations for cultivation status were missing despite having been there in the past. Fixing in the core codebase so that a) this reversion is less likely to happen again in the future and b) the infrastructure is there if we ever want to implement the transfer of cultivation status from the notes to it's own line on the public occurrence display page. 

As is, it won't bother anything in the current codebase.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
