### PR TITLE
Adds support for bmp media to be uploaded

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -942,6 +942,9 @@ class Media {
 			case 'image/gif':
 				$image = imagecreatefromgif($src_path);
 				break;
+			case 'image/bmp':
+				$image = imagecreatefrombmp($src_path);
+				break;
 			default:
 				throw new Exception(
 					'Mime Type: ' . $mime_type . ' not supported for creation'

--- a/classes/utilities/UploadUtil.php
+++ b/classes/utilities/UploadUtil.php
@@ -14,7 +14,8 @@ class UploadUtil {
 	];
 
 	const ALLOWED_IMAGE_MIMES = [
-		'image/jpeg', 'image/png', 'image/gif'
+		'image/jpeg', 'image/png', 'image/gif', 'image/bmp'
+		// Following cannot be supported in gd currently 'image/tiff', 'image/jp2'
 	];
 
 	const ALLOWED_AUDIO_MIMES = [
@@ -76,8 +77,8 @@ class UploadUtil {
 		}
 
 		$type_guess = mime_content_type($uploaded_file['tmp_name']);
-
-		if($type_guess != $uploaded_file['type']) {
+;
+		if(!self::mimesEqual($type_guess, $uploaded_file['type'])) {
 			throw new MediaException(MediaException::SuspiciousFile);
 		}
 
@@ -309,6 +310,13 @@ class UploadUtil {
 
 		return $extensionA === $extensionB ||
 			Media::ext2Mime($extensionA) === Media::ext2Mime($extensionB);
+	}
+
+	public static function mimesEqual(string $mimeA, string $mimeB): bool {
+		$mimeA = strtolower($mimeA);
+		$mimeB = strtolower($mimeB);
+
+		return self::mime2ext($mimeA) === self::mime2ext($mimeB);
 	}
 
 	/**

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -116,7 +116,7 @@ $CSS_VERSION = '16';
 
 // Used for what media is allowed to be uploaded. Does not restrict external links
 $ALLOWED_MEDIA_MIME_TYPES = [
-	"image/jpeg", "image/png", "image/gif",
+	"image/jpeg", "image/png", "image/gif", 'image/bmp',
 	"audio/mpeg", "audio/wav", "audio/ogg"
 ];
 


### PR DESCRIPTION
# Issue None

# Summary
Adds support for image/bmp type.
Alters checkFileUpload function to check mime equality based on if they generate the same extension rather than if they match exactly. This is to accommodate other valid bmp mimes such as image/x-bmp and image/x-ms-bmp. Should also work to fix other mimes of equivalent types not matching.

It should be noted that I looked at adding tiff and jpeg2000 support however there is some complications with the `gd` library so this cannot be done unless we write custom support or swap fully to image magic.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
