### PR TITLE
Fix Slow Loading on occurrence editor due to unperformant trait query

### DIFF
--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -2796,13 +2796,29 @@ class OccurrenceEditorManager {
 	}
 
 	public function getAttributeTraits($collid = ''){
+		$stateIds = [];
+
+		if($collid) {
+			$rs = QueryUtil::executeQuery($this->conn,
+				'SELECT DISTINCT a.stateid from omoccurrences o INNER JOIN tmattributes a ON a.occid = o.occid WHERE collid = ?',
+				[$collid]
+			);
+			$stateIds = [];
+
+			while($r = $rs->fetch_object()) {
+				array_push($stateIds, $r->stateid);
+			}
+		}
+
+		$sql = 'SELECT DISTINCT t.traitid, t.traitname, s.stateid, s.statename FROM tmtraits t
+		INNER JOIN tmstates s ON t.traitid = s.traitid';
+
+		if(count($stateIds) > 0) {
+			$sql .= ' where s.stateid in (' . str_repeat('?,', count($stateIds) - 1) . '?' . ')';
+		}
+		
 		$retArr = array();
-		$sql = 'SELECT DISTINCT t.traitid, t.traitname, s.stateid, s.statename '.
-			'FROM tmtraits t INNER JOIN tmstates s ON t.traitid = s.traitid '.
-			'INNER JOIN tmattributes a ON s.stateid = a.stateid '.
-			'INNER JOIN omoccurrences o ON a.occid = o.occid ';
-		if($collid) $sql .= 'WHERE o.collid = '.$collid;
-		$rs = $this->conn->query($sql);
+		$rs = QueryUtil::executeQuery($this->conn, $sql, $stateIds);
 		while($r = $rs->fetch_object()){
 			$retArr[$r->traitid]['name'] = $r->traitname;
 			$retArr[$r->traitid]['state'][$r->stateid] = $r->statename;

--- a/collections/editor/includes/queryform.php
+++ b/collections/editor/includes/queryform.php
@@ -34,7 +34,11 @@ $qTraitIds = (array_key_exists('traitid',$qryArr)?$qryArr['traitid']: []);
 $qTraitAbsence = (array_key_exists('traitAbsence',$qryArr)?$qryArr['traitAbsence']: false);
 $qTraitStateIds = (array_key_exists('stateid',$qryArr)?$qryArr['stateid']: []);
 
-$qTraitArr = $occManager->getAttributeTraits($collId);
+$qTraitArr = [];
+if($occManager->traitCodingActivated()){
+	$qTraitArr = $occManager->getAttributeTraits($collId);
+}
+
 $qCollMap = $occManager->getCollMap();
 
 $customFieldArr = array();


### PR DESCRIPTION
# Summary
Fixes performance problem with getting traits per target collection. Query was only not performing well when collid was being used in the function due to having to use either collid as index.

Solution was to seperate the queries since I expect the total number of unique state ids to remain relatively low meaning constructing a where in will be a solid choice.

I should note that the query was slow regardess of whether their was traits actually linked to occurrences or even without trait's being enabled.

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
