### PR TITLE
Media loading bugs

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -1092,11 +1092,13 @@ class Media {
 
 			//Unlink all files
 			if($remove_files) {
+				$root_url = self::getMediaRootUrl();
+				$root_path = self::getMediaRootPath();
 				foreach($media_urls as $url) {
-					if($url && $GLOBALS['IMAGE_ROOT_URL']) {
-						if(strpos($url, $GLOBALS['IMAGE_ROOT_URL']) === 0){		//Only images residing on local server can be deleted
+					if($url && $root_url) {
+						if(strpos($url, $root_url) === 0){		//Only images residing on local server can be deleted
 							//Convert url to a local path
-							$path = $GLOBALS['IMAGE_ROOT_PATH'] . substr($url, strlen($GLOBALS['IMAGE_ROOT_URL']));
+							$path = $root_path . substr($url, strlen($root_url));
 							if(file_exists($path)){
 								if(is_writable($path)) {
 									if(!unlink($path)) {

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -363,20 +363,22 @@ class Media {
 		//Not Sure if I Need
 		$mapLargeImg = !($clean_post_arr['nolgimage']?? true);
 
-		$sql = <<< SQL
-		SELECT tidinterpreted 
-		FROM omoccurrences 
-		WHERE tidinterpreted IS NOT NULL AND occid = ? 
-		SQL;
+		if(empty($clean_post_arr['tid']) && !empty($clean_post_arr['occid'])){
+			$sql = <<< SQL
+			SELECT tidinterpreted 
+			FROM omoccurrences 
+			WHERE tidinterpreted IS NOT NULL AND occid = ? 
+			SQL;
 
-		$taxon_result = QueryUtil::executeQuery(
-			$conn,
-			$sql,
-			[$clean_post_arr['occid']]
-		);
+			$taxon_result = QueryUtil::executeQuery(
+				$conn,
+				$sql,
+				[$clean_post_arr['occid']]
+			);
 
-		if(!isset($clean_post_arr['tid']) && $row = $taxon_result->fetch_object()) {
-			$clean_post_arr['tid'] = $row->tidinterpreted;
+			if($row = $taxon_result->fetch_object()) {
+				$clean_post_arr['tid'] = $row->tidinterpreted;
+			}
 		}
 
 		if(!($clean_post_arr['copytoserver'] ?? false) && !($clean_post_arr['format'] ?? false)) {
@@ -445,7 +447,7 @@ class Media {
 		INSERT INTO media($keys) VALUES ($parameters)
 		SQL;
 
-		$result = QueryUtil::executeQuery($conn, $sql, array_values($keyValuePairs));
+		QueryUtil::executeQuery($conn, $sql, array_values($keyValuePairs));
 		//Insert to other tables as needed like imagetags...
 
 		$media_id = $conn->insert_id;
@@ -488,7 +490,7 @@ class Media {
 					$post_arr['sourceIdentifier'] = 'filename: ' . $file['name'];
 				}
 			}
-			
+
 			$media_metadata = self::insert($post_arr, $conn);
 			$media_type = MediaType::tryFrom($media_metadata['mediaType']);
 
@@ -533,7 +535,7 @@ class Media {
 
 					$storage->upload($file);
 
-					$urls = [ 
+					$urls = [
 						'thumbnailUrl' => [
 							'name' => self::addToFilename($file['name'], '_tn'),
 							'width' => $GLOBALS['IMG_TN_WIDTH']?? 200,
@@ -696,7 +698,7 @@ class Media {
 		return $errors;
 	}
 
-	private static function check_file_rename(string $old_filepath, string $new_filepath) {		
+	private static function check_file_rename(string $old_filepath, string $new_filepath) {
 		if($old_filepath && $new_filepath) {
 			$old_file = self::parseFileName($old_filepath);
 			$new_file = self::parseFileName($new_filepath);
@@ -768,7 +770,7 @@ class Media {
 			foreach(['url', 'thumbnailUrl', 'originalUrl'] as $url) {
 				if(array_key_exists($url, $data) && $storage->file_exists($current_media_arr[$url])) {
 					self::check_file_rename(
-						$current_media_arr[$url], 
+						$current_media_arr[$url],
 						$data[$url]
 					);
 				}
@@ -1091,12 +1093,19 @@ class Media {
 			//Unlink all files
 			if($remove_files) {
 				foreach($media_urls as $url) {
-					if($url && file_exists($GLOBALS['SERVER_ROOT'] . $url)) {
-						if(!is_writable($GLOBALS['SERVER_ROOT'] . $url)) {
-							throw new MediaException(MediaException::FilepathNotWritable, $url);
-						}
-						if(!unlink($GLOBALS['SERVER_ROOT'] . $url)) {
-							error_log("WARNING: File (path: " . $url . ") failed to delete from server");
+					if($url && $GLOBALS['IMAGE_ROOT_URL']) {
+						if(strpos($url, $GLOBALS['IMAGE_ROOT_URL']) === 0){		//Only images residing on local server can be deleted
+							//Convert url to a local path
+							$path = $GLOBALS['IMAGE_ROOT_PATH'] . substr($url, strlen($GLOBALS['IMAGE_ROOT_URL']));
+							if(file_exists($path)){
+								if(is_writable($path)) {
+									if(!unlink($path)) {
+										error_log("WARNING: File (path: " . $path . ") failed to delete from server");
+									}
+								} else{
+									throw new MediaException(MediaException::FilepathNotWritable, $path);
+								}
+							}
 						}
 					}
 				}

--- a/content/lang/taxa/profile/tpimageeditor.en.php
+++ b/content/lang/taxa/profile/tpimageeditor.en.php
@@ -29,7 +29,6 @@ $LANG['URL_TO_SOURCE'] = 'URL to source project. Use when linking to an external
 $LANG['SOURCE_URL'] = 'Source URL';
 $LANG['COPYRIGHT'] = 'Copyright';
 $LANG['OCC_REC_NUM'] = 'Occurrence Record #';
-$LANG['LINK_TO_OCC'] = 'Link to Occurrence Record';
 $LANG['LOCALITY'] = 'Locality';
 $LANG['NOTES'] = 'Notes';
 $LANG['UPLOAD_IMAGE'] = 'Upload Media Resource';

--- a/content/lang/taxa/profile/tpimageeditor.es.php
+++ b/content/lang/taxa/profile/tpimageeditor.es.php
@@ -29,7 +29,6 @@ $LANG['URL_TO_SOURCE'] = 'URL al proyecto fuente. Úselo al vincular a un medio 
 $LANG['SOURCE_URL'] = 'URL de Origen';
 $LANG['COPYRIGHT'] = 'Derechos de Autor';
 $LANG['OCC_REC_NUM'] = 'Registro de Ocurrencia #';
-$LANG['LINK_TO_OCC'] = 'Enlace al registro de sucesos';
 $LANG['LOCALITY'] = 'Localidad';
 $LANG['NOTES'] = 'Notas';
 $LANG['UPLOAD_IMAGE'] = 'Subir medios';

--- a/content/lang/taxa/profile/tpimageeditor.fr.php
+++ b/content/lang/taxa/profile/tpimageeditor.fr.php
@@ -29,7 +29,6 @@ $LANG['URL_TO_SOURCE'] = 'URL vers le projet source. À utiliser lors de la cré
 $LANG['SOURCE_URL'] = 'URL source';
 $LANG['COPYRIGHT'] = 'Droits d\'Auteur';
 $LANG['OCC_REC_NUM'] = 'Enregistrement d\'Occurrence #';
-$LANG['LINK_TO_OCC'] = 'Lien vers l\'enregistrement d\'occurrence';
 $LANG['LOCALITY'] = 'Localité';
 $LANG['NOTES'] = 'Notes';
 $LANG['UPLOAD_IMAGE'] = 'Télécharger du multimédia';

--- a/taxa/profile/tpeditor.php
+++ b/taxa/profile/tpeditor.php
@@ -164,11 +164,6 @@ if($isEditor && $action){
 				return false;
 			}
 		}
-
-		function openOccurrenceSearch(target) {
-			occWindow=open("../../collections/misc/occurrencesearch.php?targetid="+target,"occsearch","resizable=1,scrollbars=1,width=700,height=500,left=20,top=20");
-			if (occWindow.opener == null) occWindow.opener = self;
-		}
 	</script>
 	<script src="../../js/symb/api.taxonomy.taxasuggest.js?ver=4" type="text/javascript"></script>
 	<style>

--- a/taxa/profile/tpimageeditor.php
+++ b/taxa/profile/tpimageeditor.php
@@ -206,11 +206,6 @@ if($tid){
 								<input name='copyright' type='text' value='' size='70' maxlength='250'>
 							</div>
 							<div style='margin-top:2px;'>
-								<b><?php echo $LANG['OCC_REC_NUM']; ?>:</b>
-								<input id="imgoccid-0" name="occid" type="text" value=""/>
-								<a href="#" onclick="openOccurrenceSearch('0')"><?php echo $LANG['LINK_TO_OCC']; ?></a>
-							</div>
-							<div style='margin-top:2px;'>
 								<b><?php echo $LANG['LOCALITY']; ?>:</b>
 								<input name='locality' type='text' value='' size='70' maxlength='250'>
 							</div>


### PR DESCRIPTION
- Taxon Profile Editor: Remove option to link a new image import to an existing occurrence record. If this is needed, the image should be added via the occurrence editor, which does a better job policing permissions for given occurrence record. This image loader should only be available to link field images to a taxon, which are not linked to occurrence records. 
- Media class: Only set media:tid value if not included within input values AND occid is set, thus allowing possibility to set via the occurrence:tidInterpreted. This was producing a warning when a field image was loaded, which lacked an occid input value.
- Media class: Fix bug interfering with removal of physical image from server. The image URL needs to be converted to a server path. And only images with relative path values can be deleted.


# Pull Request Checklist:
# Pre-Approval

- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing).

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **squash & merge** option
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
