### PR TITLE
Minor visual fixes in collprofiles.php and institutioneditor.php

### DIFF
--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -238,8 +238,8 @@ if ($SYMB_UID) {
 			}
 		}
 	</style>
-	<link href="<?php echo $CLIENT_ROOT ?>/collections/search/css/searchStyles.css?ver=1" type="text/css" rel="stylesheet" />
-	<link href="<?php echo $CLIENT_ROOT ?>/collections/search/css/searchStylesInner.css" type="text/css" rel="stylesheet" />
+	<link href="<?php echo $CLIENT_ROOT ?>/css/searchStyles.css?ver=1" type="text/css" rel="stylesheet" />
+	<link href="<?php echo $CLIENT_ROOT ?>/css/searchStylesInner.css" type="text/css" rel="stylesheet" />
 </head>
 <body>
 	<?php

--- a/collections/misc/institutioneditor.php
+++ b/collections/misc/institutioneditor.php
@@ -270,7 +270,7 @@ include($SERVER_ROOT.'/includes/header.php');
 						</div>
 						<div style="position:relative;clear:both;">
 							<div style="float:left;width:155px;font-weight:bold;">
-								<?php echo $LANG['CITY']; ?>City:
+								<?php echo $LANG['CITY']; ?>:
 							</div>
 							<div class="editdiv" style="display:<?php echo $eMode?'none':'block'; ?>;">
 								<?php echo $instArr['city']; ?>


### PR DESCRIPTION
# Before:
<img width="420" height="363" alt="Screenshot 2025-12-03 at 12 34 20 PM" src="https://github.com/user-attachments/assets/dfc515fb-05ae-412d-8209-0d68bca49a12" />

<img width="368" height="373" alt="Screenshot 2025-12-03 at 12 34 06 PM" src="https://github.com/user-attachments/assets/120c8fd9-9143-4603-8759-a5a79cbe41a8" />

# After:
<img width="420" height="366" alt="Screenshot 2025-12-03 at 12 32 35 PM" src="https://github.com/user-attachments/assets/2be78570-3aca-42a4-b91d-f4afa7117b9c" />

<img width="368" height="373" alt="Screenshot 2025-12-03 at 12 33 07 PM" src="https://github.com/user-attachments/assets/e531f62a-27e7-4260-8419-33c56a11b21c" />

# Changes Made:


- fixed the path to css in collprofiles.php
- remove extra html text for the city field in institutioneditor.php

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [ ] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address:
https://github.com/Symbiota/Symbiota/issues/3084
https://github.com/Symbiota/Symbiota/issues/3096
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
