### PR TITLE
Checklist image alignment fix

### DIFF
--- a/checklists/checklist.php
+++ b/checklists/checklist.php
@@ -338,7 +338,8 @@ $taxonFilter = htmlspecialchars($taxonFilter, ENT_COMPAT | ENT_HTML401 | ENT_SUB
 						</div>
 					</div>
 					<hr />
-					<div class="printoff">
+					<div style="display:flex; justify-content:space-between;" class="printoff">
+						<div>
 						<?php
 						$taxaLimit = ($showImages?$clManager->getImageLimit():$clManager->getTaxaLimit());
 						$pageCount = ceil($clManager->getTaxaCount()/$taxaLimit);
@@ -352,7 +353,9 @@ $taxonFilter = htmlspecialchars($taxonFilter, ENT_COMPAT | ENT_HTML401 | ENT_SUB
 							if(($pageNumber) == $x) echo '</b>';
 							else echo '</a>';
 						}
-						if($showImages){
+						?>
+						</div>
+						<?php if($showImages){
 							?>
 							<div style="float:right;">
 								<?php echo $LANG['IMAGE_SRC']; ?>:
@@ -372,7 +375,7 @@ $taxonFilter = htmlspecialchars($taxonFilter, ENT_COMPAT | ENT_HTML401 | ENT_SUB
 							$u = (array_key_exists('url',$sppArr) ? $sppArr['url'] : '');
 							$imgSrc = ($tu?$tu:$u);
 							?>
-							<div class="tndiv">
+							<div class="tndiv bottom-breathing-room-rel-sm">
 								<div class="tnimg" style="<?php echo ($imgSrc?'' : 'border:1px solid black;'); ?>">
 									<?php
 									$spUrl = "../taxa/index.php?taxauthid=1&taxon=$tid&clid=".$clid;

--- a/css/symbiota/main.css
+++ b/css/symbiota/main.css
@@ -489,7 +489,7 @@ button.inverse-color {
   float: left;
   text-align: center;
   width: 165px;
-  height: 230px;
+  min-height: 230px;
   page-break-before: auto;
   page-break-inside: avoid;
 }


### PR DESCRIPTION
# Before:
<img width="300" height="757" alt="Screenshot 2025-12-16 at 11 13 49 AM" src="https://github.com/user-attachments/assets/d8dea676-9fc1-4a29-b1e3-78edf561bfd9" /> 
<img width="300" height="757" alt="Screenshot 2025-12-17 at 10 56 36 AM" src="https://github.com/user-attachments/assets/f34cfcf3-113e-4dc9-9cb5-da82d980944b" />


# After:
<img width="300" height="757" alt="Screenshot 2025-12-16 at 11 14 13 AM" src="https://github.com/user-attachments/assets/418402ec-acaa-42ac-bbc6-a5dc01246923" /> 
<img width="311" height="757" alt="Screenshot 2025-12-17 at 10 57 49 AM" src="https://github.com/user-attachments/assets/bb4cd6f6-245b-499e-adf2-8be6f6f63727" />

# Changes Made:

- added bottom margin and changed to min-height to automatically adjust the size of images divs if large text is overlapping
- added flex display to prevent image source text from overlapping with bottom elements

# Pull Request Checklist:

# Pre-Approval

- [X] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [X] There are no linter errors
- [X] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [X] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [X] Comment which GitHub issue(s), if any does this PR address:
https://github.com/Symbiota/Symbiota/issues/3054
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
