### PR TITLE
Closes #3085 Fixes Issue with coord aid

### DIFF
--- a/collections/tools/mapcoordaid.php
+++ b/collections/tools/mapcoordaid.php
@@ -163,18 +163,17 @@ else{
 		}
 
 		function setRectangle(upperLat, lowerLat, leftLng, rightLng) {
-
 			setField("upperlat_NS", upperLat > 0 ? "N": "S");
-			setField("upperlat", Math.abs(upperLat).toFixed(SIG_FIGS));
+			setField("upperlat", (getField("upperlat_NS")? Math.abs(upperLat): upperLat).toFixed(SIG_FIGS));
 
 			setField("bottomlat_NS", lowerLat > 0 ? "N": "S");
-			setField("bottomlat", Math.abs(lowerLat).toFixed(SIG_FIGS));
+			setField("bottomlat", (getField("bottomlat_NS")? Math.abs(lowerLat): lowerLat).toFixed(SIG_FIGS));
 
 			setField("leftlong_EW", leftLng > 0 ? "E": "W");
-			setField("leftlong", Math.abs(leftLng).toFixed(SIG_FIGS));
+			setField("leftlong", (getField("leftlong_EW")? Math.abs(leftLng): leftLng).toFixed(SIG_FIGS));
 
 			setField("rightlong_EW", rightLng> 0 ? "E": "W");
-			setField("rightlong", Math.abs(rightLng).toFixed(SIG_FIGS));
+			setField("rightlong", (getField("rightlong_EW")? Math.abs(rightLng): rightLng).toFixed(SIG_FIGS));
 		}
 
 		function setCircle(radius, center_lat, center_lng) {
@@ -290,13 +289,13 @@ else{
 					const rightLng = getField("rightlong");
 
 					if(isNumeric(upperLat) && isNumeric(lowerLat) && isNumeric(leftLng) && isNumeric(rightLng)) {
+console.log(!getField("leftlong_EW"));
 						return {
 							type: "rectangle",
-							upperLat: upperLat * (getField("upperlat_NS") === "N"? 1: -1),
-							rightLng: rightLng * (getField("rightlong_EW") === "E"? 1: -1),
-
-							lowerLat: lowerLat * (getField("bottomlat_NS") === "N"? 1: -1),
-							leftLng: leftLng * (getField("leftlong_EW") === "E"? 1: -1),
+							upperLat: upperLat * (getField("upperlat_NS") === "N" || !getField("upperlat_NS")? 1: -1),
+							rightLng: rightLng * (getField("rightlong_EW") === "E" || !getField("rightlong_EW")? 1: -1),
+							lowerLat: lowerLat * (getField("bottomlat_NS") === "N" || !getField("bottomlat_NS")? 1: -1),
+							leftLng: leftLng * (getField("leftlong_EW") === "E" || !getField("leftlong_EW")? 1: -1),
 						}
 					}
 				break;


### PR DESCRIPTION
# Issue #3085

# Summary
Fixed issue where if direction inputs were not present then the bounding box would not be able to load and generate rectangles properly.

Solution was to default to using given lat/lng sign's when no direction inputs are present in the opener.

@themerekat would it be worth creating an issue to move (currently just the search pages) to use signed coordinates instead of the north/south and east/west inputs?

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [x] It is the code author's responsibility to merge their own pull request after it has been approved
- [x] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [x] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [x] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [x] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [x] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [x] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [x] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [x] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
