### PR TITLE
Improve error messaging for batch associations

### DIFF
--- a/classes/OccurrenceImport.php
+++ b/classes/OccurrenceImport.php
@@ -245,7 +245,26 @@ class OccurrenceImport extends UtilitiesFileImport {
 							$this->logOrEcho($LANG['ASSOC_ADDED'] . ': <a href="../editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
 							$status = true;
 						} else {
-							$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $importManager->getErrorMessage(), 1);
+							$errorMsg = $importManager->getErrorMessage();
+							if (strpos($errorMsg, 'Cannot add or update a child row: a foreign key constraint fails') !== false) {
+								$humanReadableMsg = $LANG['MISSING_IDENTIFIER'];
+								$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $humanReadableMsg, 1);
+								$this->setVerboseMode(1);
+								$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $errorMsg, 1);
+								$this->setVerboseMode(2);
+							} elseif(strpos($errorMsg, 'Duplicate entry ') !== false) {
+								$humanReadableMsg = $LANG['DUPLICATE_ENTRY'];
+								$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $humanReadableMsg, 1);
+								$this->setVerboseMode(1);
+								$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $errorMsg, 1);
+								$this->setVerboseMode(2);
+							}else{
+								$humanReadableMsg = $LANG['GENERIC_ERROR'];
+								$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $humanReadableMsg, 1);
+								$this->setVerboseMode(1);
+								$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $errorMsg, 1);
+								$this->setVerboseMode(2);
+							}
 						}
 					}
 				}

--- a/collections/admin/importextended.php
+++ b/collections/admin/importextended.php
@@ -278,7 +278,9 @@ if ($IS_ADMIN || (array_key_exists('CollAdmin', $USER_RIGHTS) && in_array($colli
 							?>
 								<div class="formField-div">
 									<label><?= $LANG['RELATIONSHIP'] ?>:</label>
-									<select name="relationship">
+									<select id="relationship" name="relationship">
+										<option value="">-------------------</option>
+										<option value="DELETE"><?= $LANG['BATCH_DELETE'] ?></option>
 										<option value="">-------------------</option>
 										<?php
 										$filter = '';
@@ -288,8 +290,6 @@ if ($IS_ADMIN || (array_key_exists('CollAdmin', $USER_RIGHTS) && in_array($colli
 											echo '<option value="' . $term . '">' . $display . '</option>';
 										}
 										?>
-										<option value="">-------------------</option>
-										<option value="DELETE"><?= $LANG['BATCH_DELETE'] ?></option>
 									</select>
 								</div>
 								<div class="formField-div">
@@ -330,7 +330,7 @@ if ($IS_ADMIN || (array_key_exists('CollAdmin', $USER_RIGHTS) && in_array($colli
 							} elseif ($importType == 1) {
 							?>
 								<div class="formField-div">
-									<input name="replace" type="checkbox" value="1">
+									<input id="replace" name="replace" type="checkbox" value="1">
 									<label for="replace"><?= $LANG['MATCHING_IDENTIFIERS'] ?></label>
 								</div>
 							<?php

--- a/content/lang/collections/admin/importextended.en.php
+++ b/content/lang/collections/admin/importextended.en.php
@@ -69,3 +69,6 @@ $LANG['BATCH_ADD_OR_UPDATE'] = 'Batch Add or Update';
 $LANG['AUDIO_UPLOAD'] = 'Audio upload';
 $LANG['IMAGE_UPLOAD'] = 'Image upload';
 $LANG['MEDIA_UPLOAD_TYPE'] = 'Media Upload Type';
+$LANG['MISSING_IDENTIFIER'] = 'One or more required identifier fields are missing or invalid; skipping row';
+$LANG['DUPLICATE_ENTRY'] = 'Duplicate entry found in import file; skipping row';
+$LANG['GENERIC_ERROR'] = 'An error occurred while importing this occurrence; skipping row. Contact your administrator';

--- a/content/lang/collections/admin/importextended.es.php
+++ b/content/lang/collections/admin/importextended.es.php
@@ -68,3 +68,6 @@ $LANG['BATCH_ADD_OR_UPDATE'] = 'Agregar o actualizar por lotes';
 $LANG['AUDIO_UPLOAD'] = 'Carga de audio';
 $LANG['IMAGE_UPLOAD'] = 'Carga de imágenes';
 $LANG['MEDIA_UPLOAD_TYPE'] = 'Tipo de carga de medios';
+$LANG['MISSING_IDENTIFIER'] = 'Faltan uno o más campos de identificación obligatorios o son inválidos; se omite la fila.';
+$LANG['DUPLICATE_ENTRY'] = 'Se encontró una entrada duplicada en el archivo de importación; se omite la fila.';
+$LANG['GENERIC_ERROR'] = 'Se produjo un error al importar esta ocurrencia; se omite la fila. Contacte a su administrador.';

--- a/content/lang/collections/admin/importextended.fr.php
+++ b/content/lang/collections/admin/importextended.fr.php
@@ -68,3 +68,6 @@ $LANG['BATCH_ADD_OR_UPDATE'] = 'Ajout ou mise à jour par lots';
 $LANG['AUDIO_UPLOAD'] = 'Téléchargement audio';
 $LANG['IMAGE_UPLOAD'] = 'Téléchargement d\'images';
 $LANG['MEDIA_UPLOAD_TYPE'] = 'Type de téléchargement multimédia';
+$LANG['MISSING_IDENTIFIER'] = 'Un ou plusieurs champs d\'identification obligatoires sont manquants ou invalides ; la ligne est ignorée.';
+$LANG['DUPLICATE_ENTRY'] = 'Entrée en double trouvée dans le fichier d\'importation ; la ligne est ignorée.';
+$LANG['GENERIC_ERROR'] = 'Une erreur s\'est produite lors de l\'importation de cette occurrence ; la ligne est ignorée. Contactez votre administrateur.';

--- a/content/lang/collections/admin/importextended.pt.php
+++ b/content/lang/collections/admin/importextended.pt.php
@@ -67,3 +67,6 @@ $LANG['BATCH_ADD_OR_UPDATE'] = 'Adicionar ou atualizar em lote';
 $LANG['AUDIO_UPLOAD'] = 'Upload de áudio';
 $LANG['IMAGE_UPLOAD'] = 'Upload de imagens';
 $LANG['MEDIA_UPLOAD_TYPE'] = 'Tipo de upload de mídia';
+$LANG['MISSING_IDENTIFIER'] = 'Um ou mais campos de identificador obrigatórios estão ausentes ou inválidos; ignorando linha';
+$LANG['DUPLICATE_ENTRY'] = 'Entrada duplicada encontrada no arquivo de importação; ignorando linha';
+$LANG['GENERIC_ERROR'] = 'Ocorreu um erro ao importar esta ocorrência; ignorando linha. Entre em contato com o administrador.';


### PR DESCRIPTION
# Description

Closes #3158. Specifically, it:
- Moves verbose error messages to the logs
- Displays simpler errors in the UI instead
- Moves the batch delete option to the top of the select list so that it is more visible

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [x] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [x] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
    - [https://github.com/Symbiota/Symbiota/issues/3158](https://github.com/Symbiota/Symbiota/issues/3158)
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
