### PR TITLE
3.4 data export bug

### DIFF
--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -92,7 +92,7 @@ class DwcArchiverCore extends Manager{
 			$this->includeAcceptedNameUsage = true;
 		}
 
-		//ini_set('memory_limit','512M');
+		ini_set('memory_limit','512M');
 		set_time_limit(1800);
 	}
 

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -1556,16 +1556,6 @@ class DwcArchiverCore extends Manager{
 					}
 				}
 				while ($r = $rs->fetch_assoc()) {
-					if ($this->isPublicDownload || $this->limitToGuids) {
-						//Is a download from public interface OR DwC-A publishing event pushed to aggregators, thus skip record if Full Protections apply
-						if($r['recordSecurity'] == 5){
-							if(!strpos($sql, 'recordSecurity != 5')){
-								//But only if protection is not already applied within the SQL string
-								continue;
-							}
-						}
-					}
-
 					if(!isset($this->collArr[$r['collID']])){
 						$this->setCollArr($r['collID'], 'internalCall');
 					}
@@ -1774,6 +1764,59 @@ class DwcArchiverCore extends Manager{
 				$this->errorMessage = 'unknown error';
 			}
 			$stmt->close();
+		}
+		if($status) $this->setFullProtections();
+		return $status;
+	}
+
+	private function setFullProtections(){
+		//Function removes records that should be expluded due to full protection status
+		$status = false;
+		$removeAllRecords = true;
+		$collToRemove = array();
+		//Do not remove records if user has one of these permissions: SuperAdmin, CollAdmin, CollEditor
+		if(!empty($GLOBALS['USER_RIGHTS']['SuperAdmin'])){
+			$removeAllRecords = false;
+		}
+		else {
+			$allowedCollArr = array();
+			if(!empty($GLOBALS['USER_RIGHTS']['CollAdmin'])){
+				$allowedCollArr = $GLOBALS['USER_RIGHTS']['CollAdmin'];
+			}
+			if(!empty($GLOBALS['USER_RIGHTS']['CollEditor'])){
+				$allowedCollArr = array_merge($this->collArr, $GLOBALS['USER_RIGHTS']['CollEditor']);
+			}
+			if($allowedCollArr){
+				$collToRemove = array_diff($this->collArr, $allowedCollArr);
+				$removeAllRecords = false;
+			}
+		}
+		if(!$removeAllRecords){
+			if($this->isPublicDownload || $this->limitToGuids) {
+				//Download is from public interface OR DwC-A publishing event pushed to aggregators, thus remove full protected records
+				//Even if user is authorized to download these records, records should be excluded to ensure these records are not accidentually pushed to public
+				$removeAllRecords = true;
+			}
+		}
+		$sql = '';
+		if($removeAllRecords){
+			$sql = 'DELETE FROM omexportoccurrences WHERE omExportID = ? AND recordSecurity = 5';
+		}
+		elseif($collToRemove){
+			$sql = 'DELETE FROM omexportoccurrences WHERE omExportID = ? AND recordSecurity = 5 AND collid IN(' . implode(',', $collToRemove) . ')';
+		}
+		if($sql){
+			echo '<br>'.$sql; exit;
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('i', $this->exportID);
+				if($stmt->execute()){
+					$status = true;
+				}
+				elseif($stmt->error){
+					$this->errorMessage = $stmt->error;
+				}
+				$stmt->close();
+			}
 		}
 		return $status;
 	}

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -1784,10 +1784,10 @@ class DwcArchiverCore extends Manager{
 				$allowedCollArr = $GLOBALS['USER_RIGHTS']['CollAdmin'];
 			}
 			if(!empty($GLOBALS['USER_RIGHTS']['CollEditor'])){
-				$allowedCollArr = array_merge($this->collArr, $GLOBALS['USER_RIGHTS']['CollEditor']);
+				$allowedCollArr = array_merge($allowedCollArr, $GLOBALS['USER_RIGHTS']['CollEditor']);
 			}
 			if($allowedCollArr){
-				$collToRemove = array_diff($this->collArr, $allowedCollArr);
+				$collToRemove = array_diff(array_keys($this->collArr), $allowedCollArr);
 				$removeAllRecords = false;
 			}
 		}
@@ -1806,7 +1806,6 @@ class DwcArchiverCore extends Manager{
 			$sql = 'DELETE FROM omexportoccurrences WHERE omExportID = ? AND recordSecurity = 5 AND collid IN(' . implode(',', $collToRemove) . ')';
 		}
 		if($sql){
-			echo '<br>'.$sql; exit;
 			if($stmt = $this->conn->prepare($sql)){
 				$stmt->bind_param('i', $this->exportID);
 				if($stmt->execute()){

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -109,7 +109,7 @@ class DwcArchiverCore extends Manager{
 			$sqlWhere = '(c.colltype IN("Observations", "General Observations")) ';
 		}
 		if ($collTarget && $collTarget != 'all') {
-			if($collType != 'internalCall') $this->conditionArr['collid'] = $collTarget;
+			$this->conditionArr['collid'] = $collTarget;
 			$sqlWhere .= ($sqlWhere ? 'AND ' : '') . '(c.collid IN(' . $collTarget . ')) ';
 		}
 		if ($sqlWhere) {
@@ -234,8 +234,7 @@ class DwcArchiverCore extends Manager{
 		}
 
 		if($this->includeAcceptedNameUsage) {
-			// TODO (Logan) Should there be a select for this?
-			$this->conditionSql .= 'AND (ts.taxauthid = 1) ';
+			$this->conditionSql .= 'AND (ts.taxauthid = 1 OR ts.taxauthid IS NULL) ';
 		}
 
 		$sqlFrag = '';
@@ -1556,9 +1555,6 @@ class DwcArchiverCore extends Manager{
 					}
 				}
 				while ($r = $rs->fetch_assoc()) {
-					if(!isset($this->collArr[$r['collID']])){
-						$this->setCollArr($r['collID'], 'internalCall');
-					}
 					//Set occurrenceID GUID or skip records if not defined (required output)
 					if(!$r['occurrenceID']) {
 						if($guidTarget = $this->collArr[$r['collID']]['guidtarget']){
@@ -1765,8 +1761,32 @@ class DwcArchiverCore extends Manager{
 			}
 			$stmt->close();
 		}
-		if($status) $this->setFullProtections();
+		if($status){
+			$this->setCollArrViaExportID();
+			$this->setFullProtections();
+		}
 		return $status;
+	}
+
+	private function setCollArrViaExportID(){
+		if(!$this->collArr){
+			$sql = 'SELECT DISTINCT collid FROM omexportoccurrences WHERE omExportID = ?';
+			$outputArr = array();
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('i', $this->exportID);
+				$stmt->execute();
+				if($rs = $stmt->get_result()){
+					while($r = $rs->fetch_object()){
+						$outputArr[] = $r->collid;
+					}
+				}
+				$stmt->close();
+			}
+			if($outputArr){
+				$targetCollidStr = implode(',', $outputArr);
+				$this->setCollArr($targetCollidStr);
+			}
+		}
 	}
 
 	private function setFullProtections(){

--- a/classes/DwcArchiverMedia.php
+++ b/classes/DwcArchiverMedia.php
@@ -194,6 +194,7 @@ class DwcArchiverMedia extends DwcArchiverBaseManager{
 	//Setters and getters
 	public function setRedactLocalities($bool){
 		if($bool) $this->redactLocalities = true;
+		else $this->redactLocalities = false;
 	}
 
 	public function setRareReaderCollStr($rareReaderArr){

--- a/classes/OccurrenceIndividual.php
+++ b/classes/OccurrenceIndividual.php
@@ -279,7 +279,7 @@ class OccurrenceIndividual extends Manager{
 					$tnUrl = $row->thumbnailurl;
 					$lgUrl = $row->originalurl;
 					if($MEDIA_DOMAIN){
-						if(substr($url,0,1)=='/') $url = $MEDIA_DOMAIN . $url;
+						if($url && substr($url,0,1)=='/') $url = $MEDIA_DOMAIN . $url;
 						if($lgUrl && substr($lgUrl, 0, 1) == '/') $lgUrl = $MEDIA_DOMAIN . $lgUrl;
 						if($tnUrl && substr($tnUrl, 0, 1) == '/') $tnUrl = $MEDIA_DOMAIN . $tnUrl;
 					}

--- a/config/schema/3.0/patches/db_schema_patch-3.4.sql
+++ b/config/schema/3.0/patches/db_schema_patch-3.4.sql
@@ -184,16 +184,19 @@ CREATE TABLE `omexportoccurrences` (
   PRIMARY KEY (`omExportID`,`occid`));
 
 ALTER TABLE `omexportoccurrences` 
-  ADD INDEX `FK_omexportoccur_omExportID_idx` (`omExportID` ASC),
-  ADD INDEX `FK_omexportoccur_occid_idx` (`occid` ASC);
+  ADD INDEX `FK_omexportoccur_omExportID_idx` (`omExportID`),
+  ADD INDEX `FK_omexportoccur_occid_idx` (`occid`);
 
 ALTER TABLE `omexportoccurrences` 
   ADD CONSTRAINT `FK_omexportoccur_omExportID`  FOREIGN KEY (`omExportID`)  REFERENCES `omexport` (`omExportID`)  ON DELETE CASCADE  ON UPDATE CASCADE,
   ADD CONSTRAINT `FK_omexportoccur_occid`  FOREIGN KEY (`occid`)  REFERENCES `omoccurrences` (`occid`)  ON DELETE CASCADE  ON UPDATE CASCADE;
 
 ALTER TABLE `omexportoccurrences` 
-  ADD INDEX `IX_omexportoccur_taxonID` (`taxonID` ASC),
-  ADD INDEX `IX_omexportoccur_collid` (`collid` ASC);
+  ADD INDEX `IX_omexportoccur_occid` (`omExportID`, `occid`),
+  ADD INDEX `IX_omexportoccur_collid` (`omExportID`, `collid`),
+  ADD INDEX `IX_omexportoccur_taxonID` (`omExportID`, `taxonID`),
+  ADD INDEX `IX_omexportoccur_kingdom` (`omExportID`, `kingdom`),
+  ADD INDEX `IX_omexportoccur_recordSecurity` (`omExportID`, `recordSecurity`);
 
 
 #Add update to omoccurdeterminations.dateLastModified tracked any update to the row


### PR DESCRIPTION
- Fix exclusion of records that have non-indexed taxonomic names when Taxonomic Resolution checkbox is checked
-- Issue https://github.com/Symbiota/Symbiota/issues/3240
- Fix bug within DwcArchiverMedia file that was always excluding media of occurrences with locality protections
-- Issue https://github.com/Symbiota/Symbiota/issues/3247
- Improve record redaction algorithm for records tagged with full protections.
- Improve omexportoccurrences indexes by converting to composite keys including omExportID field

- Set collArr metadata right after priming download tables and prior to output of occurrence data, thus allowing permission check for redacting occurrence output

Fixes above also addresses following issues, which are likely all related to failed downloads:

https://github.com/Symbiota/Symbiota/issues/3251
https://github.com/Symbiota/Symbiota/issues/3253
https://github.com/Symbiota/Symbiota/issues/3255
https://github.com/Symbiota/Symbiota/issues/3256


# Pull Request Checklist:
# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [ ] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
