### PR TITLE
Occurrence Association Publishing

### DIFF
--- a/classes/DwcArchiverAttribute.php
+++ b/classes/DwcArchiverAttribute.php
@@ -63,7 +63,7 @@ class DwcArchiverAttribute extends DwcArchiverBaseManager{
 			foreach($this->fieldArr['fields'] as $colName){
 				if($colName) $sqlFrag .= ', '.$colName;
 			}
-			$this->sql = 'SELECT '.trim($sqlFrag,', ').'
+			$this->sqlArr[] = 'SELECT '.trim($sqlFrag,', ').'
 				FROM tmtraits m INNER JOIN tmstates s ON m.traitid = s.traitid
 				INNER JOIN tmattributes a ON s.stateid = a.stateid
 				INNER JOIN omexportoccurrences e ON a.occid = e.occid

--- a/classes/DwcArchiverBaseManager.php
+++ b/classes/DwcArchiverBaseManager.php
@@ -8,7 +8,7 @@ class DwcArchiverBaseManager extends Manager{
 	protected $fieldArr;
 	protected $charSetSource = '';
 	protected $charSetOut = '';
-	protected $sql;
+	protected $sqlArr = array();
 	private $fileHandler;
 
 	public function __construct($conType, $connOverride){
@@ -34,8 +34,8 @@ class DwcArchiverBaseManager extends Manager{
 
 	public function writeOutData($exportID){
 		$recordCnt = 0;
-		if($this->sql){
-			if($stmt = $this->conn->prepare($this->sql)){
+		foreach($this->sqlArr as $sql){
+			if($stmt = $this->conn->prepare($sql)){
 				$stmt->bind_param('i', $exportID);
 				$stmt->execute();
 				$rs = $stmt->get_result();
@@ -50,7 +50,7 @@ class DwcArchiverBaseManager extends Manager{
 			}
 			else{
 				$this->logOrEcho('ERROR writing out to extension file: ' . $stmt->error . "\n");
-				//$this->logOrEcho("\tSQL: ".$this->sql."\n");
+				//$this->logOrEcho("\tSQL: ".$sql."\n");
 			}
 		}
 		return $recordCnt;

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -1962,11 +1962,7 @@ class DwcArchiverCore extends Manager{
 			$associationHandler = new DwcArchiverResourceRelationship($this->conn);
 			$associationHandler->setSchemaType($this->schemaType);
 			$associationHandler->initiateProcess($targetFile);
-
 			$recordCnt = $associationHandler->writeOutData($this->exportID);
-			//Now add inverse relationships
-			$associationHandler->setSqlInverse();
-			$recordCnt += $associationHandler->writeOutData($this->exportID);
 			if($recordCnt){
 				$this->extensionFieldMap['associations'] = $associationHandler->getFieldArrTerms();
 				$msg = $recordCnt . ' records added ';

--- a/classes/DwcArchiverDetermination.php
+++ b/classes/DwcArchiverDetermination.php
@@ -83,7 +83,7 @@ class DwcArchiverDetermination extends DwcArchiverBaseManager{
 			foreach($this->fieldArr['fields'] as $colName){
 				if($colName) $sqlFrag .= ', ' . $colName;
 			}
-			$this->sql = 'SELECT ' . trim($sqlFrag, ', ') . ' FROM omoccurdeterminations d INNER JOIN omexportoccurrences x ON d.occid = x.occid
+			$this->sqlArr[] = 'SELECT ' . trim($sqlFrag, ', ') . ' FROM omoccurdeterminations d INNER JOIN omexportoccurrences x ON d.occid = x.occid
 				LEFT JOIN taxa t ON d.tidinterpreted = t.tid
 				WHERE x.omExportID = ? AND d.appliedstatus = 1 ';
 		}

--- a/classes/DwcArchiverIdentifier.php
+++ b/classes/DwcArchiverIdentifier.php
@@ -59,7 +59,7 @@ class DwcArchiverIdentifier extends DwcArchiverBaseManager{
 			foreach($this->fieldArr['fields'] as $colName){
 				if($colName) $sqlFrag .= ', ' . $colName;
 			}
-			$this->sql = 'SELECT ' . trim($sqlFrag, ', ') . ' FROM omoccuridentifiers i INNER JOIN omexportoccurrences e ON i.occid = e.occid WHERE (e.omExportID = ?) ';
+			$this->sqlArr[] = 'SELECT ' . trim($sqlFrag, ', ') . ' FROM omoccuridentifiers i INNER JOIN omexportoccurrences e ON i.occid = e.occid WHERE (e.omExportID = ?) ';
 		}
 	}
 }

--- a/classes/DwcArchiverMaterialSample.php
+++ b/classes/DwcArchiverMaterialSample.php
@@ -78,7 +78,7 @@ class DwcArchiverMaterialSample extends DwcArchiverBaseManager{
 			foreach($this->fieldArr['fields'] as $colName){
 				if($colName && $colName != 'msDynamicField') $sqlFrag .= ', '.$colName;
 			}
-			$this->sql = 'SELECT '.trim($sqlFrag,', ').' FROM ommaterialsample m
+			$this->sqlArr[] = 'SELECT '.trim($sqlFrag,', ').' FROM ommaterialsample m
 				INNER JOIN omexportoccurrences e ON m.occid = e.occid
 				LEFT JOIN users u ON m.preparedByUid = u.uid
 				WHERE (e.omExportID = ?) ';

--- a/classes/DwcArchiverMedia.php
+++ b/classes/DwcArchiverMedia.php
@@ -82,31 +82,32 @@ class DwcArchiverMedia extends DwcArchiverBaseManager{
 			foreach($this->fieldArr['fields'] as $colName){
 				if($colName) $sqlFrag .= ', ' . $colName;
 			}
-			$this->sql = 'SELECT '.trim($sqlFrag,', '). ', x.collid
+			$sql = 'SELECT '.trim($sqlFrag,', '). ', x.collid
 				FROM media m INNER JOIN omexportoccurrences x ON m.occid = x.occid
 				LEFT JOIN imagetag tag ON m.mediaID = tag.mediaID
 				LEFT JOIN users u ON m.creatorUid = u.uid
 				WHERE (x.omExportID = ?) ';
 			if($this->redactLocalities){
 				if($this->rareReaderCollStr){
-					$this->sql .= 'AND (x.recordSecurity = 0 OR x.collid IN(' . $this->rareReaderCollStr . ')) ';
+					$sql .= 'AND (x.recordSecurity = 0 OR x.collid IN(' . $this->rareReaderCollStr . ')) ';
 				}
 				else{
-					$this->sql .= 'AND (x.recordSecurity = 0) ';
+					$sql .= 'AND (x.recordSecurity = 0) ';
 				}
 			}
-			$this->sql .= 'GROUP BY m.mediaID';
+			$sql .= 'GROUP BY m.mediaID';
+			$this->sqlArr[] = $sql;
 		}
 	}
 
 	public function writeOutMediaData($exportID, $collArr, $serverDomain){
 		$recordCnt = 0;
-		if($this->sql){
+		foreach($this->sqlArr as $sql){
 			$urlPathPrefix = $serverDomain . $GLOBALS['CLIENT_ROOT'] . (substr($GLOBALS['CLIENT_ROOT'], -1) == '/' ? '' : '/');
 			if (isset($GLOBALS['MEDIA_DOMAIN']) && $GLOBALS['MEDIA_DOMAIN']) {
 				$serverDomain = $GLOBALS['MEDIA_DOMAIN'];
 			}
-			if($stmt = $this->conn->prepare($this->sql)){
+			if($stmt = $this->conn->prepare($sql)){
 				$stmt->bind_param('i', $exportID);
 				$stmt->execute();
 				$rs = $stmt->get_result();
@@ -185,7 +186,7 @@ class DwcArchiverMedia extends DwcArchiverBaseManager{
 			}
 			else{
 				$this->logOrEcho('ERROR writing out to extension file: ' . $stmt->error . "\n");
-				//$this->logOrEcho("\tSQL: ".$this->sql."\n");
+				//$this->logOrEcho("\tSQL: ".$sql."\n");
 			}
 		}
 		return $recordCnt;

--- a/classes/DwcArchiverResourceRelationship.php
+++ b/classes/DwcArchiverResourceRelationship.php
@@ -12,8 +12,9 @@ class DwcArchiverResourceRelationship extends DwcArchiverBaseManager{
 
 	public function initiateProcess($filePath){
 		$this->setFieldArr();
-		$this->setSql();
-
+		$this->setSqlBase();
+		$this->setSqlInternal();
+		$this->setSqlInternalInverse();
 		$this->setFileHandler($filePath);
 	}
 
@@ -28,7 +29,8 @@ class DwcArchiverResourceRelationship extends DwcArchiverBaseManager{
 		$termArr['relationshipOfResourceID'] = 'http://rs.tdwg.org/dwc/terms/relationshipOfResourceID';
 		$columnArr['relationshipOfResourceID'] = 'oa.relationshipID';
 		$termArr['relatedResourceID'] = 'http://rs.tdwg.org/dwc/terms/relatedResourceID';
-		$columnArr['relatedResourceID'] = 'IFNULL(IFNULL(IFNULL(oa.objectID, oo.occurrenceID), oo.recordID), oa.resourceUrl)';
+		$columnArr['relatedResourceID'][0] = 'IFNULL(oa.objectID, oa.resourceUrl)';
+		$columnArr['relatedResourceID'][1] = 'IFNULL(IFNULL(IFNULL(oa.objectID, oo.occurrenceID), oo.recordID), oa.resourceUrl)';
 		$termArr['relationshipOfResource'] = 'http://rs.tdwg.org/dwc/terms/relationshipOfResource';
 		$columnArr['relationshipOfResource'] = 'oa.relationship';
 		$termArr['relationshipAccordingTo'] = 'http://rs.tdwg.org/dwc/terms/relationshipAccordingTo';
@@ -38,7 +40,8 @@ class DwcArchiverResourceRelationship extends DwcArchiverBaseManager{
 		$termArr['relationshipRemarks'] = 'http://rs.tdwg.org/dwc/terms/relationshipRemarks';
 		$columnArr['relationshipRemarks'] = 'oa.notes';
 		$termArr['scientificName'] = 'http://rs.tdwg.org/dwc/terms/scientificName';
-		$columnArr['scientificName'] = 'CASE WHEN oa.associationType = "observational" THEN oa.verbatimSciName ELSE t.sciname END AS sciname'; // Note that t.sciname delivers the subject sciname; hence, o.sciname
+		$columnArr['scientificName'][0] = 'oa.verbatimSciName AS sciname';
+		$columnArr['scientificName'][1] = 'CASE WHEN oa.associationType = "observational" THEN oa.verbatimSciName ELSE IFNULL(t.sciname, oo.sciname) END AS sciname'; // Note that t.sciname delivers the subject sciname; hence, o.sciname
 
 		$termArr['associd'] = 'https://symbiota.org/terms/associd';
 		$columnArr['associd'] = 'oa.associd';
@@ -90,33 +93,49 @@ class DwcArchiverResourceRelationship extends DwcArchiverBaseManager{
 		return array_diff_key($dataArr, array_flip($trimArr));
 	}
 
-	private function setSql(){
+	private function setSqlBase(){
 		if($this->fieldArr){
 			$sqlFrag = '';
 			foreach($this->fieldArr['fields'] as $colName){
+				if(is_array($colName)) $colName = $colName[0];
 				if($colName) $sqlFrag .= ', ' . $colName;
 			}
-			$this->sql = 'SELECT DISTINCT ' . trim($sqlFrag, ', ') . ' FROM omoccurrences o
-				INNER JOIN omoccurassociations oa ON o.occid = oa.occid
+			$this->sqlArr[] = 'SELECT DISTINCT ' . trim($sqlFrag, ', ') . ' FROM omoccurrences o
 				INNER JOIN omexportoccurrences e ON o.occid = e.occid
-				LEFT JOIN omoccurrences oo ON oa.occidAssociate = o.occid
+				INNER JOIN omoccurassociations oa ON o.occid = oa.occid
+				WHERE oa.occidAssociate IS NULL AND (e.omExportID = ?) ';
+		}
+	}
+
+	private function setSqlInternal(){
+		if($this->fieldArr){
+			$sqlFrag = '';
+			foreach($this->fieldArr['fields'] as $colName){
+				if(is_array($colName)) $colName = $colName[1];
+				if($colName) $sqlFrag .= ', ' . $colName;
+			}
+			$this->sqlArr[] = 'SELECT DISTINCT ' . trim($sqlFrag, ', ') . ' FROM omoccurrences o
+				INNER JOIN omexportoccurrences e ON o.occid = e.occid
+				INNER JOIN omoccurassociations oa ON o.occid = oa.occid
+				INNER JOIN omoccurrences oo ON oa.occidAssociate = oo.occid
 				LEFT JOIN taxa t ON oo.tidInterpreted = t.tid
 				WHERE (e.omExportID = ?) ';
 		}
 	}
 
-	public function setSqlInverse(){
+	private function setSqlInternalInverse(){
 		if($this->fieldArr){
 			$sqlFrag = '';
 			$this->fieldArr['fields']['relationshipOfResource'] = 'terms.inverseRelationship';
 			foreach($this->fieldArr['fields'] as $colName){
+				if(is_array($colName)) $colName = $colName[1];
 				if($colName) $sqlFrag .= ', ' . $colName;
 			}
-			$this->sql = 'SELECT DISTINCT ' . trim($sqlFrag, ', ') . ' FROM omoccurrences o
+			$this->sqlArr[] = 'SELECT DISTINCT ' . trim($sqlFrag, ', ') . ' FROM omoccurrences o
 				INNER JOIN omexportoccurrences e ON o.occid = e.occid
 				INNER JOIN omoccurassociations oa ON o.occid = oa.occidAssociate
 				INNER JOIN omoccurrences oo ON oa.occid = oo.occid
-				LEFT JOIN taxa t ON o.tidInterpreted = t.tid
+				LEFT JOIN taxa t ON oo.tidInterpreted = t.tid
 				LEFT JOIN (SELECT t.term, t.inverseRelationship
 				FROM ctcontrolvocabterm t INNER JOIN ctcontrolvocab v ON t.cvID = v.cvID
 				WHERE v.tablename = "omoccurassociations" AND fieldName = "relationship" AND t.inverseRelationship IS NOT NULL) terms ON oa.relationship = terms.term


### PR DESCRIPTION
- Modify code so that it can process multiple SQL statements when creating a DwC-A extension file
- Break association generation into 3 optimized statements (previously 2). The previous LEFT JOIN of the first statement was creating creating a bind.
- Fix error where association omoccurrence table (aka oo) was linking to incorrect table. Likely error introduced by me previously.
- Add IFNULL(t.sciname, oo.sciname) within internal statements to capture scientific name when occurrence is not indexed to taxa table (e.g. tidInterpreted IS NULL)

Addresses issue: https://github.com/Symbiota/Symbiota/issues/3290 

Transferred fix over to Ecdysis and test on collid = 164 and resourceRelationship extension file was generated quickly. However, it would be good to have a second part of eyes reviewing the SQL changes and testing output.



# Pull Request Checklist:
# Pre-Approval

- [ ] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist
- [x] Hotfixes should be branched off of the `master` branch and PR'd using the **squash & merge** option into the `Hotfix-x.x.x` branch.
- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] All new text is preferably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows
- [x] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [x] Comment which GitHub issue(s), if any does this PR address
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)

# Post-Approval

- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If this PR represents a merge from the `hotfix` branch into the `master` branch use the **merge** option (not squashed)
  - [ ] a subsequent PR from `master` into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/master/docs/release-protocol.md)
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required

Thanks for contributing and keeping it clean!
