### PR TITLE
Occurrence Editor Collections Cloning Bug

### DIFF
--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -1672,7 +1672,7 @@ else{
 														<?php
 														$targetArr = $occManager->getCollectionList(true);
 														unset($targetArr[$collId]);
-														if(count($targetArr) > 1){
+														if($targetArr){
 															?>
 															<div class="fieldGroup-div">
 																<label><?php echo $LANG['TARGET_COLL']; ?>:</label>


### PR DESCRIPTION
Small bug in code where target collection selector wouldn't render if the permissions list only listed one collection