### PR TITLE
Checklist voucher wording adjustment

### DIFF
--- a/checklists/vaconflicts.php
+++ b/checklists/vaconflicts.php
@@ -58,7 +58,7 @@ if($IS_ADMIN || (array_key_exists("ClAdmin",$USER_RIGHTS) && in_array($clid,$USE
 					<th><input type="checkbox" onclick="selectAll(this)" /></th>
 					<th><b><?php echo $LANG['CHECK_ID']; ?></b></th>
 					<th><b><?php echo $LANG['VOUCHER_SPEC']; ?></b></th>
-					<th><b><?php echo $LANG['CORRECTED_ID']; ?></b></th>
+					<th><b><?php echo $LANG['SPECIMEN_ID']; ?></b></th>
 					<th><b><?php echo $LANG['IDED_BY']; ?></b></th>
 				</tr>
 				<?php
@@ -102,8 +102,8 @@ if($IS_ADMIN || (array_key_exists("ClAdmin",$USER_RIGHTS) && in_array($clid,$USE
 				<input name="tabindex" type="hidden" value="2" />
 				<input name="submitaction" type="hidden" value="resolveconflicts" />
 				<b><?php echo $LANG['BATCH_ACTION']; ?>:</b>
-				<button name="submitbutton" type="button" value="Link Vouchers to Corrected Identification" onclick="return validateBatchConflictForm(this.form)"><?php echo $LANG['LINK_VOUCHERS']; ?></button><br/>
-				<div>* <?php echo $LANG['CORRECTED_WILL_ADD']; ?></div>
+				<button name="submitbutton" type="button" value="transferVouchers" onclick="return validateBatchConflictForm(this.form)"><?php echo $LANG['TRANSFER_VOUCHERS']; ?></button><br/>
+				<div>* <?php echo $LANG['SPECIMEN_ID_WILL_ADD']; ?></div>
 			</div>
 		</form>
 		<?php

--- a/content/lang/checklists/vaconflicts.en.php
+++ b/content/lang/checklists/vaconflicts.en.php
@@ -12,13 +12,13 @@ $LANG['EXPLAIN_PARAGRAPH'] = 'List of specimen vouchers where the current identi
 $LANG['CONFLICT_COUNT'] = 'Conflict Count';
 $LANG['CHECK_ID'] = 'Checklist ID';
 $LANG['VOUCHER_SPEC'] = 'Voucher Specimen';
-$LANG['CORRECTED_ID'] = 'Corrected Specimen ID';
+$LANG['SPECIMEN_ID'] = 'Specimen ID';
 $LANG['IDED_BY'] = 'Identified By';
 $LANG['FROM_CHILD'] = '(from child checklists)';
 $LANG['REMOVE_TAXA'] = 'Remove taxa from checklist if all vouchers are removed';
-$LANG['LINK_VOUCHERS'] = 'Link Vouchers to Corrected Identification';
+$LANG['TRANSFER_VOUCHERS'] = 'Transfer Vouchers to Specimen Identification';
 $LANG['BATCH_ACTION'] = 'Batch Action';
-$LANG['CORRECTED_WILL_ADD'] = 'Corrected taxon will be added to checklist if not yet present';
+$LANG['SPECIMEN_ID_WILL_ADD'] = 'Taxon associated with Specimen ID will be added to checklist if not yet present';
 $LANG['NO_CONFLICTS'] = 'No conflicts exist';
 
 ?>

--- a/content/lang/checklists/vaconflicts.es.php
+++ b/content/lang/checklists/vaconflicts.es.php
@@ -2,25 +2,23 @@
 /*
 ------------------
 Language: Español (Spanish)
-Translated by: Samanta Orellana
-Date Translated: 2021-08-05
+Translated by: Samanta Orellana (2021-08-05)
 ------------------
 */
-
 $LANG['SELECT_ONE'] = 'Al menos un voucher necesita ser seleccionado';
-$LANG['EXPLAIN_PARAGRAPH'] = 'Listado de especímenes voucher cuya identificación actual está en conflicto con el listado de especies. 
-		Los conflictos de voucher se deben típicamente a anotaciones recientes de especímenes localizados dentro de colecciones. 
+$LANG['EXPLAIN_PARAGRAPH'] = 'Listado de especímenes voucher cuya identificación actual está en conflicto con el listado de especies.
+		Los conflictos de voucher se deben típicamente a anotaciones recientes de especímenes localizados dentro de colecciones.
 		Hacer click en ID del Listado de Especies para abrir el panel de edición para ese registro.';
 $LANG['CONFLICT_COUNT'] = 'Recuento de Conflictos';
 $LANG['CHECK_ID'] = 'ID del Listado de Especies';
 $LANG['VOUCHER_SPEC'] = 'Espécimen Voucher';
-$LANG['CORRECTED_ID'] = 'Identificación Corregida del Espécimen';
+$LANG['SPECIMEN_ID'] = 'Identificación del Espécimen';
 $LANG['IDED_BY'] = 'Identificado Por';
 $LANG['FROM_CHILD'] = '(de listados inferiores)';
 $LANG['REMOVE_TAXA'] = 'Remover taxa del listado de especies si todos los vouchers son removidos';
-$LANG['LINK_VOUCHERS'] = 'Enlazar Vouchers a la Identificación Corregida';
+$LANG['TRANSFER_VOUCHERS'] = 'Enlazar Vouchers a la Identificación Corregida';
 $LANG['BATCH_ACTION'] = 'Acción en Bloque';
-$LANG['CORRECTED_WILL_ADD'] = 'El taxón corregido será añadido al listado de especies si aún no está presente';
+$LANG['SPECIMEN_ID_WILL_ADD'] = 'El taxón asociado con el ID del espécimen se agregará a la lista de verificación si aún no está presente';
 $LANG['NO_CONFLICTS'] = 'No existen conflictos';
 
 ?>

--- a/content/lang/checklists/vaconflicts.fr.php
+++ b/content/lang/checklists/vaconflicts.fr.php
@@ -6,20 +6,19 @@ Language: Français (French)
 */
 
 $LANG['SELECT_ONE'] = 'Au moins un échantillon doit être sélectionné';
-$LANG['POSS_CONFLICTS'] = 'Conflits Possibles d\'Échantillons';
-$LANG['POSS_CONFLICTS'] = "Liste des échantillons pour lesquels les identifications actuelles sont en conflit avec la liste. 
-		Les conflits d'échantillons sont généralement dus à des annotations récentes de spécimens situés dans la collection. 
+$LANG['EXPLAIN_PARAGRAPH'] = "Liste des échantillons pour lesquels les identifications actuelles sont en conflit avec la liste.
+		Les conflits d'échantillons sont généralement dus à des annotations récentes de spécimens situés dans la collection.
 		Cliquez sur ID de Liste pour ouvrir le volet d'édition de cet enregistrement.";
 $LANG['CONFLICT_COUNT'] = 'Nombre de Conflits';
 $LANG['CHECK_ID'] = 'ID de Liste';
 $LANG['VOUCHER_SPEC'] = 'Échantillon';
-$LANG['CORRECTED_ID'] = "ID d'Échantillon corrigé";
+$LANG['SPECIMEN_ID'] = "ID d'Échantillon";
 $LANG['IDED_BY'] = 'Identifié par';
 $LANG['FROM_CHILD'] = '(à partir des listes d\'enfants)';
 $LANG['REMOVE_TAXA'] = 'Supprimer taxons de liste si tous les échantillons sont supprimés';
-$LANG['LINK_VOUCHERS'] = 'Lier les Échantillons à l\'Identification Corrigée';
+$LANG['TRANSFER_VOUCHERS'] = 'Lier les Échantillons à l\'Identification Corrigée';
 $LANG['BATCH_ACTION'] = 'Action par Lot';
-$LANG['CORRECTED_WILL_ADD'] = 'Le taxon corrigé sera ajouté à la liste s\'il n\'est pas encore présent';
+$LANG['SPECIMEN_ID_WILL_ADD'] = "Le taxon associé à l'identifiant du spécimen sera ajouté à la liste de contrôle s'il n'y figure pas déjà";
 $LANG['NO_CONFLICTS'] = 'Aucun conflit n\'existe';
 
 ?>


### PR DESCRIPTION
- Change wording to remove "corrected", since voucher specimens might be annotated incorrectly, at least to the perspective of author of the checklist. The IDs within the checklist and those associated with the specimens can differ due to competing, yet valid, hypothesis, and wording should not support one over the other. Text modified highlighted in screenshot below. 
- Fix mismatched LANG tags in French file

<img width="2465" height="1531" alt="image" src="https://github.com/user-attachments/assets/de42e59f-49d3-4232-ba60-d5f37be03331" />

