### PR TITLE
Add hyperlink to version badge within sitemap

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -497,7 +497,9 @@ if(!$schemaVersion){
 			?>
 			</section>
 			<div id="symbiotaschema">
-				<img style="height:1.85rem" src="https://img.shields.io/badge/Symbiota-v<?= $CODE_VERSION ?>-blue.svg" alt="a blue badge depicting Symbiota software version" />
+				<a href="https://github.com/Symbiota/Symbiota/releases/tag/v<?= $CODE_VERSION ?>" target="_blank">
+					<img style="height:1.85rem" src="https://img.shields.io/badge/Symbiota-v<?= $CODE_VERSION ?>-blue.svg" alt="a blue badge depicting Symbiota software version" />
+				</a>
 				<img style="height:1.85rem" src="https://img.shields.io/badge/Schema-v<?= $schemaVersion ?>-blue.svg" alt="a blue badge depicting Symbiota database schema version" />
 			</div>
 		</div>


### PR DESCRIPTION
- Add hyperlink to version badge within sitemap that directs the user to the code version release listing details of change. 

Note that when testing PR, hyperlink will try to take you to 3.4.4 release, which show a broken link because it has not yet been released. For a 3.4.3 portal, clicking on badge will take you to:  https://github.com/Symbiota/Symbiota/releases/tag/v3.4.3 

Please go to the `Preview` tab and select the appropriate sub-template:

* [Feature or Bugfix](?expand=1&template=feature_or_bugfix.md)
* [Hotfix](?expand=1&template=hotfix.md)
* [General Release](?expand=1&template=general_release.md)