### PR TITLE
Hotfix trait editor debugging

### DIFF
--- a/classes/OccurrenceAttributes.php
+++ b/classes/OccurrenceAttributes.php
@@ -175,69 +175,74 @@ class OccurrenceAttributes extends Manager {
 	}
 
 	//Get data functions
-	public function getImageUrls(){
+	public function getImageUrls($traitID){
 		$retArr = array();
 		if($this->collidStr){
-			if(!$this->sqlBody) $this->setSqlBody();
-			$sql = 'SELECT m.occid, IFNULL(o.catalognumber, o.othercatalognumbers) AS catnum '.$this->sqlBody.'ORDER BY RAND() LIMIT 1';
-			$rs = $this->conn->query($sql);
-			if($r = $rs->fetch_object()){
-				$retArr[$r->occid]['catnum'] = $r->catnum;
-				$sql2 = 'SELECT m.mediaID, m.url, m.originalurl, m.occid '.
-					'FROM media m '.
-					'WHERE (m.occid = '.$r->occid.') ';
-				$rs2 = $this->conn->query($sql2);
-				$cnt = 1;
-				while($r2 = $rs2->fetch_object()){
-					$retArr[$r2->occid][$cnt]['web'] = $r2->url;
-					$retArr[$r2->occid][$cnt]['lg'] = $r2->originalurl;
-					$cnt++;
+			if(!$this->sqlBody) $this->setSqlBody($traitID);
+			if($this->sqlBody){
+				$sql = 'SELECT m.occid, IFNULL(o.catalognumber, o.othercatalognumbers) AS catnum '.$this->sqlBody.'ORDER BY RAND() LIMIT 1';
+				$rs = $this->conn->query($sql);
+				if($r = $rs->fetch_object()){
+					$retArr[$r->occid]['catnum'] = $r->catnum;
+					$sql2 = 'SELECT m.mediaID, m.url, m.originalurl, m.occid '.
+						'FROM media m '.
+						'WHERE (m.occid = '.$r->occid.') ';
+					$rs2 = $this->conn->query($sql2);
+					$cnt = 1;
+					while($r2 = $rs2->fetch_object()){
+						$retArr[$r2->occid][$cnt]['web'] = $r2->url;
+						$retArr[$r2->occid][$cnt]['lg'] = $r2->originalurl;
+						$cnt++;
+					}
+					$rs2->free();
 				}
-				$rs2->free();
+				$rs->free();
 			}
-			$rs->free();
 		}
 		return $retArr;
 	}
 
-	public function getSpecimenCount(){
+	public function getSpecimenCount($traitID){
 		$retCnt = 0;
 		if($this->collidStr){
-			if(!$this->sqlBody) $this->setSqlBody();
-			$sql = 'SELECT COUNT(DISTINCT o.occid) AS cnt '.$this->sqlBody;
-			//echo $sql;
-			$rs = $this->conn->query($sql);
-			if($r = $rs->fetch_object()){
-				$retCnt = $r->cnt;
+			if(!$this->sqlBody) $this->setSqlBody($traitID);
+			if($this->sqlBody){
+				$sql = 'SELECT COUNT(DISTINCT o.occid) AS cnt ' . $this->sqlBody;
+				//echo $sql;
+				$rs = $this->conn->query($sql);
+				if($r = $rs->fetch_object()){
+					$retCnt = $r->cnt;
+				}
+				$rs->free();
 			}
-			$rs->free();
 		}
 		return $retCnt;
 	}
 
-	private function setSqlBody(){
-		$this->sqlBody = 'FROM omoccurrences o INNER JOIN media m ON o.occid = m.occid '.
-			'LEFT JOIN tmattributes a ON m.occid = a.occid '.
-			'WHERE (a.occid IS NULL) AND (o.collid = '.$this->collidStr.') ';
-		if(isset($this->filterArr['tidfilter']) && $this->filterArr['tidfilter']){
-			//Get Synonyms
-			$tidArr = array();
-			$sql = 'SELECT ts1.tid '.
-				'FROM taxstatus ts1 INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted '.
-				'WHERE ts2.tid = '.$this->filterArr['tidfilter'].' AND ts1.taxauthid = 1 AND ts2.taxauthid = 1';
-			$rs = $this->conn->query($sql);
-			while($r = $rs->fetch_object()){
-				$tidArr[] = $r->tid;
+	private function setSqlBody($traitID){
+		if(is_numeric($traitID)){
+			$this->sqlBody = 'FROM omoccurrences o INNER JOIN media m ON o.occid = m.occid
+				WHERE (o.collid = '.$this->collidStr.') ';
+			if(isset($this->filterArr['tidfilter']) && $this->filterArr['tidfilter']){
+				//Get Synonyms
+				$tidArr = array();
+				$sql = 'SELECT ts1.tid
+					FROM taxstatus ts1 INNER JOIN taxstatus ts2 ON ts1.tidaccepted = ts2.tidaccepted
+					WHERE ts2.tid = '.$this->filterArr['tidfilter'].' AND ts1.taxauthid = 1 AND ts2.taxauthid = 1';
+				$rs = $this->conn->query($sql);
+				while($r = $rs->fetch_object()){
+					$tidArr[] = $r->tid;
+				}
+				$rs->free();
+				$this->sqlBody = 'FROM omoccurrences o INNER JOIN media m ON o.occid = m.occid
+					INNER JOIN taxaenumtree e ON m.tid = e.tid
+					WHERE (e.parenttid IN('.$this->filterArr['tidfilter'].') OR e.tid IN('.implode(',',$tidArr).'))
+					AND (o.collid = '.$this->collidStr.') AND (e.taxauthid = 1) ';
 			}
-			$rs->free();
-			$this->sqlBody = 'FROM omoccurrences o INNER JOIN media m ON o.occid = m.occid '.
-				'INNER JOIN taxaenumtree e ON m.tid = e.tid '.
-				'LEFT JOIN tmattributes a ON m.occid = a.occid '.
-				'WHERE (e.parenttid IN('.$this->filterArr['tidfilter'].') OR e.tid IN('.implode(',',$tidArr).')) '.
-				'AND (a.occid IS NULL) AND (o.collid = '.$this->collidStr.') AND (e.taxauthid = 1) ';
-		}
-		if(isset($this->filterArr['localfilter']) && $this->filterArr['localfilter']){
-			$this->sqlBody .= 'AND (o.country = "'.$this->filterArr['localfilter'].'" OR o.stateProvince = "'.$this->filterArr['localfilter'].'") ';
+			if(isset($this->filterArr['localfilter']) && $this->filterArr['localfilter']){
+				$this->sqlBody .= 'AND (o.country = "'.$this->filterArr['localfilter'].'" OR o.stateProvince = "'.$this->filterArr['localfilter'].'") ';
+			}
+			$this->sqlBody .= 'AND o.occid NOT IN(SELECT a.occid FROM tmattributes a INNER JOIN tmstates s ON a.stateid = s.stateid WHERE s.traitid = ' . $traitID . ') ';
 		}
 	}
 

--- a/collections/traitattr/occurattributes.php
+++ b/collections/traitattr/occurattributes.php
@@ -64,7 +64,7 @@ $catNum = '';
 if ($traitID) {
 	$imgRetArr = array();
 	if ($mode == 1) {
-		$imgRetArr = $attrManager->getImageUrls();
+		$imgRetArr = $attrManager->getImageUrls($traitID);
 		$imgArr = current($imgRetArr);
 	} elseif ($mode == 2) {
 		$imgRetArr = $attrManager->getReviewUrls($traitID);
@@ -112,11 +112,14 @@ if ($traitID) {
 
 		$(document).ready(function() {
 			setImgRes();
+
 			$("#specimg").imagetool({
 				maxWidth: 6000,
 				viewportWidth: <?= $paneX ?>,
-				viewportHeight: <?= $paneY ?>
+				viewportHeight: <?= $paneY ?>,
+				edgeSensitivity: 25
 			});
+
 		});
 
 		function setImgRes() {
@@ -272,7 +275,7 @@ if ($traitID) {
 								echo '</span>';
 							}
 							$imgTotal = count($imgArr);
-							if ($imgTotal > 1) echo '<span id="labelcnt" style="margin-left:60px;">1</span> of ' . $imgTotal . ' images ' . ($imgTotal > 1 ? '<a href="#" onclick="nextImage()">&gt;&gt; ' . $LANG['NEXT'] . '</a>' : '');
+							if ($imgTotal > 1) echo '<span id="labelcnt" style="margin-left:60px;">1</span> of ' . $imgTotal . ' images ' . ($imgTotal > 1 ? '<a href="#" onclick="nextImage();return false;">&gt;&gt; ' . $LANG['NEXT'] . '</a>' : '');
 							if ($occid && $mode != 2) echo '<span style="margin-left:80px" title="' . $LANG['SKIP_SPECIMEN'] . '"><a href="#" onclick="skipSpecimen()">' . $LANG['SKIP'] . ' &gt;&gt;</a></span>';
 							?>
 						</div>
@@ -309,7 +312,7 @@ if ($traitID) {
 					if ($mode == 1) {
 						?>
 						<form id="filterform" name="filterform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
-							<fieldset style="margin-top:25px">
+							<fieldset>
 								<legend><b><?= $LANG['FILTER'] ?></b></legend>
 								<div>
 									<select name="traitid">
@@ -353,7 +356,7 @@ if ($traitID) {
 									<span id="notvalid-span" style="display:none;font-weight:bold;color:red;"><?= $LANG['TAXON_NOT_VALID'] ?></span>
 								</div>
 								<div style="margin:10px">
-									<?php if ($traitID) echo '<b> ' . $LANG['TARGET_SPECIMEN'] . '</b> ' . $attrManager->getSpecimenCount() ?>
+									<?php if ($traitID) echo '<b> ' . $LANG['TARGET_SPECIMEN'] . '</b> ' . $attrManager->getSpecimenCount($traitID) ?>
 								</div>
 								<?php
 								if ($isEditor == 2){
@@ -371,7 +374,7 @@ if ($traitID) {
 					} elseif ($mode == 2) {
 						?>
 						<form id="reviewform" name="reviewform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
-							<fieldset style="margin-top:25px">
+							<fieldset>
 								<legend><b><?= $LANG['REVIEWER'] ?></b></legend>
 								<div>
 									<select name="traitid">
@@ -494,7 +497,7 @@ if ($traitID) {
 						?>
 						<div id="traitdiv">
 							<form name="submitform" method="post" action="occurattributes.php" onsubmit="return verifySubmitForm(this)">
-								<fieldset style="margin-top:20px">
+								<fieldset>
 									<legend><b><?= $traitArr[$traitID]['name'] ?></b></legend>
 									<div style="float:right;margin-right:10px">
 										<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="<?= $LANG['TOGGLE_ATTRI_TREE'] ?>">

--- a/collections/traitattr/occurattributes.php
+++ b/collections/traitattr/occurattributes.php
@@ -2,6 +2,7 @@
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceAttributes.php');
 include_once($SERVER_ROOT . '/classes/utilities/GeneralUtil.php');
+include_once($SERVER_ROOT . '/classes/utilities/Sanitize.php');
 include_once($SERVER_ROOT . '/classes/utilities/Language.php');
 
 Language::load('collections/traitattr/occurattributes');
@@ -10,20 +11,13 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 if (!$SYMB_UID) header('Location: ' . $CLIENT_ROOT . '/profile/index.php?refurl=../collections/traitattr/occurattributes.php?' . htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES));
 
-$collid = $_REQUEST['collid'];
+$collid = Sanitize::int($_REQUEST['collid']);
+$mode = Sanitize::int($_REQUEST['mode'] ?? 1);
+$traitID = Sanitize::int($_REQUEST['traitid'] ?? '');
+$paneX = Sanitize::int($_POST['panex'] ?? '700');
+$paneY = Sanitize::int($_POST['paney'] ?? '550');
+$imgRes = Sanitize::int($_POST['imgres'] ?? 0);
 $submitForm = array_key_exists('submitform', $_POST) ? $_POST['submitform'] : '';
-$mode = array_key_exists('mode', $_REQUEST) ? $_REQUEST['mode'] : 1;
-$traitID = array_key_exists('traitid', $_REQUEST) ? $_REQUEST['traitid'] : '';
-$paneX = array_key_exists('panex', $_POST) ? $_POST['panex'] : '575';
-$paneY = array_key_exists('paney', $_POST) ? $_POST['paney'] : '550';
-$imgRes = array_key_exists('imgres', $_POST) ? $_POST['imgres'] : 'med';
-
-
-//Sanitation
-if (!is_numeric($collid)) $collid = 0;
-if (!is_numeric($traitID)) $traitID = '';
-if (!is_numeric($paneX)) $paneX = '';
-if (!is_numeric($paneY)) $paneY = '';
 
 $isEditor = 0;
 if ($SYMB_UID) {
@@ -35,6 +29,7 @@ if ($SYMB_UID) {
 			$isEditor = 2;
 		} elseif (array_key_exists("CollEditor", $USER_RIGHTS) && in_array($collid, $USER_RIGHTS["CollEditor"])) {
 			$isEditor = 1;
+			$mode = 1;		//Editors are not allowed to review, thus default to edit mode
 		}
 	}
 }
@@ -84,16 +79,16 @@ if ($traitID) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="<?php echo $LANG_TAG ?>">
+<html lang="<?= $LANG_TAG ?>">
 	<head>
-		<title><?php echo $LANG['OCC_ATTRIBUTE_BATCH_EDIT'] ?></title>
-		<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
+		<title><?= $LANG['OCC_ATTRIBUTE_BATCH_EDIT'] ?></title>
+		<link href="<?= $CSS_BASE_PATH ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 		<?php
 		include_once($SERVER_ROOT . '/includes/head.php');
 		?>
-		<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
-		<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
-		<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery.imagetool-1.7.js?ver=160102" type="text/javascript"></script>
+		<script src="<?= $CLIENT_ROOT ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
+		<script src="<?= $CLIENT_ROOT ?>/js/jquery-ui.min.js" type="text/javascript"></script>
+		<script src="<?= $CLIENT_ROOT ?>/js/jquery.imagetool-1.7.js?ver=160102" type="text/javascript"></script>
 		<script type="text/javascript">
 			var activeImgIndex = 1;
 			var imgArr = [];
@@ -119,21 +114,21 @@ if ($traitID) {
 			setImgRes();
 			$("#specimg").imagetool({
 				maxWidth: 6000,
-				viewportWidth: <?php echo $paneX; ?>,
-				viewportHeight: <?php echo $paneY; ?>
+				viewportWidth: <?= $paneX ?>,
+				viewportHeight: <?= $paneY ?>
 			});
 		});
 
 		function setImgRes() {
 			if (imgLgArr[activeImgIndex] != null) {
-				if ($("#imgres1").val() == 'lg') changeImgRes('lg');
+				if ($("#imgres1").val() == 1) changeImgRes('lg');
 			} else {
 				if (imgArr[activeImgIndex] != null) {
 					$("#specimg").attr("src", imgArr[activeImgIndex]);
 					document.getElementById("imgresmed").checked = true;
 					var imgResLgRadio = document.getElementById("imgreslg");
 					imgResLgRadio.disabled = true;
-					imgResLgRadio.title = "<?php echo $LANG['LARGE_RESOLUTION_IMAGE_NOT_AVAI'] ?>";
+					imgResLgRadio.title = "<?= $LANG['LARGE_RESOLUTION_IMAGE_NOT_AVAI'] ?>";
 				}
 			}
 			if (imgArr[activeImgIndex] != null) {
@@ -144,22 +139,22 @@ if ($traitID) {
 					document.getElementById("imgreslg").checked = true;
 					var imgResMedRadio = document.getElementById("imgresmed");
 					imgResMedRadio.disabled = true;
-					imgResMedRadio.title = "<?php echo $LANG['MED_RESOLUTION_IMAGE_NOT_AVAI'] ?>";
+					imgResMedRadio.title = "<?= $LANG['MED_RESOLUTION_IMAGE_NOT_AVAI'] ?>";
 				}
 			}
 		}
 
 		function changeImgRes(resType) {
 			if (resType == 'lg') {
-				$("#imgres1").val("lg");
-				$("#imgres2").val("lg");
+				$("#imgres1").val(1);
+				$("#imgres2").val(1);
 				if (imgLgArr[activeImgIndex]) {
 					$("#specimg").attr("src", imgLgArr[activeImgIndex]);
 					$("#imgreslg").prop("checked", true);
 				}
 			} else {
-				$("#imgres1").val("med");
-				$("#imgres2").val("med");
+				$("#imgres1").val(0);
+				$("#imgres2").val(0);
 				if (imgArr[activeImgIndex]) {
 					$("#specimg").attr("src", imgArr[activeImgIndex]);
 					$("#imgresmed").prop("checked", true);
@@ -193,13 +188,13 @@ if ($traitID) {
 		}
 
 		function verifyFilterForm(f) {
-			if (f.taxonfilter.value == "<?php echo $LANG['ALL_TAXA']; ?>") f.taxonfilter.value = '';
+			if (f.taxonfilter.value == "<?= $LANG['ALL_TAXA'] ?>") f.taxonfilter.value = '';
 			if (f.traitid.value == "") {
-				alert("<?php echo $LANG['OCC_TRAIT_MUST_SELECTED'] ?>");
+				alert("<?= $LANG['OCC_TRAIT_MUST_SELECTED'] ?>");
 				return false;
 			}
 			if (f.taxonfilter.value != "" && f.tidfilter.value == "") {
-				alert("<?php echo $LANG['TAXON_FILTER_NOT_SYNC_THES'] ?>");
+				alert("<?= $LANG['TAXON_FILTER_NOT_SYNC_THES'] ?>");
 				return false;
 			}
 			return true;
@@ -217,11 +212,11 @@ if ($traitID) {
 		}
 
 		function taxonFilterFocus(formElem) {
-			if (formElem.value == "<?php echo $LANG['ALL_TAXA']; ?>") formElem.value = '';
+			if (formElem.value == "<?= $LANG['ALL_TAXA'] ?>") formElem.value = '';
 		}
 	</script>
-	<script src="<?php echo $CLIENT_ROOT; ?>/js/symb/collections.traitattr.js" type="text/javascript"></script>
-	<script src="<?php echo $CLIENT_ROOT; ?>/js/symb/shared.js?ver=151229" type="text/javascript"></script>
+	<script src="<?= $CLIENT_ROOT ?>/js/symb/collections.traitattr.js" type="text/javascript"></script>
+	<script src="<?= $CLIENT_ROOT ?>/js/symb/shared.js?ver=1" type="text/javascript"></script>
 	<style>
 		input {
 			margin: 3px
@@ -237,19 +232,10 @@ if ($traitID) {
 	<?php
 	$displayLeftMenu = false;
 	include($SERVER_ROOT . '/includes/header.php');
-	if ($isEditor == 2) {
-		echo '<div style="float:right;margin:0px 3px;font-size:90%">';
-		if ($mode == 1) {
-			echo '<a href="occurattributes.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '&mode=2&traitid=' . htmlspecialchars($traitID, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '"><img src="../../images/edit.png" style="width:1.3em" />' . $LANG['REVIEW'] . '</a>';
-		} else {
-			echo '<a href="occurattributes.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '&mode=1&traitid=' . htmlspecialchars($traitID, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '"><img src="../../images/edit.png" style="width:1.3em" />' . $LANG['EDIT'] . '</a>';
-		}
-		echo '</div>';
-	}
 	?>
 	<div class="navpath">
-		<a href="../../index.php"><?php echo $LANG['HOME'] ?></a> &gt;&gt;
-		<a href="../misc/collprofiles.php?collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>&emode=1"><?php echo $LANG['COLLECTION_MANAGEMENT'] ?></a> &gt;&gt;
+		<a href="../../index.php"><?= $LANG['HOME'] ?></a> &gt;&gt;
+		<a href="../misc/collprofiles.php?collid=<?= $collid ?>&emode=1"><?= $LANG['COLLECTION_MANAGEMENT'] ?></a> &gt;&gt;
 		<?php
 		if ($mode == 2) {
 			echo '<b>' . $LANG['ATTRIBUTE_REVIEWER'] . '</b>';
@@ -267,21 +253,21 @@ if ($traitID) {
 	?>
 	<!-- This is inner text! -->
 	<div role="main" id="innertext" style="position:relative;">
-		<h1 class="page-heading"><?= $LANG['OCC_ATTRIBUTE_BATCH_EDIT']; ?></h1>
+		<h1 class="page-heading"><?= $LANG['OCC_ATTRIBUTE_BATCH_EDIT'] ?></h1>
 		<?php
 		if ($collid) {
-		?>
+			?>
 			<div style="float:right;width:290px;">
 				<?php
 				$attrNameArr = $attrManager->getTraitNames();
 				if ($mode == 1) {
-				?>
-					<fieldset style="margin-top:25px">
-						<legend><b><?php echo $LANG['FILTER'] ?></b></legend>
-						<form id="filterform" name="filterform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
+					?>
+					<form id="filterform" name="filterform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
+						<fieldset style="margin-top:25px">
+							<legend><b><?= $LANG['FILTER'] ?></b></legend>
 							<div>
 								<select name="traitid">
-									<option value=""><?php echo $LANG['SELECT_TRAIT_REQ'] ?></option>
+									<option value=""><?= $LANG['SELECT_TRAIT_REQ'] ?></option>
 									<option value="">------------------------------------</option>
 									<?php
 									if ($attrNameArr) {
@@ -296,7 +282,7 @@ if ($traitID) {
 							</div>
 							<div>
 								<select name="localfilter" style="width:250px">
-									<option value=""><?php echo $LANG['ALL_COUNTRIES_STATES'] ?></option>
+									<option value=""><?= $LANG['ALL_COUNTRIES_STATES'] ?></option>
 									<option value="">-----------------------------</option>
 									<?php
 									$localArr = $attrManager->getLocalFilterOptions();
@@ -307,33 +293,43 @@ if ($traitID) {
 								</select>
 							</div>
 							<div>
-								<input id="taxonfilter" name="taxonfilter" type="text" value="<?php echo ($taxonFilter ? $taxonFilter : $LANG['ALL_TAXA']); ?>" taxonFilterFocus(this) />
-								<input id="tidfilter" name="tidfilter" type="hidden" value="<?php echo $tidFilter; ?>" />
+								<input id="taxonfilter" name="taxonfilter" type="text" value="<?= ($taxonFilter ? $taxonFilter : $LANG['ALL_TAXA']) ?>" taxonFilterFocus(this) />
+								<input id="tidfilter" name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
 							</div>
 							<div>
-								<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
-								<input id="panex1" name="panex" type="hidden" value="<?php echo $paneX; ?>" />
-								<input id="paney1" name="paney" type="hidden" value="<?php echo $paneY; ?>" />
-								<input id="imgres1" name="imgres" type="hidden" value="<?php echo $imgRes; ?>" />
-								<button id="filtersubmit" name="submitform" type="submit" value="Load Images"><?php echo $LANG['LOAD_IMAGES'] ?></button>
+								<input name="collid" type="hidden" value="<?= $collid ?>" />
+								<input id="panex1" name="panex" type="hidden" value="<?= $paneX ?>" />
+								<input id="paney1" name="paney" type="hidden" value="<?= $paneY ?>" />
+								<input id="imgres1" name="imgres" type="hidden" value="<?= $imgRes ?>" />
+								<button id="filtersubmit" name="submitform" type="submit" value="Load Images"><?= $LANG['LOAD_IMAGES'] ?></button>
 
-								<span id="verify-span" style="display:none;font-weight:bold;color:green;"><?php echo $LANG['VERIFY_TAXONOMY'] ?></span>
-								<span id="notvalid-span" style="display:none;font-weight:bold;color:red;"><?php echo $LANG['TAXON_NOT_VALID'] ?></span>
+								<span id="verify-span" style="display:none;font-weight:bold;color:green;"><?= $LANG['VERIFY_TAXONOMY'] ?></span>
+								<span id="notvalid-span" style="display:none;font-weight:bold;color:red;"><?= $LANG['TAXON_NOT_VALID'] ?></span>
 							</div>
 							<div style="margin:10px">
-								<?php if ($traitID) echo '<b> ' . $LANG['TARGET_SPECIMEN'] . '</b> ' . $attrManager->getSpecimenCount(); ?>
+								<?php if ($traitID) echo '<b> ' . $LANG['TARGET_SPECIMEN'] . '</b> ' . $attrManager->getSpecimenCount() ?>
 							</div>
-						</form>
-					</fieldset>
-				<?php
+							<?php
+							if ($isEditor == 2){
+								?>
+								<div style="text-align:center">
+									<hr>
+									<?= $LANG['GO_TO'] ?> <a href="occurattributes.php?collid=<?= $collid ?>&mode=2&traitid=<?= $traitID ?>"><?= $LANG['REVIEW_MODE'] ?></a>
+								</div>
+								<?php
+							}
+							?>
+						</fieldset>
+					</form>
+					<?php
 				} elseif ($mode == 2) {
-				?>
-					<fieldset style="margin-top:25px">
-						<legend><b><?php echo $LANG['REVIEWER'] ?></b></legend>
-						<form id="reviewform" name="reviewform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
+					?>
+					<form id="reviewform" name="reviewform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
+						<fieldset style="margin-top:25px">
+							<legend><b><?= $LANG['REVIEWER'] ?></b></legend>
 							<div>
 								<select name="traitid">
-									<option value=""><?php echo $LANG['SELECT_TRAIT_REQ'] ?></option>
+									<option value=""><?= $LANG['SELECT_TRAIT_REQ'] ?></option>
 									<option value="">------------------------------------</option>
 									<?php
 									if ($attrNameArr) {
@@ -348,7 +344,7 @@ if ($traitID) {
 							</div>
 							<div>
 								<select name="reviewuid">
-									<option value=""><?php echo $LANG['ALL_EDITORS'] ?></option>
+									<option value=""><?= $LANG['ALL_EDITORS'] ?></option>
 									<option value="">-----------------------</option>
 									<?php
 									$editorArr = $attrManager->getEditorArr();
@@ -360,7 +356,7 @@ if ($traitID) {
 							</div>
 							<div>
 								<select name="reviewdate">
-									<option value=""><?php echo $LANG['ALL_DATES'] ?></option>
+									<option value=""><?= $LANG['ALL_DATES'] ?></option>
 									<option value="">-----------------------</option>
 									<?php
 									$dateArr = $attrManager->getEditDates();
@@ -372,14 +368,14 @@ if ($traitID) {
 							</div>
 							<div>
 								<select name="reviewstatus">
-									<option value="0"><?php echo $LANG['NOT_REVIEWED'] ?></option>
-									<option value="5" <?php echo ($reviewStatus == 5 ? 'SELECTED' : ''); ?>><?php echo $LANG['EXPERT_NEEDED'] ?></option>
-									<option value="10" <?php echo ($reviewStatus == 10 ? 'SELECTED' : ''); ?>><?php echo $LANG['REVIEWED'] ?></option>
+									<option value="0"><?= $LANG['NOT_REVIEWED'] ?></option>
+									<option value="5" <?= ($reviewStatus == 5 ? 'SELECTED' : '') ?>><?= $LANG['EXPERT_NEEDED'] ?></option>
+									<option value="10" <?= ($reviewStatus == 10 ? 'SELECTED' : '') ?>><?= $LANG['REVIEWED'] ?></option>
 								</select>
 							</div>
 							<div>
 								<select name="sourcefilter">
-									<option value=""><?php echo $LANG['ALL_SOURCE_TYPE'] ?></option>
+									<option value=""><?= $LANG['ALL_SOURCE_TYPE'] ?></option>
 									<option value="">-----------------------------</option>
 									<?php
 									$sourceControlArr = $attrManager->getSourceControlledArr();
@@ -391,7 +387,7 @@ if ($traitID) {
 							</div>
 							<div>
 								<select name="localfilter" style="width:250px;">
-									<option value=""><?php echo $LANG['ALL_COUNTRIES_STATES'] ?></option>
+									<option value=""><?= $LANG['ALL_COUNTRIES_STATES'] ?></option>
 									<option value="">-----------------------------</option>
 									<?php
 									$localArr = $attrManager->getLocalFilterOptions();
@@ -402,17 +398,17 @@ if ($traitID) {
 								</select>
 							</div>
 							<div>
-								<input id="taxonfilter" name="taxonfilter" type="text" value="<?php echo ($taxonFilter ? $taxonFilter : 'All Taxa'); ?>" onfocus="taxonFilterFocus(this)" />
-								<input id="tidfilter" name="tidfilter" type="hidden" value="<?php echo $tidFilter; ?>" />
+								<input id="taxonfilter" name="taxonfilter" type="text" value="<?= ($taxonFilter ? $taxonFilter : 'All Taxa') ?>" onfocus="taxonFilterFocus(this)" />
+								<input id="tidfilter" name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
 							</div>
 							<div style="margin:10px;">
-								<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
-								<input id="panex1" name="panex" type="hidden" value="<?php echo $paneX; ?>" />
-								<input id="paney1" name="paney" type="hidden" value="<?php echo $paneY; ?>" />
-								<input id="imgres1" name="imgres" type="hidden" value="<?php echo $imgRes; ?>" />
+								<input name="collid" type="hidden" value="<?= $collid ?>" />
+								<input id="panex1" name="panex" type="hidden" value="<?= $paneX ?>" />
+								<input id="paney1" name="paney" type="hidden" value="<?= $paneY ?>" />
+								<input id="imgres1" name="imgres" type="hidden" value="<?= $imgRes ?>" />
 								<input name="mode" type="hidden" value="2" />
 								<input name="start" type="hidden" value="" />
-								<button name="submitform" type="submit" value="Get Images"><?php echo $LANG['GET_IMAGES'] ?></button>
+								<button name="submitform" type="submit" value="Get Images"><?= $LANG['GET_IMAGES'] ?></button>
 							</div>
 							<div>
 								<?php
@@ -427,9 +423,19 @@ if ($traitID) {
 								}
 								?>
 							</div>
-						</form>
-					</fieldset>
-				<?php
+							<?php
+							if ($isEditor == 2){
+								?>
+								<div style="text-align:center">
+									<hr>
+									<?= $LANG['GO_TO'] ?> <a href="occurattributes.php?collid=<?= $collid?>&mode=1&traitid=<?= $traitID ?>"><?= $LANG['EDIT_MODE'] ?></a>
+								</div>
+								<?php
+							}
+							?>
+						</fieldset>
+					</form>
+					<?php
 				}
 				if ($imgArr) {
 					$traitArr = $attrManager->getTraitArr($traitID, ($mode == 2 ? true : false));
@@ -439,59 +445,56 @@ if ($traitID) {
 						if (isset($stArr['statuscode']) && $stArr['statuscode']) $statusCode = $stArr['statuscode'];
 						if (isset($stArr['notes']) && $stArr['notes']) $notes = $stArr['notes'];
 					}
-				?>
+					?>
 					<div id="traitdiv">
-						<fieldset style="margin-top:20px">
-							<legend><b><?php echo $traitArr[$traitID]['name']; ?></b></legend>
-							<form name="submitform" method="post" action="occurattributes.php" onsubmit="return verifySubmitForm(this)">
+						<form name="submitform" method="post" action="occurattributes.php" onsubmit="return verifySubmitForm(this)">
+							<fieldset style="margin-top:20px">
+								<legend><b><?= $traitArr[$traitID]['name'] ?></b></legend>
 								<div style="float:right;margin-right:10px">
-									<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="<?php echo $LANG['TOGGLE_ATTRI_TREE'] ?>">
+									<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="<?= $LANG['TOGGLE_ATTRI_TREE'] ?>">
 										<img class="triangleright" src="../../images/tochild.png" style="width:1.4em" />
 										<img class="triangledown" src="../../images/toparent.png" style="display:none;width:1.4em" />
 									</div>
 								</div>
-								<div>
-									<?php
-									$attrManager->echoFormTraits($traitID);
-									?>
+								<div><?= $attrManager->echoFormTraits($traitID) ?>
 								</div>
 								<div style="margin:10px 5px;clear:both">
-									<?php echo $LANG['NOTES'] ?>
-									<input name="notes" type="text" style="width:200px" value="<?php echo $notes; ?>" />
+									<?= $LANG['NOTES'] ?>
+									<input name="notes" type="text" style="width:200px" value="<?= $notes ?>" />
 								</div>
 								<div style="margin-left:5;">
-									<?php echo $LANG['STATUS'] ?>
+									<?= $LANG['STATUS'] ?>
 									<select name="setstatus">
 										<?php
 										if ($mode == 2) {
-										?>
-											<option value="0"><?php echo $LANG['NOT_REVIEWED'] ?></option>
-											<option value="5"><?php echo $LANG['EXPERT_NEEDED'] ?></option>
-											<option value="10" selected><?php echo $LANG['REVIEWED'] ?></option>
-										<?php
+											?>
+											<option value="0"><?= $LANG['NOT_REVIEWED'] ?></option>
+											<option value="5"><?= $LANG['EXPERT_NEEDED'] ?></option>
+											<option value="10" selected><?= $LANG['REVIEWED'] ?></option>
+											<?php
 										} else {
-										?>
+											?>
 											<option value="0">---------------</option>
-											<option value="5"><?php echo $LANG['EXPERT_NEEDED'] ?></option>
-										<?php
+											<option value="5"><?= $LANG['EXPERT_NEEDED'] ?></option>
+											<?php
 										}
 										?>
 									</select>
 								</div>
 								<div style="margin:20px">
-									<input name="taxonfilter" type="hidden" value="<?php echo $taxonFilter; ?>" />
-									<input name="tidfilter" type="hidden" value="<?php echo $tidFilter; ?>" />
-									<input name="localfilter" type="hidden" value="<?php echo $localFilter; ?>" />
-									<input name="traitid" type="hidden" value="<?php echo $traitID; ?>" />
-									<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
-									<input id="panex2" name="panex" type="hidden" value="<?php echo $paneX; ?>" />
-									<input id="paney2" name="paney" type="hidden" value="<?php echo $paneY; ?>" />
-									<input id="imgres2" name="imgres" type="hidden" value="<?php echo $imgRes; ?>" />
-									<input name="targetoccid" type="hidden" value="<?php echo $occid; ?>" />
-									<input name="mode" type="hidden" value="<?php echo $mode; ?>" />
-									<input name="reviewuid" type="hidden" value="<?php echo $reviewUid; ?>" />
-									<input name="reviewdate" type="hidden" value="<?php echo $reviewDate; ?>" />
-									<input name="reviewstatus" type="hidden" value="<?php echo $reviewStatus; ?>" />
+									<input name="taxonfilter" type="hidden" value="<?= $taxonFilter ?>" />
+									<input name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
+									<input name="localfilter" type="hidden" value="<?= $localFilter ?>" />
+									<input name="traitid" type="hidden" value="<?= $traitID ?>" />
+									<input name="collid" type="hidden" value="<?= $collid ?>" />
+									<input id="panex2" name="panex" type="hidden" value="<?= $paneX ?>" />
+									<input id="paney2" name="paney" type="hidden" value="<?= $paneY ?>" />
+									<input id="imgres2" name="imgres" type="hidden" value="<?= $imgRes ?>" />
+									<input name="targetoccid" type="hidden" value="<?= $occid ?>" />
+									<input name="mode" type="hidden" value="<?= $mode ?>" />
+									<input name="reviewuid" type="hidden" value="<?= $reviewUid ?>" />
+									<input name="reviewdate" type="hidden" value="<?= $reviewDate ?>" />
+									<input name="reviewstatus" type="hidden" value="<?= $reviewStatus ?>" />
 									<?php
 									if ($mode == 2) {
 										echo '<button name="submitform" type="submit" value="Set Status and Save">' . $LANG['SET_STATUS_SAVE'] . '</button>';
@@ -500,25 +503,25 @@ if ($traitID) {
 									}
 									?>
 								</div>
-							</form>
-						</fieldset>
+							</fieldset>
+						</form>
 					</div>
-				<?php
+					<?php
 				}
 				?>
 			</div>
 			<div style="height:600px">
 				<?php
 				if ($imgArr) {
-				?>
+					?>
 					<div>
-						<span><input id="imgresmed" name="resradio" type="radio" checked onchange="changeImgRes('med')" /><?php echo $LANG['MED_RES'] ?></span>
-						<span style="margin-left:6px;"><input id="imgreslg" name="resradio" type="radio" onchange="changeImgRes('lg')" /><?php echo $LANG['HIGH_RES'] ?></span>
+						<span><input id="imgresmed" name="resradio" type="radio" checked onchange="changeImgRes('med')" /><?= $LANG['MED_RES'] ?></span>
+						<span style="margin-left:6px;"><input id="imgreslg" name="resradio" type="radio" onchange="changeImgRes('lg')" /><?= $LANG['HIGH_RES'] ?></span>
 						<?php
 						if ($occid) {
 							if (!$catNum) $catNum = 'Specimen Details';
 							echo '<span style="margin-left:50px;">';
-							echo '<a href="../individual/index.php?occid=' . htmlspecialchars($occid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '" target="_blank" title= " ' . $LANG['SPECIMEN_DETAILS'] . ' ">' . htmlspecialchars($catNum, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>';
+							echo '<a href="../individual/index.php?occid=' . $occid . '" target="_blank" title= " ' . $LANG['SPECIMEN_DETAILS'] . ' ">' . htmlspecialchars($catNum, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>';
 							echo '</span>';
 						}
 						$imgTotal = count($imgArr);
@@ -536,19 +539,19 @@ if ($traitID) {
 					<?php
 				} else {
 					if ($submitForm) {
-					?>
-						<div style="margin:50px;font-size:120%;font-weight: bold"><?php echo $LANG['NO_IMAGES_MATCHING_CRITERIA'] ?></div>
-					<?php
+						?>
+						<div style="margin:50px;font-size:120%;font-weight: bold"><?= $LANG['NO_IMAGES_MATCHING_CRITERIA'] ?></div>
+						<?php
 					} else {
-					?>
+						?>
 						<div style="margin-top:50px;font-size:120%;font-weight: bold">
-							<?php echo $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] ?>
+							<?= $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] ?>
 						</div>
 						<div style="margin-top:15px;">
-							<?php echo $LANG['TRAIT_TOOL_EXPLAIN'] ?>
-							<a href="https://tools.gbif.org/dwca-validator/extension.do?id=http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact" target="_blank"><?php echo $LANG['MEASUREMENT_OR_FACT'] ?></a> <?php echo $LANG['DWC_EXTEN_FILE'] ?>
+							<?= $LANG['TRAIT_TOOL_EXPLAIN'] ?>
+							<a href="https://tools.gbif.org/dwca-validator/extension.do?id=http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact" target="_blank"><?= $LANG['MEASUREMENT_OR_FACT'] ?></a> <?= $LANG['DWC_EXTEN_FILE'] ?>
 						</div>
-				<?php
+						<?php
 					}
 				}
 				?>
@@ -563,5 +566,4 @@ if ($traitID) {
 	include($SERVER_ROOT . '/includes/footer.php');
 	?>
 </body>
-
 </html>

--- a/collections/traitattr/occurattributes.php
+++ b/collections/traitattr/occurattributes.php
@@ -218,16 +218,15 @@ if ($traitID) {
 	<script src="<?= $CLIENT_ROOT ?>/js/symb/collections.traitattr.js" type="text/javascript"></script>
 	<script src="<?= $CLIENT_ROOT ?>/js/symb/shared.js?ver=1" type="text/javascript"></script>
 	<style>
-		input {
-			margin: 3px
-		}
-
-		select {
-			margin: 3px
-		}
+		.flex-row { display: flex; }
+		.flex-cell { justify-content: space-between }
+		#cell-1 { min-height: 700px; }
+		#cell-2 { width: 290px; }
+		#img-div{ border: 1px solid #ccc; resize: both; min-width: 250px; min-height: 250px; }
+		input { margin: 3px; }
+		select { margin: 3px; }
 	</style>
 </head>
-
 <body>
 	<?php
 	$displayLeftMenu = false;
@@ -257,304 +256,306 @@ if ($traitID) {
 		<?php
 		if ($collid) {
 			?>
-			<div style="float:right;width:290px;">
-				<?php
-				$attrNameArr = $attrManager->getTraitNames();
-				if ($mode == 1) {
-					?>
-					<form id="filterform" name="filterform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
-						<fieldset style="margin-top:25px">
-							<legend><b><?= $LANG['FILTER'] ?></b></legend>
-							<div>
-								<select name="traitid">
-									<option value=""><?= $LANG['SELECT_TRAIT_REQ'] ?></option>
-									<option value="">------------------------------------</option>
-									<?php
-									if ($attrNameArr) {
-										foreach ($attrNameArr as $ID => $aName) {
-											echo '<option value="' . $ID . '" ' . ($traitID == $ID ? 'SELECTED' : '') . '>' . $aName . '</option>';
-										}
-									} else {
-										echo '<option value="0">'.$LANG['NO_ATTRI_AVAILABLE'].'</option>';
-									}
-									?>
-								</select>
+			<div class="flex-row">
+				<div id="cell-1" class="flex-cell">
+					<?php
+					if ($imgArr) {
+						?>
+						<div>
+							<span><input id="imgresmed" name="resradio" type="radio" checked onchange="changeImgRes('med')" /><?= $LANG['MED_RES'] ?></span>
+							<span style="margin-left:6px;"><input id="imgreslg" name="resradio" type="radio" onchange="changeImgRes('lg')" /><?= $LANG['HIGH_RES'] ?></span>
+							<?php
+							if ($occid) {
+								if (!$catNum) $catNum = 'Specimen Details';
+								echo '<span style="margin-left:50px;">';
+								echo '<a href="../individual/index.php?occid=' . $occid . '" target="_blank" title= " ' . $LANG['SPECIMEN_DETAILS'] . ' ">' . htmlspecialchars($catNum, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>';
+								echo '</span>';
+							}
+							$imgTotal = count($imgArr);
+							if ($imgTotal > 1) echo '<span id="labelcnt" style="margin-left:60px;">1</span> of ' . $imgTotal . ' images ' . ($imgTotal > 1 ? '<a href="#" onclick="nextImage()">&gt;&gt; ' . $LANG['NEXT'] . '</a>' : '');
+							if ($occid && $mode != 2) echo '<span style="margin-left:80px" title="' . $LANG['SKIP_SPECIMEN'] . '"><a href="#" onclick="skipSpecimen()">' . $LANG['SKIP'] . ' &gt;&gt;</a></span>';
+							?>
+						</div>
+						<div id="img-div">
+							<?php
+							$url = $imgArr[1]['web'];
+							if (substr($url, 0, 1) == '/') $url = $imgDomain . $url;
+							echo '<img id="specimg" src="' . $url . '" />';
+							?>
+						</div>
+						<?php
+					} else {
+						if ($submitForm) {
+							?>
+							<div style="margin:50px;font-size:120%;font-weight: bold"><?= $LANG['NO_IMAGES_MATCHING_CRITERIA'] ?></div>
+							<?php
+						} else {
+							?>
+							<div style="margin-top:50px;font-size:120%;font-weight: bold">
+								<?= $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] ?>
 							</div>
-							<div>
-								<select name="localfilter" style="width:250px">
-									<option value=""><?= $LANG['ALL_COUNTRIES_STATES'] ?></option>
-									<option value="">-----------------------------</option>
-									<?php
-									$localArr = $attrManager->getLocalFilterOptions();
-									foreach ($localArr as $localTerm) {
-										echo '<option ' . ($localFilter == $localTerm ? 'selected' : '') . '>' . $localTerm . '</option>';
-									}
-									?>
-								</select>
-							</div>
-							<div>
-								<input id="taxonfilter" name="taxonfilter" type="text" value="<?= ($taxonFilter ? $taxonFilter : $LANG['ALL_TAXA']) ?>" taxonFilterFocus(this) />
-								<input id="tidfilter" name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
-							</div>
-							<div>
-								<input name="collid" type="hidden" value="<?= $collid ?>" />
-								<input id="panex1" name="panex" type="hidden" value="<?= $paneX ?>" />
-								<input id="paney1" name="paney" type="hidden" value="<?= $paneY ?>" />
-								<input id="imgres1" name="imgres" type="hidden" value="<?= $imgRes ?>" />
-								<button id="filtersubmit" name="submitform" type="submit" value="Load Images"><?= $LANG['LOAD_IMAGES'] ?></button>
-
-								<span id="verify-span" style="display:none;font-weight:bold;color:green;"><?= $LANG['VERIFY_TAXONOMY'] ?></span>
-								<span id="notvalid-span" style="display:none;font-weight:bold;color:red;"><?= $LANG['TAXON_NOT_VALID'] ?></span>
-							</div>
-							<div style="margin:10px">
-								<?php if ($traitID) echo '<b> ' . $LANG['TARGET_SPECIMEN'] . '</b> ' . $attrManager->getSpecimenCount() ?>
+							<div style="margin-top:15px;">
+								<?= $LANG['TRAIT_TOOL_EXPLAIN'] ?>
+								<a href="https://tools.gbif.org/dwca-validator/extension.do?id=http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact" target="_blank"><?= $LANG['MEASUREMENT_OR_FACT'] ?></a> <?= $LANG['DWC_EXTEN_FILE'] ?>
 							</div>
 							<?php
-							if ($isEditor == 2){
-								?>
-								<div style="text-align:center">
-									<hr>
-									<?= $LANG['GO_TO'] ?> <a href="occurattributes.php?collid=<?= $collid ?>&mode=2&traitid=<?= $traitID ?>"><?= $LANG['REVIEW_MODE'] ?></a>
-								</div>
-								<?php
-							}
-							?>
-						</fieldset>
-					</form>
-					<?php
-				} elseif ($mode == 2) {
-					?>
-					<form id="reviewform" name="reviewform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
-						<fieldset style="margin-top:25px">
-							<legend><b><?= $LANG['REVIEWER'] ?></b></legend>
-							<div>
-								<select name="traitid">
-									<option value=""><?= $LANG['SELECT_TRAIT_REQ'] ?></option>
-									<option value="">------------------------------------</option>
-									<?php
-									if ($attrNameArr) {
-										foreach ($attrNameArr as $ID => $aName) {
-											echo '<option value="' . $ID . '" ' . ($traitID == $ID ? 'SELECTED' : '') . '>' . $aName . '</option>';
-										}
-									} else {
-										echo '<option value="0">' . $LANG['NO_ATTRI_AVAILABLE'] . '</option>';
-									}
-									?>
-								</select>
-							</div>
-							<div>
-								<select name="reviewuid">
-									<option value=""><?= $LANG['ALL_EDITORS'] ?></option>
-									<option value="">-----------------------</option>
-									<?php
-									$editorArr = $attrManager->getEditorArr();
-									foreach ($editorArr as $uid => $name) {
-										echo '<option value="' . $uid . '" ' . ($uid == $reviewUid ? 'SELECTED' : '') . '>' . $name . '</option>';
-									}
-									?>
-								</select>
-							</div>
-							<div>
-								<select name="reviewdate">
-									<option value=""><?= $LANG['ALL_DATES'] ?></option>
-									<option value="">-----------------------</option>
-									<?php
-									$dateArr = $attrManager->getEditDates();
-									foreach ($dateArr as $date) {
-										echo '<option ' . ($date == $reviewDate ? 'SELECTED' : '') . '>' . $date . '</option>';
-									}
-									?>
-								</select>
-							</div>
-							<div>
-								<select name="reviewstatus">
-									<option value="0"><?= $LANG['NOT_REVIEWED'] ?></option>
-									<option value="5" <?= ($reviewStatus == 5 ? 'SELECTED' : '') ?>><?= $LANG['EXPERT_NEEDED'] ?></option>
-									<option value="10" <?= ($reviewStatus == 10 ? 'SELECTED' : '') ?>><?= $LANG['REVIEWED'] ?></option>
-								</select>
-							</div>
-							<div>
-								<select name="sourcefilter">
-									<option value=""><?= $LANG['ALL_SOURCE_TYPE'] ?></option>
-									<option value="">-----------------------------</option>
-									<?php
-									$sourceControlArr = $attrManager->getSourceControlledArr();
-									foreach ($sourceControlArr as $sourceTerm) {
-										echo '<option ' . ($sourceFilter == $sourceTerm ? 'selected' : '') . '>' . $sourceTerm . '</option>';
-									}
-									?>
-								</select>
-							</div>
-							<div>
-								<select name="localfilter" style="width:250px;">
-									<option value=""><?= $LANG['ALL_COUNTRIES_STATES'] ?></option>
-									<option value="">-----------------------------</option>
-									<?php
-									$localArr = $attrManager->getLocalFilterOptions();
-									foreach ($localArr as $localTerm) {
-										echo '<option ' . ($localFilter == $localTerm ? 'selected' : '') . '>' . $localTerm . '</option>';
-									}
-									?>
-								</select>
-							</div>
-							<div>
-								<input id="taxonfilter" name="taxonfilter" type="text" value="<?= ($taxonFilter ? $taxonFilter : 'All Taxa') ?>" onfocus="taxonFilterFocus(this)" />
-								<input id="tidfilter" name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
-							</div>
-							<div style="margin:10px;">
-								<input name="collid" type="hidden" value="<?= $collid ?>" />
-								<input id="panex1" name="panex" type="hidden" value="<?= $paneX ?>" />
-								<input id="paney1" name="paney" type="hidden" value="<?= $paneY ?>" />
-								<input id="imgres1" name="imgres" type="hidden" value="<?= $imgRes ?>" />
-								<input name="mode" type="hidden" value="2" />
-								<input name="start" type="hidden" value="" />
-								<button name="submitform" type="submit" value="Get Images"><?= $LANG['GET_IMAGES'] ?></button>
-							</div>
-							<div>
-								<?php
-								if ($traitID) {
-									$rCnt = $attrManager->getReviewCount($traitID);
-									echo '<b>' . ($rCnt ? $start + 1 : 0) . ' of ' . $rCnt . ' ' . $LANG['RECORD'] . '</b>';
-									if ($rCnt > 1) {
-										$next = ($start + 1);
-										if ($next >= $rCnt) $next = 0;
-										echo ' (<a href="#" onclick="nextReviewRecord(' . ($next) . ')">' . $LANG['NEXT_RECORD'] . ' &gt;&gt;</a>)';
-									}
-								}
-								?>
-							</div>
-							<?php
-							if ($isEditor == 2){
-								?>
-								<div style="text-align:center">
-									<hr>
-									<?= $LANG['GO_TO'] ?> <a href="occurattributes.php?collid=<?= $collid?>&mode=1&traitid=<?= $traitID ?>"><?= $LANG['EDIT_MODE'] ?></a>
-								</div>
-								<?php
-							}
-							?>
-						</fieldset>
-					</form>
-					<?php
-				}
-				if ($imgArr) {
-					$traitArr = $attrManager->getTraitArr($traitID, ($mode == 2 ? true : false));
-					$statusCode = 0;
-					$notes = '';
-					foreach ($traitArr[$traitID]['states'] as $stArr) {
-						if (isset($stArr['statuscode']) && $stArr['statuscode']) $statusCode = $stArr['statuscode'];
-						if (isset($stArr['notes']) && $stArr['notes']) $notes = $stArr['notes'];
+						}
 					}
 					?>
-					<div id="traitdiv">
-						<form name="submitform" method="post" action="occurattributes.php" onsubmit="return verifySubmitForm(this)">
-							<fieldset style="margin-top:20px">
-								<legend><b><?= $traitArr[$traitID]['name'] ?></b></legend>
-								<div style="float:right;margin-right:10px">
-									<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="<?= $LANG['TOGGLE_ATTRI_TREE'] ?>">
-										<img class="triangleright" src="../../images/tochild.png" style="width:1.4em" />
-										<img class="triangledown" src="../../images/toparent.png" style="display:none;width:1.4em" />
-									</div>
-								</div>
-								<div><?= $attrManager->echoFormTraits($traitID) ?>
-								</div>
-								<div style="margin:10px 5px;clear:both">
-									<?= $LANG['NOTES'] ?>
-									<input name="notes" type="text" style="width:200px" value="<?= $notes ?>" />
-								</div>
-								<div style="margin-left:5;">
-									<?= $LANG['STATUS'] ?>
-									<select name="setstatus">
+				</div>
+				<div  id="cell-2" class="flex-cell">
+					<?php
+					$attrNameArr = $attrManager->getTraitNames();
+					if ($mode == 1) {
+						?>
+						<form id="filterform" name="filterform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
+							<fieldset style="margin-top:25px">
+								<legend><b><?= $LANG['FILTER'] ?></b></legend>
+								<div>
+									<select name="traitid">
+										<option value=""><?= $LANG['SELECT_TRAIT_REQ'] ?></option>
+										<option value="">------------------------------------</option>
 										<?php
-										if ($mode == 2) {
-											?>
-											<option value="0"><?= $LANG['NOT_REVIEWED'] ?></option>
-											<option value="5"><?= $LANG['EXPERT_NEEDED'] ?></option>
-											<option value="10" selected><?= $LANG['REVIEWED'] ?></option>
-											<?php
+										if ($attrNameArr) {
+											foreach ($attrNameArr as $ID => $aName) {
+												echo '<option value="' . $ID . '" ' . ($traitID == $ID ? 'SELECTED' : '') . '>' . $aName . '</option>';
+											}
 										} else {
-											?>
-											<option value="0">---------------</option>
-											<option value="5"><?= $LANG['EXPERT_NEEDED'] ?></option>
-											<?php
+											echo '<option value="0">'.$LANG['NO_ATTRI_AVAILABLE'].'</option>';
 										}
 										?>
 									</select>
 								</div>
-								<div style="margin:20px">
-									<input name="taxonfilter" type="hidden" value="<?= $taxonFilter ?>" />
-									<input name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
-									<input name="localfilter" type="hidden" value="<?= $localFilter ?>" />
-									<input name="traitid" type="hidden" value="<?= $traitID ?>" />
+								<div>
+									<select name="localfilter" style="width:250px">
+										<option value=""><?= $LANG['ALL_COUNTRIES_STATES'] ?></option>
+										<option value="">-----------------------------</option>
+										<?php
+										$localArr = $attrManager->getLocalFilterOptions();
+										foreach ($localArr as $localTerm) {
+											echo '<option ' . ($localFilter == $localTerm ? 'selected' : '') . '>' . $localTerm . '</option>';
+										}
+										?>
+									</select>
+								</div>
+								<div>
+									<input id="taxonfilter" name="taxonfilter" type="text" value="<?= ($taxonFilter ? $taxonFilter : $LANG['ALL_TAXA']) ?>" taxonFilterFocus(this) />
+									<input id="tidfilter" name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
+								</div>
+								<div>
 									<input name="collid" type="hidden" value="<?= $collid ?>" />
-									<input id="panex2" name="panex" type="hidden" value="<?= $paneX ?>" />
-									<input id="paney2" name="paney" type="hidden" value="<?= $paneY ?>" />
-									<input id="imgres2" name="imgres" type="hidden" value="<?= $imgRes ?>" />
-									<input name="targetoccid" type="hidden" value="<?= $occid ?>" />
-									<input name="mode" type="hidden" value="<?= $mode ?>" />
-									<input name="reviewuid" type="hidden" value="<?= $reviewUid ?>" />
-									<input name="reviewdate" type="hidden" value="<?= $reviewDate ?>" />
-									<input name="reviewstatus" type="hidden" value="<?= $reviewStatus ?>" />
+									<input id="panex1" name="panex" type="hidden" value="<?= $paneX ?>" />
+									<input id="paney1" name="paney" type="hidden" value="<?= $paneY ?>" />
+									<input id="imgres1" name="imgres" type="hidden" value="<?= $imgRes ?>" />
+									<button id="filtersubmit" name="submitform" type="submit" value="Load Images"><?= $LANG['LOAD_IMAGES'] ?></button>
+
+									<span id="verify-span" style="display:none;font-weight:bold;color:green;"><?= $LANG['VERIFY_TAXONOMY'] ?></span>
+									<span id="notvalid-span" style="display:none;font-weight:bold;color:red;"><?= $LANG['TAXON_NOT_VALID'] ?></span>
+								</div>
+								<div style="margin:10px">
+									<?php if ($traitID) echo '<b> ' . $LANG['TARGET_SPECIMEN'] . '</b> ' . $attrManager->getSpecimenCount() ?>
+								</div>
+								<?php
+								if ($isEditor == 2){
+									?>
+									<div style="text-align:center">
+										<hr>
+										<?= $LANG['GO_TO'] ?> <a href="occurattributes.php?collid=<?= $collid ?>&mode=2&traitid=<?= $traitID ?>"><?= $LANG['REVIEW_MODE'] ?></a>
+									</div>
 									<?php
-									if ($mode == 2) {
-										echo '<button name="submitform" type="submit" value="Set Status and Save">' . $LANG['SET_STATUS_SAVE'] . '</button>';
-									} else {
-										echo '<button name="submitform" type="submit" value="Save and Next" disabled >' . $LANG['SAVE_NEXT'] . '</button>';
+								}
+								?>
+							</fieldset>
+						</form>
+						<?php
+					} elseif ($mode == 2) {
+						?>
+						<form id="reviewform" name="reviewform" method="post" action="occurattributes.php" onsubmit="return verifyFilterForm(this)">
+							<fieldset style="margin-top:25px">
+								<legend><b><?= $LANG['REVIEWER'] ?></b></legend>
+								<div>
+									<select name="traitid">
+										<option value=""><?= $LANG['SELECT_TRAIT_REQ'] ?></option>
+										<option value="">------------------------------------</option>
+										<?php
+										if ($attrNameArr) {
+											foreach ($attrNameArr as $ID => $aName) {
+												echo '<option value="' . $ID . '" ' . ($traitID == $ID ? 'SELECTED' : '') . '>' . $aName . '</option>';
+											}
+										} else {
+											echo '<option value="0">' . $LANG['NO_ATTRI_AVAILABLE'] . '</option>';
+										}
+										?>
+									</select>
+								</div>
+								<div>
+									<select name="reviewuid">
+										<option value=""><?= $LANG['ALL_EDITORS'] ?></option>
+										<option value="">-----------------------</option>
+										<?php
+										$editorArr = $attrManager->getEditorArr();
+										foreach ($editorArr as $uid => $name) {
+											echo '<option value="' . $uid . '" ' . ($uid == $reviewUid ? 'SELECTED' : '') . '>' . $name . '</option>';
+										}
+										?>
+									</select>
+								</div>
+								<div>
+									<select name="reviewdate">
+										<option value=""><?= $LANG['ALL_DATES'] ?></option>
+										<option value="">-----------------------</option>
+										<?php
+										$dateArr = $attrManager->getEditDates();
+										foreach ($dateArr as $date) {
+											echo '<option ' . ($date == $reviewDate ? 'SELECTED' : '') . '>' . $date . '</option>';
+										}
+										?>
+									</select>
+								</div>
+								<div>
+									<select name="reviewstatus">
+										<option value="0"><?= $LANG['NOT_REVIEWED'] ?></option>
+										<option value="5" <?= ($reviewStatus == 5 ? 'SELECTED' : '') ?>><?= $LANG['EXPERT_NEEDED'] ?></option>
+										<option value="10" <?= ($reviewStatus == 10 ? 'SELECTED' : '') ?>><?= $LANG['REVIEWED'] ?></option>
+									</select>
+								</div>
+								<div>
+									<select name="sourcefilter">
+										<option value=""><?= $LANG['ALL_SOURCE_TYPE'] ?></option>
+										<option value="">-----------------------------</option>
+										<?php
+										$sourceControlArr = $attrManager->getSourceControlledArr();
+										foreach ($sourceControlArr as $sourceTerm) {
+											echo '<option ' . ($sourceFilter == $sourceTerm ? 'selected' : '') . '>' . $sourceTerm . '</option>';
+										}
+										?>
+									</select>
+								</div>
+								<div>
+									<select name="localfilter" style="width:250px;">
+										<option value=""><?= $LANG['ALL_COUNTRIES_STATES'] ?></option>
+										<option value="">-----------------------------</option>
+										<?php
+										$localArr = $attrManager->getLocalFilterOptions();
+										foreach ($localArr as $localTerm) {
+											echo '<option ' . ($localFilter == $localTerm ? 'selected' : '') . '>' . $localTerm . '</option>';
+										}
+										?>
+									</select>
+								</div>
+								<div>
+									<input id="taxonfilter" name="taxonfilter" type="text" value="<?= ($taxonFilter ? $taxonFilter : 'All Taxa') ?>" onfocus="taxonFilterFocus(this)" />
+									<input id="tidfilter" name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
+								</div>
+								<div style="margin:10px;">
+									<input name="collid" type="hidden" value="<?= $collid ?>" />
+									<input id="panex1" name="panex" type="hidden" value="<?= $paneX ?>" />
+									<input id="paney1" name="paney" type="hidden" value="<?= $paneY ?>" />
+									<input id="imgres1" name="imgres" type="hidden" value="<?= $imgRes ?>" />
+									<input name="mode" type="hidden" value="2" />
+									<input name="start" type="hidden" value="" />
+									<button name="submitform" type="submit" value="Get Images"><?= $LANG['GET_IMAGES'] ?></button>
+								</div>
+								<div>
+									<?php
+									if ($traitID) {
+										$rCnt = $attrManager->getReviewCount($traitID);
+										echo '<b>' . ($rCnt ? $start + 1 : 0) . ' of ' . $rCnt . ' ' . $LANG['RECORD'] . '</b>';
+										if ($rCnt > 1) {
+											$next = ($start + 1);
+											if ($next >= $rCnt) $next = 0;
+											echo ' (<a href="#" onclick="nextReviewRecord(' . ($next) . ')">' . $LANG['NEXT_RECORD'] . ' &gt;&gt;</a>)';
+										}
 									}
 									?>
 								</div>
+								<?php
+								if ($isEditor == 2){
+									?>
+									<div style="text-align:center">
+										<hr>
+										<?= $LANG['GO_TO'] ?> <a href="occurattributes.php?collid=<?= $collid?>&mode=1&traitid=<?= $traitID ?>"><?= $LANG['EDIT_MODE'] ?></a>
+									</div>
+									<?php
+								}
+								?>
 							</fieldset>
 						</form>
-					</div>
-					<?php
-				}
-				?>
-			</div>
-			<div style="height:600px">
-				<?php
-				if ($imgArr) {
-					?>
-					<div>
-						<span><input id="imgresmed" name="resradio" type="radio" checked onchange="changeImgRes('med')" /><?= $LANG['MED_RES'] ?></span>
-						<span style="margin-left:6px;"><input id="imgreslg" name="resradio" type="radio" onchange="changeImgRes('lg')" /><?= $LANG['HIGH_RES'] ?></span>
 						<?php
-						if ($occid) {
-							if (!$catNum) $catNum = 'Specimen Details';
-							echo '<span style="margin-left:50px;">';
-							echo '<a href="../individual/index.php?occid=' . $occid . '" target="_blank" title= " ' . $LANG['SPECIMEN_DETAILS'] . ' ">' . htmlspecialchars($catNum, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>';
-							echo '</span>';
+					}
+					if ($imgArr) {
+						$traitArr = $attrManager->getTraitArr($traitID, ($mode == 2 ? true : false));
+						$statusCode = 0;
+						$notes = '';
+						foreach ($traitArr[$traitID]['states'] as $stArr) {
+							if (isset($stArr['statuscode']) && $stArr['statuscode']) $statusCode = $stArr['statuscode'];
+							if (isset($stArr['notes']) && $stArr['notes']) $notes = $stArr['notes'];
 						}
-						$imgTotal = count($imgArr);
-						if ($imgTotal > 1) echo '<span id="labelcnt" style="margin-left:60px;">1</span> of ' . $imgTotal . ' images ' . ($imgTotal > 1 ? '<a href="#" onclick="nextImage()">&gt;&gt; ' . $LANG['NEXT'] . '</a>' : '');
-						if ($occid && $mode != 2) echo '<span style="margin-left:80px" title="' . $LANG['SKIP_SPECIMEN'] . '"><a href="#" onclick="skipSpecimen()">' . $LANG['SKIP'] . ' &gt;&gt;</a></span>';
 						?>
-					</div>
-					<div>
-						<?php
-						$url = $imgArr[1]['web'];
-						if (substr($url, 0, 1) == '/') $url = $imgDomain . $url;
-						echo '<img id="specimg" src="' . $url . '" />';
-						?>
-					</div>
-					<?php
-				} else {
-					if ($submitForm) {
-						?>
-						<div style="margin:50px;font-size:120%;font-weight: bold"><?= $LANG['NO_IMAGES_MATCHING_CRITERIA'] ?></div>
-						<?php
-					} else {
-						?>
-						<div style="margin-top:50px;font-size:120%;font-weight: bold">
-							<?= $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] ?>
-						</div>
-						<div style="margin-top:15px;">
-							<?= $LANG['TRAIT_TOOL_EXPLAIN'] ?>
-							<a href="https://tools.gbif.org/dwca-validator/extension.do?id=http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact" target="_blank"><?= $LANG['MEASUREMENT_OR_FACT'] ?></a> <?= $LANG['DWC_EXTEN_FILE'] ?>
+						<div id="traitdiv">
+							<form name="submitform" method="post" action="occurattributes.php" onsubmit="return verifySubmitForm(this)">
+								<fieldset style="margin-top:20px">
+									<legend><b><?= $traitArr[$traitID]['name'] ?></b></legend>
+									<div style="float:right;margin-right:10px">
+										<div class="trianglediv" style="margin:4px 3px;float:right;cursor:pointer" onclick="setAttributeTree(this)" title="<?= $LANG['TOGGLE_ATTRI_TREE'] ?>">
+											<img class="triangleright" src="../../images/tochild.png" style="width:1.4em" />
+											<img class="triangledown" src="../../images/toparent.png" style="display:none;width:1.4em" />
+										</div>
+									</div>
+									<div><?= $attrManager->echoFormTraits($traitID) ?>
+									</div>
+									<div style="margin:10px 5px;clear:both">
+										<?= $LANG['NOTES'] ?>
+										<input name="notes" type="text" style="width:200px" value="<?= $notes ?>" />
+									</div>
+									<div style="margin-left:5;">
+										<?= $LANG['STATUS'] ?>
+										<select name="setstatus">
+											<?php
+											if ($mode == 2) {
+												?>
+												<option value="0"><?= $LANG['NOT_REVIEWED'] ?></option>
+												<option value="5"><?= $LANG['EXPERT_NEEDED'] ?></option>
+												<option value="10" selected><?= $LANG['REVIEWED'] ?></option>
+												<?php
+											} else {
+												?>
+												<option value="0">---------------</option>
+												<option value="5"><?= $LANG['EXPERT_NEEDED'] ?></option>
+												<?php
+											}
+											?>
+										</select>
+									</div>
+									<div style="margin:20px">
+										<input name="taxonfilter" type="hidden" value="<?= $taxonFilter ?>" />
+										<input name="tidfilter" type="hidden" value="<?= $tidFilter ?>" />
+										<input name="localfilter" type="hidden" value="<?= $localFilter ?>" />
+										<input name="traitid" type="hidden" value="<?= $traitID ?>" />
+										<input name="collid" type="hidden" value="<?= $collid ?>" />
+										<input id="panex2" name="panex" type="hidden" value="<?= $paneX ?>" />
+										<input id="paney2" name="paney" type="hidden" value="<?= $paneY ?>" />
+										<input id="imgres2" name="imgres" type="hidden" value="<?= $imgRes ?>" />
+										<input name="targetoccid" type="hidden" value="<?= $occid ?>" />
+										<input name="mode" type="hidden" value="<?= $mode ?>" />
+										<input name="reviewuid" type="hidden" value="<?= $reviewUid ?>" />
+										<input name="reviewdate" type="hidden" value="<?= $reviewDate ?>" />
+										<input name="reviewstatus" type="hidden" value="<?= $reviewStatus ?>" />
+										<?php
+										if ($mode == 2) {
+											echo '<button name="submitform" type="submit" value="Set Status and Save">' . $LANG['SET_STATUS_SAVE'] . '</button>';
+										} else {
+											echo '<button name="submitform" type="submit" value="Save and Next" disabled >' . $LANG['SAVE_NEXT'] . '</button>';
+										}
+										?>
+									</div>
+								</fieldset>
+							</form>
 						</div>
 						<?php
 					}
-				}
-				?>
+					?>
+				</div>
 			</div>
 		<?php
 		} else {

--- a/content/lang/collections/traitattr/occurattributes.en.php
+++ b/content/lang/collections/traitattr/occurattributes.en.php
@@ -13,17 +13,13 @@ $LANG['SELECT_TRAIT_REQ'] = 'Select Trait (required)';
 $LANG['ALL_COUNTRIES_STATES'] = 'All Counties & All States';
 $LANG['VERIFY_TAXONOMY'] = 'verifying taxonomy...';
 $LANG['TAXON_NOT_VALID']  = 'taxon not valid...';
-$LANG['REVIEW'] = 'review';
 $LANG['REVIEWER'] = 'Reviewer';
 $LANG['ATTRIBUTE_REVIEWER'] = 'Attribute Reviewer';
-$LANG['EDIT'] = 'edit';
 $LANG['ATTRIBUTE_EDITOR'] = 'Attribute Editor';
 $LANG['ALL_EDITORS'] = 'All Editors';
 $LANG['ALL_DATES'] = 'All Dates';
 $LANG['NO_ATTRI_AVAILABLE'] = 'No attributes are available';
-
 $LANG['LOAD_IMAGES'] = 'Load Images';
-
 $LANG['EXPERT_NEEDED'] = 'Expert Needed';
 $LANG['REVIEWED']  = 'Reviewed';
 $LANG['ALL_SOURCE_TYPE'] = 'All Source Types';
@@ -31,39 +27,32 @@ $LANG['GET_IMAGES'] = 'Get Images';
 $LANG['NOTES'] = 'Notes:';
 $LANG['STATUS'] = 'Status:';
 $LANG['NOT_REVIEWED'] = 'Not reviewed';
-
 $LANG['SET_STATUS_SAVE'] = 'Set Status and Save';
 $LANG['SAVE_NEXT'] = 'Save and Next';
 $LANG['MED_RES'] = 'Med Res.';
 $LANG['HIGH_RES'] = 'High Res.';
 $LANG['NO_IMAGES_MATCHING_CRITERIA'] = 'There are no images available matching search criteria';
-
 $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] = 'Select a trait to display images that have not yet been scored';
-
 $LANG['TRAIT_TOOL_EXPLAIN'] = 'This module allows one to code Occurrence Traits from viewing images of the specimen or observation.
-							Upon submitting the filter to the right, images will be displayed randomly for occurrences that have not yet been coded for the selected trait.
-							Coded trait attributes can be downloaded and shared via the Darwin Core (DwC) Archive export and publishing tools.
-							Traits are included within a';
-
+	Upon submitting the filter to the right, images will be displayed randomly for occurrences that have not yet been coded for the selected trait.
+	Coded trait attributes can be downloaded and shared via the Darwin Core (DwC) Archive export and publishing tools. Traits are included within a';
 $LANG['SKIP_SPECIMEN'] = 'Skip Specimen';
-
 $LANG['SPECIMEN_DETAILS'] = 'Specimen Details';
-
 $LANG['MEASUREMENT_OR_FACT'] = 'Measurement Or Fact';
 $LANG['DWC_EXTEN_FILE'] = 'DwC Extension file.';
-
 $LANG['OCC_TRAIT_MUST_SELECTED'] = 'An occurrence trait must be selected';
 $LANG['TAXON_FILTER_NOT_SYNC_THES'] = 'Taxon filter not syncronized with thesaurus';
 $LANG['ERROR_CONNECTION_IDENTIFIER'] = 'ERROR: collection identifier is not set';
-
 $LANG['TARGET_SPECIMEN'] = 'Target Specimens:';
-
+$LANG['GO_TO'] = 'Go to';
+$LANG['REVIEW_MODE'] = 'review mode';
 $LANG['MED_RESOLUTION_IMAGE_NOT_AVAI'] = 'Medium resolution image not available';
 $LANG['LARGE_RESOLUTION_IMAGE_NOT_AVAI'] = 'Large resolution image not available';
-
 $LANG['RECORD'] = 'records';
 $LANG['NEXT_RECORD'] = 'Next record';
+$LANG['EDIT_MODE'] = 'edit mode';
 $LANG['TOGGLE_ATTRI_TREE'] = 'Toggle attribute tree open/close';
 $LANG['NEXT'] = 'next';
 $LANG['SKIP'] = 'SKIP';
 $LANG['ALL_TAXA'] = 'All Taxa';
+?>

--- a/content/lang/collections/traitattr/occurattributes.es.php
+++ b/content/lang/collections/traitattr/occurattributes.es.php
@@ -2,8 +2,7 @@
 /*
 ------------------
 Language: Español (Spanish)
-Translated by: Google Translate
-Date Translated: 2024/01/31
+Translated by: Google Translate (2024/01/31)
 ------------------
 */
 $LANG['OCC_ATTRIBUTE_BATCH_EDIT'] = 'Editor por Lotes de Atributos de Ocurrencia';
@@ -14,21 +13,13 @@ $LANG['SELECT_TRAIT_REQ'] = 'Seleccionar rasgo (obligatorio)';
 $LANG['ALL_COUNTRIES_STATES'] = 'Todos los condados y todos los estados';
 $LANG['VERIFY_TAXONOMY'] = 'verificando taxonomía...';
 $LANG['TAXON_NOT_VALID'] = 'taxón no válido...';
-
-$LANG['REVIEW'] = 'revisión';
-
 $LANG['REVIEWER'] = 'Revisor';
 $LANG['ATTRIBUTE_REVIEWER'] = 'Revisor de atributos';
-
-$LANG['EDIT'] = 'editar';
-
 $LANG['ATTRIBUTE_EDITOR'] = 'Editor de atributos';
 $LANG['ALL_EDITORS'] = 'Todos los editores';
 $LANG['ALL_DATES'] = 'Todas las fechas';
 $LANG['NO_ATTRI_AVAILABLE'] = 'No hay atributos disponibles';
-
 $LANG['LOAD_IMAGES'] = 'Cargar imágenes';
-
 $LANG['EXPERT_NEEDED'] = 'Se necesita experto';
 $LANG['REVIEWED'] = 'Revisado';
 $LANG['ALL_SOURCE_TYPE'] = 'Todos los tipos de fuentes';
@@ -36,39 +27,32 @@ $LANG['GET_IMAGES'] = 'Obtener imágenes';
 $LANG['NOTES'] = 'Notas:';
 $LANG['STATUS'] = 'Estado:';
 $LANG['NOT_REVIEWED'] = 'No revisado';
-
 $LANG['SET_STATUS_SAVE'] = 'Establecer estado y guardar';
 $LANG['SAVE_NEXT'] = 'Guardar y Siguiente';
 $LANG['MED_RES'] = 'Res. Médica';
 $LANG['HIGH_RES'] = 'Alta Res.';
 $LANG['NO_IMAGES_MATCHING_CRITERIA'] = 'No hay imágenes disponibles que coincidan con los criterios de búsqueda';
-
 $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] = 'Seleccione un rasgo para mostrar imágenes que aún no han sido calificadas';
-
 $LANG['TRAIT_TOOL_EXPLAIN'] = 'Este módulo permite codificar rasgos de ocurrencia a partir de la visualización de imágenes del espécimen o de la observación.
-Al enviar el filtro a la derecha, las imágenes se mostrarán aleatoriamente para las ocurrencias que aún no han sido codificadas para el rasgo seleccionado.
-Los atributos de rasgos codificados se pueden descargar y compartir a través de las herramientas de publicación y exportación del archivo Darwin Core (DwC).
-Los rasgos están incluidos dentro de a';
-
+	Al enviar el filtro a la derecha, las imágenes se mostrarán aleatoriamente para las ocurrencias que aún no han sido codificadas para el rasgo seleccionado.
+	Los atributos de rasgos codificados se pueden descargar y compartir a través de las herramientas de publicación y exportación del archivo Darwin Core (DwC). Los rasgos están incluidos dentro de a';
 $LANG['SKIP_SPECIMEN'] = 'Omitir muestra';
-
 $LANG['SPECIMEN_DETAILS'] = 'Detalles de la muestra';
-
 $LANG['MEASUREMENT_OR_FACT'] = 'Medición o hecho';
 $LANG['DWC_EXTEN_FILE'] = 'Archivo de extensión DwC.';
-
 $LANG['OCC_TRAIT_MUST_SELECTED'] = 'Se debe seleccionar un rasgo de ocurrencia';
 $LANG['TAXON_FILTER_NOT_SYNC_THES'] = 'Filtro de taxón no sincronizado con el diccionario de sinónimos';
 $LANG['ERROR_CONNECTION_IDENTIFIER'] = 'ERROR: el identificador de colección no está establecido';
-
 $LANG['TARGET_SPECIMEN'] = 'Especímenes objetivo:';
-
+$LANG['GO_TO'] = 'Ir a';
+$LANG['REVIEW_MODE'] = 'modo de revisión';
 $LANG['MED_RESOLUTION_IMAGE_NOT_AVAI'] = 'Imagen de resolución media no disponible';
 $LANG['LARGE_RESOLUTION_IMAGE_NOT_AVAI'] = 'Imagen de gran resolución no disponible';
-
 $LANG['RECORD'] = 'registros';
 $LANG['NEXT_RECORD'] = 'Siguiente registro';
+$LANG['EDIT_MODE'] = 'modo de edición';
 $LANG['TOGGLE_ATTRI_TREE'] = 'Activar/cerrar árbol de atributos';
 $LANG['NEXT'] = 'siguiente';
 $LANG['SKIP'] = 'SALTAR';
 $LANG['ALL_TAXA'] = 'Todos los taxones';
+?>

--- a/content/lang/collections/traitattr/occurattributes.fr.php
+++ b/content/lang/collections/traitattr/occurattributes.fr.php
@@ -2,8 +2,7 @@
 /*
 ------------------
 Language: Français (French)
-Translated by: Google Translate
-Date Translated: 2024/01/31
+Translated by: Google Translate (2024-01-31)
 ------------------
 */
 $LANG['OCC_ATTRIBUTE_BATCH_EDIT'] = 'Éditeur de Lots d\'Attributs d\'Occurrence';
@@ -14,17 +13,13 @@ $LANG['SELECT_TRAIT_REQ'] = 'Sélectionner un trait (obligatoire)';
 $LANG['ALL_COUNTRIES_STATES'] = 'Tous les comtés et tous les états';
 $LANG['VERIFY_TAXONOMY'] = 'vérification de la taxonomie...';
 $LANG['TAXON_NOT_VALID'] = 'taxon non valide...';
-$LANG['REVIEW'] = 'révision';
 $LANG['REVIEWER'] = 'Réviseur';
 $LANG['ATTRIBUTE_REVIEWER'] = 'Réviseur d\'attributs';
-$LANG['EDIT'] = 'modifier';
 $LANG['ATTRIBUTE_EDITOR'] = 'Éditeur d\'attributs';
 $LANG['ALL_EDITORS'] = 'Tous les éditeurs';
 $LANG['ALL_DATES'] = 'Toutes les dates';
 $LANG['NO_ATTRI_AVAILABLE'] = 'Aucun attribut n\'est disponible';
-
 $LANG['LOAD_IMAGES'] = 'Charger les images';
-
 $LANG['EXPERT_NEEDED'] = 'Expert requis';
 $LANG['REVIEWED'] = 'Révisé';
 $LANG['ALL_SOURCE_TYPE'] = 'Tous les types de sources';
@@ -32,39 +27,32 @@ $LANG['GET_IMAGES'] = 'Obtenir des images';
 $LANG['NOTES'] = 'Remarques :';
 $LANG['STATUS'] = 'Statut :';
 $LANG['NOT_REVIEWED'] = 'Non révisé';
-
 $LANG['SET_STATUS_SAVE'] = 'Définir le statut et enregistrer';
 $LANG['SAVE_NEXT'] = 'Enregistrer et suivant';
 $LANG['MED_RES'] = 'Rés. Med.';
 $LANG['HIGH_RES'] = 'Haute Rés.';
 $LANG['NO_IMAGES_MATCHING_CRITERIA'] = 'Aucune image disponible correspondant aux critères de recherche';
-
 $LANG['SELECT_UNSCORED_IMAGE_TRAIT'] = 'Sélectionnez un trait pour afficher les images qui n\'ont pas encore été notées';
-
 $LANG['TRAIT_TOOL_EXPLAIN'] = 'Ce module permet de coder des traits d\'occurrence à partir de la visualisation d\'images du spécimen ou de l\'observation.
-Lors de la soumission du filtre à droite, les images seront affichées de manière aléatoire pour les occurrences qui n\'ont pas encore été codées pour le trait sélectionné.
-Les attributs de traits codés peuvent être téléchargés et partagés via les outils d\'exportation et de publication des archives Darwin Core (DwC).
-Les traits sont inclus dans a';
-
+	Lors de la soumission du filtre à droite, les images seront affichées de manière aléatoire pour les occurrences qui n\'ont pas encore été codées pour le trait sélectionné.
+	Les attributs de traits codés peuvent être téléchargés et partagés via les outils d\'exportation et de publication des archives Darwin Core (DwC). Les traits sont inclus dans a';
 $LANG['SKIP_SPECIMEN'] = 'Sauter l\'échantillon';
-
 $LANG['SPECIMEN_DETAILS'] = 'Détails du spécimen';
-
 $LANG['MEASUREMENT_OR_FACT'] = 'Mesure ou fait';
 $LANG['DWC_EXTEN_FILE'] = 'Fichier d\'extension DwC.';
-
 $LANG['OCC_TRAIT_MUST_SELECTED'] = 'Un trait d\'occurrence doit être sélectionné';
 $LANG['TAXON_FILTER_NOT_SYNC_THES'] = 'Filtre taxon non synchronisé avec le thésaurus';
 $LANG['ERROR_CONNECTION_IDENTIFIER'] = 'ERREUR : l\'identifiant de collection n\'est pas défini';
-
 $LANG['TARGET_SPECIMEN'] = 'Spécimens cibles:';
-
+$LANG['GO_TO'] = 'Aller à';
+$LANG['REVIEW_MODE'] = 'mode révision';
 $LANG['MED_RESOLUTION_IMAGE_NOT_AVAI'] = 'Image moyenne résolution non disponible';
 $LANG['LARGE_RESOLUTION_IMAGE_NOT_AVAI'] = 'Image en grande résolution non disponible';
-
 $LANG['RECORD'] = 'enregistrements';
 $LANG['NEXT_RECORD'] = 'Enregistrement suivant';
+$LANG['EDIT_MODE'] = 'mode édition';
 $LANG['TOGGLE_ATTRI_TREE'] = 'Basculer l\'ouverture/la fermeture de l\'arborescence des attributs';
 $LANG['NEXT'] = 'suivant';
 $LANG['SKIP'] = 'SAUTER';
 $LANG['ALL_TAXA'] = 'Tous les taxons';
+?>


### PR DESCRIPTION
- Fix SQL bug so that it includes full record set for target trait independent of other traits. Previous SQL was excluding all images that were coded for any trait at all.
- Convert layout to flex flow in order to improve layout of image and filter option panels 
- Increase size of image panel plus additional layout improvements 


Please go to the `Preview` tab and select the appropriate sub-template:

* [Feature or Bugfix](?expand=1&template=feature_or_bugfix.md)
* [Hotfix](?expand=1&template=hotfix.md)
* [General Release](?expand=1&template=general_release.md)