### PR TITLE
Bugfix: Multiple NOT_LIKE conditions should be AND'd together

### DIFF
--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -311,7 +311,7 @@ class DwcArchiverCore extends Manager{
 				} elseif ($cond == 'LIKE') {
 					$sqlFrag .= 'OR (' . $field . ' LIKE "%' . $value . '%") ';
 				} elseif ($cond == 'NOT_LIKE') {
-					$sqlFrag .= 'OR (' . $field . ' NOT LIKE "%' . $value . '%" OR ' . $field . ' IS NULL) ';
+					$sqlFrag .= 'AND (' . $field . ' NOT LIKE "%' . $value . '%" OR ' . $field . ' IS NULL) ';
 				} elseif ($cond == 'LESS_THAN') {
 					$sqlFrag .= 'OR (' . $field . ' < "' . $value . '") ';
 				} elseif ($cond == 'GREATER_THAN') {


### PR DESCRIPTION
When using custom field criteria on the record search form (e.g. from the collections/editor/occurrencetabledisplay.php), we noticed that using multiple DOES NOT CONTAIN conditions on the same field would show the correct filtering on the results, but when using the export button, these conditions seemed to be ignored.

I traced this to a bug in the logic in DwcArchiverCore; since these are negative conditions they need to be AND'd. 

I also noticed that there are other limitations in this separate implementation of custom filtering which would result in other unexpeced behavior for certain custom field queries: the `customandor`, `customopenparen`, and `customcloseparen` parameters are not passed to the exporter page, so those will not be obeyed. That isn't addressed by this PR but I wanted to raise the issue. 

Lastly, I'm not really sure how Symbiota distinguishes hotfixes from normal bugfixes, so let me know if this should be based off a different branch.

# Pull Request Checklist:

## Pre-Approval

- [x] Does the PR have a **release-notes-friendly title**?
- [x] There is a **description section** in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the the current `Hotfix-x.x.x` branch and PR'd into the same using the **squash & merge** option.

- [x] All new **text** is preferably **internationalized** (i.e., no end-user-visible text is hard-coded on the PHP pages), and the [spreadsheet tracking internationalizations](https://docs.google.com/spreadsheets/d/133fps9w2pUCEjUA6IGCcQotk7dn9KvepMXJ2IWUZsE8/edit?usp=sharing) has been updated either with a new row or with checkmarks to existing rows.
- [x] There are **no linter errors**
- [x] New features have **responsive design** (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [x] [**Symbiota coding standards**](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] If any files have been reformatted (e.g., by an **autoformatter**), the reformat is its own, **separate commit** in the PR
- [x] Comment which **GitHub issue(s)**, if any does this PR address
- [x] If this PR makes any changes that would require **additional configuration** of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are **detailed in [this document]**(https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)
- [x] If this **feature** has not been **documented** in [https://docs.symbiota.org/](https://docs.symbiota.org/) OR if changes are needed to the documentation, create a new github issue in [https://github.com/Symbiota/Symbiota/issues](https://github.com/Symbiota/Symbiota/issues) **labeled as documentation** and **add a link** to it herein.
- [x] If there are **merge conflicts** with this PR's **parent branch, resolve** them before marking the PR as ready for review.

## Post-Approval

- [ ] It is the code author's responsibility to **merge** their own pull request after it has been approved
- [ ] Remember to use the **squash & merge** option for a merge into the `Hotfix-x.x.x` branch
- [ ] Use the **merge** option (not squashed) for merges from the `hotfix` branch into the `master` branch.
  - [ ] a **subsequent PR from `master`** into `Development` should be made with the **merge** option (i.e., no squash)
  - [ ] **Immediately** **delete the `Hotfix-x.x.x` branch** and create a new `Hotfix-x.x.x+1` branch
  - [ ] **increment** the Symbiota **version** number in the symbase.php file and commit to the `Hotfix-x.x.x+1` branch

Thanks for contributing and keeping it clean!
