### PR TITLE
Fix Loan Specimen removal function

### DIFF
--- a/collections/loans/specimentab.php
+++ b/collections/loans/specimentab.php
@@ -217,9 +217,11 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 		if(mode){
 			hideAll();
 			$(".form-checkbox").css("display", "revert");
+			$('#newdet-fieldset').prop('disabled', false);
 			$('#newdet-div').show();
 		}
 		else{
+			$('#newdet-fieldset').prop('disabled', true);
 			$(".form-checkbox").hide();
 			$('#newdet-div').hide();
 		}
@@ -337,7 +339,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 	<div id="speclist-div" style="<?php echo (!$specList?'display:none;':''); ?>">
 		<form name="speceditform" action="outgoing.php" method="post" onsubmit="return verifySpecEditForm(this)" >
 			<div id="newdet-div" style="display:none;">
-				<fieldset>
+				<fieldset id="newdet-fieldset">
 					<legend><b><?php echo $LANG['ADD_A_DET']; ?></b></legend>
 					<div style='margin:3px;'>
 						<b><?php echo $LANG['ID_QUALIFIER']; ?>:</b>

--- a/collections/loans/specimentab.php
+++ b/collections/loans/specimentab.php
@@ -66,22 +66,6 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 		});
 	}
 
-	function verifyLoanDet(){
-		if(document.getElementById('dafsciname').value == ""){
-			alert("<?php echo $LANG['SCINAME_NEEDS_VALUE']; ?>");
-			return false;
-		}
-		if(document.getElementById('identifiedby').value == ""){
-			alert("<?php echo $LANG['DET_NEEDS_VALUE']; ?>");
-			return false;
-		}
-		if(document.getElementById('dateidentified').value == ""){
-			alert("<?php echo $LANG['DET_DATE_NEEDS_VALUE']; ?>");
-			return false;
-		}
-		return true;
-	}
-
 	function verifySpecEditForm(f){
 		var cbChecked = false;
 		var dbElements = document.getElementsByName("occid[]");
@@ -387,7 +371,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 					</div>
 					<div style='margin:15px;'>
 						<div style="float:left;">
-							<button type="submit" name="formsubmit" value="addDeterminations" onclick="return verifyLoanDet();"><?php echo $LANG['ADD_NEW_DET']; ?></button>
+							<button type="submit" name="formsubmit" value="addDeterminations"><?php echo $LANG['ADD_NEW_DET']; ?></button>
 						</div>
 					</div>
 				</fieldset>

--- a/content/lang/collections/loans/loan_langs.en.php
+++ b/content/lang/collections/loans/loan_langs.en.php
@@ -171,9 +171,6 @@ $LANG['ENVELOPE'] = 'Envelope';
 
 //from specimentab.php
 $LANG['TAXON_NOT_FOUND'] = 'WARNING: Taxon not found. It may be misspelled or needs to be added to taxonomic thesaurus by a taxonomic editor.';
-$LANG['SCINAME_NEEDS_VALUE'] = 'Scientific Name field must have a value';
-$LANG['DET_NEEDS_VALUE'] = "Determiner field must have a value (enter 'unknown' if not defined)";
-$LANG['DET_DATE_NEEDS_VALUE'] = "Determination Date field must have a value (enter 's.d.' if not defined)";
 $LANG['PLS_SEL_SPECIMENS'] = 'Please select specimens to which you wish to apply the action';
 $LANG['PLS_ENTER_CATNO'] = 'Please enter a catalog number!';
 $LANG['ERROR_NO_SPECS'] = 'ERROR: No specimens found with that catalog number';

--- a/content/lang/collections/loans/loan_langs.es.php
+++ b/content/lang/collections/loans/loan_langs.es.php
@@ -171,9 +171,6 @@ $LANG['ENVELOPE'] = 'Sobre';
 
 //from specimentab.php
 $LANG['TAXON_NOT_FOUND'] = 'ADVERTENCIA: Taxón no encontrado. Puede estar mal escrito o necesita ser añadido en el tesauro taxonómico por un editor taxonómico.';
-$LANG['SCINAME_NEEDS_VALUE'] = 'Campo de Nombre Científico debe tener un valor';
-$LANG['DET_NEEDS_VALUE'] = "Campo de Determinador debe tener un valor (añada 'desconocido' si no está definido)";
-$LANG['DET_DATE_NEEDS_VALUE'] = "Campo de Fecha de Determinación debe tener un valor (añada 's.d.' si no está definido)";
 $LANG['PLS_SEL_SPECIMENS'] = 'Por favor seleccione especímenes a los que le gustaría aplicar esta acción';
 $LANG['PLS_ENTER_CATNO'] = '¡Por favor ingrese un número de catálogo!';
 $LANG['ERROR_NO_SPECS'] = 'ERROR: No se encontraron especímenes con ese número de catálogo';

--- a/content/lang/collections/loans/loan_langs.fr.php
+++ b/content/lang/collections/loans/loan_langs.fr.php
@@ -174,9 +174,6 @@ $LANG['ENVELOPE'] = 'Enveloppe';
 
 //from specimentab.php
 $LANG['TAXON_NOT_FOUND'] = 'ATTENTION : Taxon introuvable. Il peut être mal orthographié ou doit être ajouté au thésaurus taxonomique par un éditeur taxonomique.';
-$LANG['SCINAME_NEEDS_VALUE'] = 'Le champ Nom scientifique doit avoir une valeur';
-$LANG['DET_NEEDS_VALUE'] = "Le champ déterminant doit avoir une valeur (entrez 'inconnu' s'il n'est pas défini)";
-$LANG['DET_DATE_NEEDS_VALUE'] = "Le champ Date de détermination doit avoir une valeur (entrez 's.d.' s'il n'est pas défini)";
 $LANG['PLS_SEL_SPECIMENS'] = 'Veuillez sélectionner les spécimens auxquels vous souhaitez appliquer l\'action';
 $LANG['PLS_ENTER_CATNO'] = 'Veuillez saisir un numéro de catalogue !';
 $LANG['ERROR_NO_SPECS'] = 'ERREUR : Aucun spécimen trouvé avec ce numéro de catalogue';


### PR DESCRIPTION
## Description

Disable controls on hidden 'newdet' div to prevent unneccesary  form validation from blocking form submit action. Fixes #3512  

- [x] Does the PR have a **release-notes-friendly title**?
- [x] There is a **description section** in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Hotfixes should be branched off of the the current `Hotfix-x.x.x` branch and PR'd into the same using the **squash & merge** option.
- [x] Comment which **GitHub issue(s)**, if any does this PR address
