### PR TITLE
Hotfix checklist issues

### DIFF
--- a/checklists/checklist.php
+++ b/checklists/checklist.php
@@ -302,7 +302,7 @@ $taxonFilter = htmlspecialchars($taxonFilter, ENT_COMPAT | ENT_HTML401 | ENT_SUB
 				<?php
 			}
 			?>
-			<div style="clear:both">
+			<div style="clear:both; padding-top: 3px">
 				<hr/>
 			</div>
 			<div id="checklist-container" style="display:flex; gap: 0.5rem">

--- a/checklists/checklistadmin.php
+++ b/checklists/checklistadmin.php
@@ -169,7 +169,7 @@ include($SERVER_ROOT.'/includes/header.php');
 	<?php
 	if($statusStr){
 		$statusColor = 'green';
-		if(strpos($statusStr, $LANG['ERROR']) !== false) $statusColor = 'red';
+		if(strpos($statusStr, 'ERR') !== false) $statusColor = 'red';
 		?>
 		<hr />
 		<div style="margin:20px;font-weight:bold;color:<?php echo $statusColor;?>;">

--- a/checklists/checklistadminchildren.php
+++ b/checklists/checklistadminchildren.php
@@ -8,7 +8,7 @@ Language::load('checklists/checklistadminchildren');
 $clid = array_key_exists('clid', $_REQUEST) ? filter_var($_REQUEST['clid'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $pid = array_key_exists('pid', $_REQUEST) ? filter_var($_REQUEST['pid'], FILTER_SANITIZE_NUMBER_INT) : '';
 $targetClid = array_key_exists('targetclid', $_REQUEST) ? filter_var($_REQUEST['targetclid'], FILTER_SANITIZE_NUMBER_INT) : '';
-$transferMethod = array_key_exists('transmethod', $_REQUEST) ? filter_var($_REQUEST['transmethod'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$transferMethod = array_key_exists('transmethod', $_REQUEST) ? filter_var($_REQUEST['transmethod'], FILTER_SANITIZE_NUMBER_INT) : '';
 $parentClid = array_key_exists('parentclid', $_REQUEST) ? filter_var($_REQUEST['parentclid'], FILTER_SANITIZE_NUMBER_INT) : '';
 $targetPid = array_key_exists('targetpid', $_REQUEST) ? filter_var($_REQUEST['targetpid'], FILTER_SANITIZE_NUMBER_INT) : '';
 $copyAttributes = array_key_exists('copyattributes', $_REQUEST) ? filter_var($_REQUEST['copyattributes'], FILTER_SANITIZE_NUMBER_INT) : '';
@@ -34,13 +34,32 @@ $childArr = $clManager->getChildrenChecklist()
 			if(ui.item){
 				$("#parsetid").val(ui.item.id);
 			}
+		},
+		change: function(event, ui){
+			if(!ui.item){
+				$("#parsetid").val("");
+				if(this.value != ""){
+					alert("<?= $LANG['SELECT_FROM_LIST'] ?>");
+				}
+			}
 		}
 	});
+
+	function validateParseChecklistForm(f){
+		if(f.taxon.value != "" && f.parsetid.value == ""){
+			alert("<?= $LANG['SELECT_FROM_LIST'] ?>");
+			return false;
+		}
+		return true;
+	}
 </script>
 <style>
-	.section-div{ margin-bottom: 3px; }
+	.section-div{ margin: 5px 0px; }
 	#taxa{ width:400px }
 	#parsetid{ width:100px }
+	fieldset{ padding: 15px; }
+	legend{ font-weight: bold; }
+	label{ font-weight: bold; }
 	button{ margin:20px; }
 </style>
 <!-- inner text -->
@@ -53,11 +72,11 @@ $childArr = $clManager->getChildrenChecklist()
 		<?= $LANG['CHILD_DESCRIBE'] ?>
 	</div>
 	<div id="addchilddiv" style="margin:15px;display:none;">
-		<fieldset style="padding:15px;">
-			<legend><b><?= $LANG['LINK_NEW'] ?></b></legend>
-			<form name="addchildform" target="checklistadmin.php" method="post" onsubmit="validateAddChildForm(this)">
+		<fieldset>
+			<legend><?= $LANG['LINK_NEW'] ?></legend>
+			<form name="addchildform" target="checklistadmin.php" method="post">
 				<div style="margin:10px;">
-					<select name="clidadd">
+					<select name="clidadd" required>
 						<option value=""><?= $LANG['SELECT_CHILD'] ?></option>
 						<option value="">-------------------------------</option>
 						<?php
@@ -110,100 +129,99 @@ $childArr = $clManager->getChildrenChecklist()
 	if($displayExclusionCreateQucikLink){
 		?>
 		<div style="margin:15px;">
-			<a href="../profile/viewprofile.php?excludeparent=<?= $clid ?>" target="_blank"><?= $LANG['CREATE_EXCLUSION_LIST'] ?></a>
+			<a href="../profile/viewprofile.php?tabindex=1&excludeparent=<?= $clid ?>" target="_blank"><?= $LANG['CREATE_EXCLUSION_LIST'] ?></a>
 		</div>
 		<?php
 	}
 	?>
 	<h2><?= $LANG['PARENTS'] ?></h2>
-		<ul>
-			<?php
-			if($parentArr = $clManager->getParentChecklists()){
-				foreach($parentArr as $k => $name){
-					$k = htmlspecialchars($k, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
-					$name = htmlspecialchars($name, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
-					?>
-					<li>
-						<a href="checklist.php?clid=<?= $k ?>" target="_blank"><?= $name ?></a>
-					</li>
+	<ul>
+		<?php
+		if($parentArr = $clManager->getParentChecklists()){
+			foreach($parentArr as $k => $name){
+				$k = htmlspecialchars($k, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+				$name = htmlspecialchars($name, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+				?>
+				<li>
+					<a href="checklist.php?clid=<?= $k ?>" target="_blank"><?= $name ?></a>
+				</li>
+				<?php
+			}
+		}
+		else{
+			echo '<div style="font-size:110%;">' . $LANG['NO_PARENTS'] . '</div>';
+		}
+		?>
+	</ul>
+</div>
+<hr>
+<div style="margin:20px 0px;">
+	<fieldset>
+		<legend><?= $LANG['BATCH_PARSE_SP_LIST']; ?></legend>
+		<div style="margin:10px 0px 20px 0px; "><?= $LANG['BATCH_PARSE_DESCRIBE']; ?></div>
+		<form name="parsechecklistform" target="checklistadmin.php" method="post" onsubmit="return validateParseChecklistForm(this)">
+			<div class="section-div">
+				<label for="taxon"><?= $LANG['TAXONOMICNODE'] ?>:</label>
+				<input id="taxon" name="taxon" type="text" />
+				<label for="parsetid"><?= $LANG['PARSETID'] ?>:</label>
+				<input id="parsetid" name="parsetid" type="text" >
+			</div>
+			<div class="section-div">
+				<label for="targetclid"><?= $LANG['TARGETCHECKLIST'] ?>:</label>
+				<select name="targetclid" id="targetclid" required>
+					<option value=""><?= $LANG['SELECTTARGETCHECKLIST'] ?></option>
+					<option value="0"><?= $LANG['CREATENEWCHECKLIST'] ?></option>
+					<option value="">--------------------------</option>
 					<?php
-				}
-			}
-			else{
-				echo '<div style="font-size:110%;">' . $LANG['NO_PARENTS'] . '</div>';
-			}
-			?>
-		</ul>
-	</div>
-	<hr>
-	<div style="margin:20px 0px;">
-		<fieldset>
-			<legend><?= $LANG['BATCH_PARSE_SP_LIST']; ?></legend>
-			<div style="margin:10px 0px;"><?= $LANG['BATCH_PARSE_DESCRIBE']; ?></div>
-			<form name="parsechecklistform" target="checklistadmin.php" method="post" onsubmit="validateParseChecklistForm(this)">
-				<div class="section-div">
-					<label for="taxon"><?= $LANG['TAXONOMICNODE'] ?>:</label>
-					<input id="taxon" name="taxon" type="text" required />
-					<label for="parsetid"><?= $LANG['PARSETID'] ?>:</label>
-					<input id="parsetid" name="parsetid" type="text" required >
-				</div>
-				<div class="section-div">
-					<label for="targetclid"><?= $LANG['TARGETCHECKLIST'] ?>:</label>
-					<select name="targetclid" id="targetclid" required>
-						<option value=""><?= $LANG['SELECTTARGETCHECKLIST'] ?></option>
-						<option value="0"><?= $LANG['CREATENEWCHECKLIST'] ?></option>
-						<option value="">--------------------------</option>
-						<?php
-						foreach($clArr as $k => $name){
-							if(!isset($childArr[$k])) echo '<option value="'.$k.'" '.($targetClid == $k?'SELECTED':'').'>'.$name.'</option>';
-						}
-						?>
-					</select>
-				</div>
-				<div class="section-div">
-					<label><?= $LANG['TRANSFER_METHOD'] ?>:</label>
-					<input name="transmethod" id="transtaxa" type="radio" value="0" <?php if(!$transferMethod) echo 'checked'; ?>>
-					<label for="transtaxa"><?= $LANG['TRANSFERTAXA'] ?></label>
-					<input name="transmethod" id="copytaxa" type="radio" value="1" <?php if($transferMethod == 1) echo 'checked'; ?>>
-					<label for="copytaxa"><?= $LANG['COPYTAXA'] ?></label>
-				</div>
-				<div class="section-div">
-					<label><?= $LANG['LINK_PARENT_CHECKLIST'] ?>:</label>
-					<select name="parentclid">
-						<option value=""><?= $LANG['NOPARENTCHECKLIST'] ?></option>
-						<option value="0" <?php if($parentClid === 0) echo 'SELECTED'; ?>><?= $LANG['CREATENEWCHECKLIST'] ?></option>
-						<option value="">--------------------------</option>
-						<?php
-						foreach($clArr as $k => $name){
-							if(!isset($childArr[$k])) echo '<option value="' . $k . '" ' . ($parentClid == $k?'SELECTED':'') . '>' . $name . '</option>';
-						}
-						?>
-					</select>
-				</div>
-				<div class="section-div">
-					<label><?= $LANG['ADD_TO_PROJECT'] ?>:</label>
-					<select name="targetpid">
-						<option value="">--<?= $LANG['NO_ACTION'] ?>--</option>
-						<option value="0"><?= $LANG['NEWPROJECT'] ?></option>
-						<option value="">--------------------------</option>
-						<?php
-						$projArr = $clManager->getUserProjectArr();
-						foreach($projArr as $k => $name){
-							echo '<option value="'.$k.'" '.($targetPid == $k?'SELECTED':'').'>'.$name.'</option>';
-						}
-						?>
-					</select>
-				</div>
-				<div class="section-div">
-					<input name="copyattributes" id="copyattributes" type="checkbox" value="1" <?php if($copyAttributes) echo 'checked'; ?>>
-					<label for="copyattributes"><?= $LANG['COPYPERMISSIONANDGENERAL'] ?></label>
-				</div>
-				<div class="section-div">
-					<input name="tabindex" type="hidden" value="2" >
-					<button name="submitaction" type="submit" value="parseChecklist"><?= $LANG['PARSE_CHECKLIST'] ?></button>
-				</div>
-			</form>
-			<div><a href="<?= $CLIENT_ROOT ?>/taxa/taxonomy/taxonomydisplay.php" target="_blank"><?= $LANG['OPEN_TAX_THES_EXPLORE'] ?></a></div>
-		</fieldset>
-	</div>
+					foreach($clArr as $k => $name){
+						echo '<option value="'.$k.'" '.($targetClid == $k?'SELECTED':'').'>'.$name.'</option>';
+					}
+					?>
+				</select>
+			</div>
+			<div class="section-div">
+				<label for="transtaxa"><?= $LANG['TRANSFER_METHOD'] ?>:</label>
+				<input name="transmethod" id="transtaxa" type="radio" value="0" style="margin-left: 5px" <?php if($transferMethod === 0) echo 'checked'; ?> required>
+				<span><?= $LANG['TRANSFERTAXA'] ?></span>
+				<input name="transmethod" id="copytaxa" type="radio" value="1" style="margin-left: 5px" <?php if($transferMethod == 1) echo 'checked'; ?> required>
+				<span><?= $LANG['COPYTAXA'] ?></span>
+			</div>
+			<div class="section-div">
+				<label for="parentclid"><?= $LANG['LINK_PARENT_CHECKLIST'] ?>:</label>
+				<select name="parentclid" id="parentclid">
+					<option value=""><?= $LANG['NO_PARENT_CHECKLIST'] ?></option>
+					<option value="<?= $clid ?>"><?= $LANG['CURRENT_CHECKLIST'] ?></option>
+					<option value="">--------------------------</option>
+					<?php
+					foreach($clArr as $k => $name){
+						echo '<option value="' . $k . '" ' . ($parentClid == $k?'SELECTED':'') . '>' . $name . '</option>';
+					}
+					?>
+				</select>
+			</div>
+			<div class="section-div">
+				<label for="targetpid"><?= $LANG['ADD_TO_PROJECT'] ?>:</label>
+				<select name="targetpid" id="targetpid">
+					<option value="">--<?= $LANG['NO_ACTION'] ?>--</option>
+					<option value="0"><?= $LANG['NEWPROJECT'] ?></option>
+					<option value="">--------------------------</option>
+					<?php
+					$projArr = $clManager->getUserProjectArr();
+					foreach($projArr as $k => $name){
+						echo '<option value="'.$k.'" '.($targetPid == $k?'SELECTED':'').'>'.$name.'</option>';
+					}
+					?>
+				</select>
+			</div>
+			<div class="section-div">
+				<input name="copyattributes" id="copyattributes" type="checkbox" value="1" <?php if($copyAttributes) echo 'checked'; ?>>
+				<span for="copyattributes"><?= $LANG['COPYPERMISSIONANDGENERAL'] ?></span>
+			</div>
+			<div class="section-div">
+				<input name="tabindex" type="hidden" value="2" >
+				<button name="submitaction" type="submit" value="parseChecklist"><?= $LANG['SUBMIT_FORM'] ?></button>
+			</div>
+		</form>
+		<div><a href="<?= $CLIENT_ROOT ?>/taxa/taxonomy/taxonomydisplay.php" target="_blank"><?= $LANG['OPEN_TAX_THES_EXPLORE'] ?></a></div>
+	</fieldset>
 </div>

--- a/checklists/checklistadminchildren.php
+++ b/checklists/checklistadminchildren.php
@@ -158,7 +158,7 @@ $childArr = $clManager->getChildrenChecklist()
 <div style="margin:20px 0px;">
 	<fieldset>
 		<legend><?= $LANG['BATCH_PARSE_SP_LIST']; ?></legend>
-		<div style="margin:10px 0px 20px 0px; "><?= $LANG['BATCH_PARSE_DESCRIBE']; ?></div>
+		<div style="margin:10px 0px 20px 0px; "><?= $LANG['BATCH_PARSE_DESCRIBE'] ?></div>
 		<form name="parsechecklistform" target="checklistadmin.php" method="post" onsubmit="return validateParseChecklistForm(this)">
 			<div class="section-div">
 				<label for="taxon"><?= $LANG['TAXONOMICNODE'] ?>:</label>

--- a/classes/ChecklistAdmin.php
+++ b/classes/ChecklistAdmin.php
@@ -620,11 +620,11 @@ class ChecklistAdmin extends Manager{
 
 	private function transferTaxa($targetClid, $tidNode){
 		$status = false;
-		$sql = 'UPDATE fmchklsttaxalink SET clid = ? WHERE clid = ?';
+		$sql = 'UPDATE IGNORE fmchklsttaxalink SET clid = ? WHERE clid = ?';
 		$typeStr = 'ii';
 		$paramArr = array($targetClid, $this->clid);
 		if($tidNode){
-			$sql = 'UPDATE fmchklsttaxalink c INNER JOIN taxaenumtree e ON c.tid = e.tid
+			$sql = 'UPDATE IGNORE fmchklsttaxalink c INNER JOIN taxaenumtree e ON c.tid = e.tid
 				SET c.clid = ?
 				WHERE e.taxauthid = 1 AND c.clid = ? AND e.parenttid = ?';
 			$typeStr = 'iii';
@@ -645,14 +645,14 @@ class ChecklistAdmin extends Manager{
 
 	private function copyTaxa($targetClid, $tidNode){
 		$status = false;
-		$sql = 'INSERT INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
+		$sql = 'INSERT IGNORE INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
 			SELECT tid, ?, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties
 			FROM fmchklsttaxalink
 			WHERE clid = ? ';
 		$typeStr = 'ii';
 		$paramArr = array($targetClid, $this->clid);
 		if($tidNode){
-			$sql = 'INSERT INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
+			$sql = 'INSERT IGNORE INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
 				SELECT c.tid, ?, c.morphoSpecies, c.familyOverride, c.habitat, c.abundance, c.notes, c.explicitExclude, c.source, c.nativity, c.endemic, c.invasive, c.internalnotes, c.dynamicProperties
 				FROM fmchklsttaxalink c INNER JOIN taxa t ON c.tid = t.tid
 				INNER JOIN taxaenumtree e ON c.tid = e.tid
@@ -673,7 +673,7 @@ class ChecklistAdmin extends Manager{
 
 		if($status){
 			//Copy voucher links to new checklist (vouchers are automatcially included with transfers, thus no extra action needed)
-			$sql = 'INSERT INTO fmvouchers(clTaxaID, occid, notes)
+			$sql = 'INSERT IGNORE INTO fmvouchers(clTaxaID, occid, notes)
 				SELECT t.clTaxaID, v.occid, v.notes
 				FROM fmchklsttaxalink c INNER JOIN fmvouchers v ON c.clTaxaID = v.clTaxaID
 				INNER JOIN fmchklsttaxalink t ON c.tid = t.tid

--- a/classes/ChecklistAdmin.php
+++ b/classes/ChecklistAdmin.php
@@ -538,98 +538,155 @@ class ChecklistAdmin extends Manager{
 		return $returnArr;
 	}
 
-	public function parseChecklist($tidNode, $taxa, $targetClid, $parentClid, $targetPid, $transferMethod, $copyAttributes){
-		$statusArr = false;
-		if(is_numeric($tidNode)){
-			$inventoryManager = new ImInventories();
-			$fieldArr = array();
-			$clMeta = $this->getMetaData();
-			if($copyAttributes){
-				$extraArr = array('authors','type','locality','publication','abstract','notes','latcentroid','longcentroid','pointradiusmeters','access','defaultsettings','dynamicsql','uid','type','sortsequence');
-				foreach($extraArr as $fieldName){
-					$fieldArr[$fieldName] = $clMeta[$fieldName];
+	public function parseChecklist($tidNode, $taxa, $targetClid, $parentClid, $targetPid, $copyTaxaToTarget, $copyAttributes){
+		$statusArr = array();
+		$inventoryManager = new ImInventories();
+		$fieldArr = array();
+		$clMeta = $this->getMetaData();
+		if($copyAttributes){
+			$extraArr = array('authors','type','locality','publication','abstract','notes','latcentroid','longcentroid','pointradiusmeters','access','defaultsettings','dynamicsql','uid','type','sortsequence');
+			foreach($extraArr as $fieldName){
+				$fieldArr[$fieldName] = $clMeta[$fieldName];
+			}
+		}
+		$clManagerArr = array();
+		if($copyAttributes) $clManagerArr = $inventoryManager->getManagers('ClAdmin', 'fmchecklists', $this->clid);
+		if(!array_key_exists($GLOBALS['SYMB_UID'], $clManagerArr)) $clManagerArr[$GLOBALS['SYMB_UID']] = '';
+		if(!$targetClid){
+			//Create a new checklist that will serve as target checklist
+			$fieldArr['name'] = $clMeta['name'] . ($taxa ? ' - ' . $taxa : '') . ' - Copy';
+			$inventoryManager->insertChecklist($fieldArr);
+			$targetClid = $inventoryManager->getPrimaryKey();
+			if($targetClid){
+				foreach($clManagerArr as $managerUid => $managerArr){
+					$inventoryManager->insertUserRole($managerUid, 'ClAdmin', 'fmchecklists', $targetClid, $GLOBALS['SYMB_UID']);
 				}
 			}
-			$clManagerArr = array();
-			if($copyAttributes) $clManagerArr = $inventoryManager->getManagers('ClAdmin', 'fmchecklists', $this->clid);
-			if(!array_key_exists($GLOBALS['SYMB_UID'], $clManagerArr)) $clManagerArr[$GLOBALS['SYMB_UID']] = '';
-			if(!$targetClid){
-				$fieldArr['name'] = 'Copy ' . $clMeta['name'] . ' - ' . $taxa;
-				$inventoryManager->insertChecklist($fieldArr);
-				$targetClid = $inventoryManager->getPrimaryKey();
-				if($targetClid && $copyAttributes){
-					foreach($clManagerArr as $managerUid => $managerArr){
-						$inventoryManager->insertUserRole($managerUid, 'ClAdmin', 'fmchecklists', $targetClid, $GLOBALS['SYMB_UID']);
+		}
+		if($targetClid && is_numeric($targetClid)){
+			$transerStatus = false;
+			if($copyTaxaToTarget){
+				$transerStatus = $this->copyTaxa($targetClid, $tidNode);
+			}
+			else{
+				$transerStatus = $this->transferTaxa($targetClid, $tidNode);
+			}
+			if($transerStatus){
+				$statusArr['targetClid'] = $targetClid;
+				if($targetPid === '0'){
+					$projectFieldArr = array(
+						'projname' => $clMeta['name'] . ' project',
+						'managers' => $clMeta['authors'],
+						'ispublic' => ($clMeta['access'] == 'private'?0:1));
+					$targetPid = $inventoryManager->insertProject($projectFieldArr);
+					if($targetPid){
+						foreach($clManagerArr as $managerUid => $managerArr){
+							$inventoryManager->insertUserRole($managerUid, 'ProjAdmin', 'fmprojects', $targetPid, $GLOBALS['SYMB_UID']);
+						}
 					}
 				}
-			}
-			if($targetClid && is_numeric($targetClid)){
-				if($this->transferTaxa($targetClid, $tidNode, $transferMethod)){
-					$statusArr['targetClid'] = $targetClid;
-					if($targetPid === '0'){
-						$projectFieldArr = array(
-							'projname' => $clMeta['name'] . ' project',
-							'managers' => $clMeta['authors'],
-							'ispublic' => ($clMeta['access'] == 'private'?0:1));
-						$targetPid = $inventoryManager->insertProject($projectFieldArr);
-						if($targetPid && $copyAttributes){
-							foreach($clManagerArr as $managerUid => $managerArr){
-								$inventoryManager->insertUserRole($managerUid, 'ProjAdmin', 'fmprojects', $targetPid, $GLOBALS['SYMB_UID']);
-							}
+				if($targetPid && is_numeric($targetPid)){
+					$inventoryManager->setPid($targetPid);
+					$inventoryManager->insertChecklistProjectLink($targetClid);
+					$statusArr['targetPid'] = $targetPid;
+				}
+				if($parentClid === '0'){
+					//Create a new parent checklist
+					$fieldArr['name'] = 'Parent: ' . $clMeta['name'];
+					$inventoryManager->insertChecklist($fieldArr);
+					$parentClid = $inventoryManager->getPrimaryKey();
+					if($parentClid){
+						foreach($clManagerArr as $managerUid => $managerArr){
+							$inventoryManager->insertUserRole($managerUid, 'ClAdmin', 'fmchecklists', $parentClid, $GLOBALS['SYMB_UID']);
 						}
 					}
 					if($targetPid && is_numeric($targetPid)){
-						$inventoryManager->setPid($targetPid);
-						$inventoryManager->insertChecklistProjectLink($targetClid);
-						$statusArr['targetPid'] = $targetPid;
-					}
-					if($parentClid === '0'){
-						$fieldArr['name'] = 'Parent: ' . $clMeta['name'];
-						$inventoryManager->insertChecklist($fieldArr);
-						$parentClid = $inventoryManager->getPrimaryKey();
-						if($parentClid && $copyAttributes){
-							foreach($clManagerArr as $managerUid => $managerArr){
-								$inventoryManager->insertUserRole($managerUid, 'ClAdmin', 'fmchecklists', $parentClid, $GLOBALS['SYMB_UID']);
-							}
-						}
-					}
-					if($parentClid && is_numeric($parentClid)){
-						$inventoryManager->setClid($parentClid);
-						$inventoryManager->insertChildChecklist($targetClid, $GLOBALS['SYMB_UID']);
-						if($targetPid && is_numeric($targetPid)){
-							$inventoryManager->insertChecklistProjectLink($parentClid);
-						}
-						$statusArr['parentClid'] = $parentClid;
+						//Link new parent checklist to target project
+						$inventoryManager->insertChecklistProjectLink($parentClid);
 					}
 				}
-				if($copyAttributes  ){
-					$newPManager = new ProfileManager();
-					$newPManager->setUserName($GLOBALS['USERNAME']);
-					$newPManager->authenticate();
+				if($parentClid && is_numeric($parentClid)){
+					$inventoryManager->setClid($parentClid);
+					$inventoryManager->insertChildChecklist($targetClid, $GLOBALS['SYMB_UID']);
+					$statusArr['parentClid'] = $parentClid;
 				}
 			}
+			$newPManager = new ProfileManager();
+			$newPManager->setUserName($GLOBALS['USERNAME']);
+			$newPManager->authenticate();
 		}
 		return $statusArr;
 	}
 
-	private function transferTaxa($targetClid, $tidNode, $transferMethod){
-		$status = true;
-		if($tidNode && is_numeric($tidNode)){
-			$sql = 'UPDATE fmchklsttaxalink c INNER JOIN taxa t ON c.tid = t.tid
-				INNER JOIN taxaenumtree e ON c.tid = e.tid
-				SET c.clid = '.$targetClid.'
-				WHERE e.taxauthid = 1 AND c.clid = '.$this->clid.' AND e.parenttid = '.$tidNode;
-			if($transferMethod){
-				$sql = 'INSERT INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
-					SELECT c.tid, '.$targetClid.', c.morphoSpecies, c.familyOverride, c.habitat, c.abundance, c.notes, c.explicitExclude, c.source,
-					c.nativity, c.endemic, c.invasive, c.internalnotes, c.dynamicProperties
-					FROM fmchklsttaxalink c INNER JOIN taxa t ON c.tid = t.tid
-					INNER JOIN taxaenumtree e ON c.tid = e.tid
-					WHERE e.taxauthid = 1 AND c.clid = '.$this->clid.' AND e.parenttid = '.$tidNode;
+	private function transferTaxa($targetClid, $tidNode){
+		$status = false;
+		$sql = 'UPDATE fmchklsttaxalink SET clid = ? WHERE clid = ?';
+		$typeStr = 'ii';
+		$paramArr = array($targetClid, $this->clid);
+		if($tidNode){
+			$sql = 'UPDATE fmchklsttaxalink c INNER JOIN taxaenumtree e ON c.tid = e.tid
+				SET c.clid = ?
+				WHERE e.taxauthid = 1 AND c.clid = ? AND e.parenttid = ?';
+			$typeStr = 'iii';
+			$paramArr[] = $tidNode;
+		}
+		if($stmt = $this->conn->prepare($sql)){
+			$stmt->bind_param($typeStr, ...$paramArr);
+			if($stmt->execute()){
+				$status = true;
 			}
-			if(!$this->conn->query($sql)){
-				$this->errorMessage = 'ERROR transferring taxa to checklist: '.$this->conn->error;
-				$status = false;
+			else{
+				$this->errorMessage = $stmt->error;
+			}
+			$stmt->close();
+		}
+		return $status;
+	}
+
+	private function copyTaxa($targetClid, $tidNode){
+		$status = false;
+		$sql = 'INSERT INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
+			SELECT tid, ?, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties
+			FROM fmchklsttaxalink
+			WHERE clid = ? ';
+		$typeStr = 'ii';
+		$paramArr = array($targetClid, $this->clid);
+		if($tidNode){
+			$sql = 'INSERT INTO fmchklsttaxalink(tid, clid, morphoSpecies, familyOverride, habitat, abundance, notes, explicitExclude, source, nativity, endemic, invasive, internalnotes, dynamicProperties)
+				SELECT c.tid, ?, c.morphoSpecies, c.familyOverride, c.habitat, c.abundance, c.notes, c.explicitExclude, c.source, c.nativity, c.endemic, c.invasive, c.internalnotes, c.dynamicProperties
+				FROM fmchklsttaxalink c INNER JOIN taxa t ON c.tid = t.tid
+				INNER JOIN taxaenumtree e ON c.tid = e.tid
+				WHERE e.taxauthid = 1 AND c.clid = ? AND e.parenttid = ?';
+			$typeStr = 'iii';
+			$paramArr[] = $tidNode;
+		}
+		if($stmt = $this->conn->prepare($sql)){
+			$stmt->bind_param($typeStr, ...$paramArr);
+			if($stmt->execute()){
+				$status = true;
+			}
+			else{
+				$this->errorMessage = $stmt->error;
+			}
+			$stmt->close();
+		}
+
+		if($status){
+			//Copy voucher links to new checklist (vouchers are automatcially included with transfers, thus no extra action needed)
+			$sql = 'INSERT INTO fmvouchers(clTaxaID, occid, notes)
+				SELECT t.clTaxaID, v.occid, v.notes
+				FROM fmchklsttaxalink c INNER JOIN fmvouchers v ON c.clTaxaID = v.clTaxaID
+				INNER JOIN fmchklsttaxalink t ON c.tid = t.tid
+				WHERE c.clid = ? AND t.clid = ?';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('ii', $this->clid, $targetClid);
+				if($stmt->execute()){
+					$status = true;
+				}
+				else{
+					$this->errorMessage = $stmt->error;
+				}
+				$stmt->close();
 			}
 		}
 		return $status;

--- a/classes/ChecklistManager.php
+++ b/classes/ChecklistManager.php
@@ -783,9 +783,12 @@ class ChecklistManager extends Manager{
 	public function getVoucherCount(){
 		$voucherCnt = 0;
 		if($this->clid){
-			$sql = 'SELECT COUNT(v.occid) as cnt FROM fmchklsttaxalink c INNER JOIN fmvouchers v ON c.clTaxaID = v.clTaxaID WHERE c.clid = ?';
+			$clidStr = $this->clid;
+			if($this->childClidArr){
+				$clidStr .= ','.implode(',',array_keys($this->childClidArr));
+			}
+			$sql = 'SELECT COUNT(v.occid) as cnt FROM fmchklsttaxalink c INNER JOIN fmvouchers v ON c.clTaxaID = v.clTaxaID WHERE c.clid IN(' . $clidStr . ')';
 			if($stmt = $this->conn->prepare($sql)){
-				$stmt->bind_param('i', $this->clid);
 				$stmt->execute();
 				$stmt->bind_result($voucherCnt);
 				$stmt->fetch();

--- a/classes/ImInventories.php
+++ b/classes/ImInventories.php
@@ -738,7 +738,7 @@ class ImInventories extends Manager{
 	public function insertChecklistProjectLink($clid){
 		$status = true;
 		if(is_numeric($clid)){
-			$sql = 'INSERT INTO fmchklstprojlink(pid,clid) VALUES('.$this->pid.', '.$clid.') ';
+			$sql = 'INSERT IGNORE INTO fmchklstprojlink(pid,clid) VALUES('.$this->pid.', '.$clid.') ';
 			if(!$this->conn->query($sql)){
 				$this->errorMessage = 'ERROR adding checklist to project: '.$this->conn->error;
 			}

--- a/content/lang/checklists/checklistadmin.en.php
+++ b/content/lang/checklists/checklistadmin.en.php
@@ -17,7 +17,6 @@ $LANG['TARGET_CHECKLIST'] = 'Target checklist';
 $LANG['PARENT_CHECKLIST'] = 'Parent checklist';
 $LANG['SELECTPROJECT'] = 'Select a project';
 $LANG['RETURNCHECK'] = 'Return to Checklist';
-$LANG['ERROR'] = 'ERROR';
 $LANG['ADMIN'] = 'Admin';
 $LANG['DESCRIPTION'] = 'Description';
 $LANG['RELATEDCHECK'] = 'Related Checklists';

--- a/content/lang/checklists/checklistadmin.es.php
+++ b/content/lang/checklists/checklistadmin.es.php
@@ -20,7 +20,6 @@ $LANG['RETURNCHECK'] = 'Volver al Listado de Comprobación';
 $LANG['ADMIN'] = 'Admin';
 $LANG['DESCRIPTION'] = 'Descripción';
 $LANG['RELATEDCHECK'] = 'Listados de Comprobación Relacionados';
-$LANG['ERROR'] = 'ERROR';
 $LANG['ADDIMGVOUCHER'] = 'Agregar Imágen Voucher';
 $LANG['NOEDITOR'] = 'Nadie ha sido asignado explícitamente como un editor';
 $LANG['ADDNEWUSER'] = 'Agregar Usuario Nuevo';

--- a/content/lang/checklists/checklistadmin.fr.php
+++ b/content/lang/checklists/checklistadmin.fr.php
@@ -17,7 +17,6 @@ $LANG['TARGET_CHECKLIST'] = 'Liste cible';
 $LANG['PARENT_CHECKLIST'] = 'Liste des parents';
 $LANG['SELECTPROJECT'] = 'Sélectionner un Projet';
 $LANG['RETURNCHECK'] = 'Retour &agrave; Liste';
-$LANG['ERREUR'] = 'ERREUR';
 $LANG['ADMIN'] = 'Admin';
 $LANG['DESCRIPTION'] = 'Description';
 $LANG['RELATEDCHECK'] = 'Listes Connexes';

--- a/content/lang/checklists/checklistadminchildren.en.php
+++ b/content/lang/checklists/checklistadminchildren.en.php
@@ -5,10 +5,12 @@ Language: English
 ------------------
 */
 
+
+$LANG['SELECT_FROM_LIST'] = 'You must select a taxon from list (e.g. Taxon ID must not be null)';
 $LANG['CHILD_CHECKLIST'] = 'Children Checklists';
 $LANG['CHILD_DESCRIBE'] = 'Checklists will inherit scientific names, vouchers, notes, etc from all children checklists.
 	Adding a new taxon or voucher to a child checklist will automatically add it to all parent checklists.';
-$LANG['LINK_NEW'] = 'Link New Checklist';
+$LANG['LINK_NEW'] = 'Link Checklist';
 $LANG['SELECT_CHILD'] = 'Select Child Checklist';
 $LANG['ADD_CHILD'] = 'Add Child Checklist';
 $LANG['SURE'] = 'Are you sure you want to remove';
@@ -17,10 +19,10 @@ $LANG['NO_CHILDREN'] = 'There are no Children Checklists';
 $LANG['CREATE_EXCLUSION_LIST'] = 'Create a Species Exclusion List';
 $LANG['PARENTS'] = 'Parent Checklists';
 $LANG['NO_PARENTS'] = 'There are no Parent Checklists';
-$LANG['BATCH_PARSE_SP_LIST'] = 'Batch Parse Species List';
-$LANG['BATCH_PARSE_DESCRIBE'] = 'Use the following tool to parse a list into multiple children checklists based on taxonomic nodes (Liliopsida, Eudicots, Pinopsida, etc)';
+$LANG['BATCH_PARSE_SP_LIST'] = 'Species List Transfer and Parsing Tool';
+$LANG['BATCH_PARSE_DESCRIBE'] = 'Use the following tool to transfer, copy, and parse the current list into multiple child checklists';
 $LANG['TAXONOMICNODE'] = "Sci name";
-$LANG['PARSETID'] = "Taxonomic id";
+$LANG['PARSETID'] = "Taxon ID";
 $LANG['TARGETCHECKLIST'] = "Target checklist";
 $LANG['SELECTTARGETCHECKLIST'] = "Select Target Checklist";
 $LANG['CREATENEWCHECKLIST'] = "Create New Checklist";
@@ -28,12 +30,13 @@ $LANG['TRANSFER_METHOD'] = 'Transfer method';
 $LANG['TRANSFERTAXA'] = "Transfer taxa";
 $LANG['COPYTAXA'] = "Copy taxa";
 $LANG['LINK_PARENT_CHECKLIST'] = 'Link to parent checklist';
-$LANG['NOPARENTCHECKLIST'] = "No Parent Checklist";
+$LANG['NO_PARENT_CHECKLIST'] = "No Parent Checklist";
+$LANG['CURRENT_CHECKLIST'] = 'This Checklist';
 $LANG['ADD_TO_PROJECT'] = 'Add to project';
 $LANG['NO_ACTION'] = 'no action';
 $LANG['NEWPROJECT'] = "New Project";
 $LANG['COPYPERMISSIONANDGENERAL'] = "Copy over permission and general attributes";
-$LANG['PARSE_CHECKLIST'] = 'Parse Checklist';
+$LANG['SUBMIT_FORM'] = 'Submit Form';
 $LANG['OPEN_TAX_THES_EXPLORE'] = 'Open Taxonomic Thesaurus Explorer';
 
 ?>

--- a/content/lang/checklists/checklistadminchildren.en.php
+++ b/content/lang/checklists/checklistadminchildren.en.php
@@ -20,7 +20,8 @@ $LANG['CREATE_EXCLUSION_LIST'] = 'Create a Species Exclusion List';
 $LANG['PARENTS'] = 'Parent Checklists';
 $LANG['NO_PARENTS'] = 'There are no Parent Checklists';
 $LANG['BATCH_PARSE_SP_LIST'] = 'Species List Transfer and Parsing Tool';
-$LANG['BATCH_PARSE_DESCRIBE'] = 'Use the following tool to transfer, copy, and parse the current list into multiple child checklists';
+$LANG['BATCH_PARSE_DESCRIBE'] = 'Use the following tool to transfer, copy, and parse the current list into multiple child checklists.
+	Tool only works from current checklist and will not transfer taxa, vouchers, and properties from child checklists.';
 $LANG['TAXONOMICNODE'] = "Sci name";
 $LANG['PARSETID'] = "Taxon ID";
 $LANG['TARGETCHECKLIST'] = "Target checklist";

--- a/content/lang/checklists/checklistadminchildren.es.php
+++ b/content/lang/checklists/checklistadminchildren.es.php
@@ -2,15 +2,15 @@
 /*
 ------------------
 Language: Español (Spanish)
-Translated by: Samanta Orellana; Google Translate
-Date Translated: 2021-08-05; 2024-02-20
+Translated by: Samanta Orellana (2024-02-20); Google Translate (2021-08-05)
 ------------------
 */
 
+$LANG['SELECT_FROM_LIST'] = 'Debe seleccionar un taxon de la lista (p. ej., el ID del taxón no debe ser nulo)';
 $LANG['CHILD_CHECKLIST'] = 'Listados inferiores';
 $LANG['CHILD_DESCRIBE'] = 'Los listados de especies heredarán nombres científicos, vouchers, notas, etc. de todos los listados inferiores.
 	Añadir un nuevo taxon o voucher a un listado inferior lo añadirá automáticamente  a todos los listados superiores.';
-$LANG['LINK_NEW'] = 'Enlazar nuevo Listado';
+$LANG['LINK_NEW'] = 'Enlazar Listado';
 $LANG['SELECT_CHILD'] = 'Seleccionar Listado Inferior';
 $LANG['ADD_CHILD'] = 'Añadir Listado Inferior';
 $LANG['SURE'] = 'Está seguro que quiere remover el listado';
@@ -19,8 +19,8 @@ $LANG['NO_CHILDREN'] = 'No hay Listados Inferiores';
 $LANG['CREATE_EXCLUSION_LIST'] = 'Create an Exclusion child checklist';
 $LANG['PARENTS'] = 'Listados Superiores';
 $LANG['NO_PARENTS'] = 'No hay Listados Superiores';
-$LANG['BATCH_PARSE_SP_LIST'] = 'Lista de especies de análisis por lotes';
-$LANG['BATCH_PARSE_DESCRIBE'] = 'Utilice la siguiente herramienta para analizar una lista en listas de verificación de múltiples hijos basadas en nodos taxonómicos (Liliopsida, Eudicots, Pinopsida, etc.)';
+$LANG['BATCH_PARSE_SP_LIST'] = 'Herramienta de transferencia y análisis de listas de especies';
+$LANG['BATCH_PARSE_DESCRIBE'] = 'Utilice la siguiente herramienta para transferir, copiar y dividir la lista actual en múltiples sublistas de verificación';
 $LANG['TAXONOMICNODE'] = "Sci name";
 $LANG['PARSETID'] = "Identificación taxonómica";
 $LANG['TARGETCHECKLIST'] = "Lista de verificación de objetivos";
@@ -30,12 +30,13 @@ $LANG['TRANSFER_METHOD'] = 'Método de Transferencia';
 $LANG['TRANSFERTAXA'] = "Transferir taxones";
 $LANG['COPYTAXA'] = "Copiar taxones";
 $LANG['LINK_PARENT_CHECKLIST'] = 'Enlace a la lista de verificación para padres';
-$LANG['NOPARENTCHECKLIST'] = "Sin Lista de Verificación para Padres";
+$LANG['NO_PARENT_CHECKLIST'] = "Sin Lista de Verificación para Padres";
+$LANG['CURRENT_CHECKLIST'] = 'Esta lista de verificación';
 $LANG['ADD_TO_PROJECT'] = 'Agregar al Proyecto';
 $LANG['NO_ACTION'] = 'sin acción';
 $LANG['NEWPROJECT'] = "Nuevo Proyecto";
 $LANG['COPYPERMISSIONANDGENERAL'] = "Copia sobre permiso y atributos generales";
-$LANG['PARSE_CHECKLIST'] = 'Analizar lista de verificación';
+$LANG['SUBMIT_FORM'] = 'Enviar formulario';
 $LANG['OPEN_TAX_THES_EXPLORE'] = 'Abrir Explorador de tesauros taxonómicos';
 
 ?>

--- a/content/lang/checklists/checklistadminchildren.es.php
+++ b/content/lang/checklists/checklistadminchildren.es.php
@@ -20,7 +20,8 @@ $LANG['CREATE_EXCLUSION_LIST'] = 'Create an Exclusion child checklist';
 $LANG['PARENTS'] = 'Listados Superiores';
 $LANG['NO_PARENTS'] = 'No hay Listados Superiores';
 $LANG['BATCH_PARSE_SP_LIST'] = 'Herramienta de transferencia y análisis de listas de especies';
-$LANG['BATCH_PARSE_DESCRIBE'] = 'Utilice la siguiente herramienta para transferir, copiar y dividir la lista actual en múltiples sublistas de verificación';
+$LANG['BATCH_PARSE_DESCRIBE'] = 'Utilice la siguiente herramienta para transferir, copiar y dividir la lista actual en múltiples sublistas de verificación.
+	La herramienta solo opera a partir de la lista de verificación actual y no transferirá taxones, ejemplares de referencia ni propiedades de las listas de verificación secundarias.';
 $LANG['TAXONOMICNODE'] = "Sci name";
 $LANG['PARSETID'] = "Identificación taxonómica";
 $LANG['TARGETCHECKLIST'] = "Lista de verificación de objetivos";

--- a/content/lang/checklists/checklistadminchildren.fr.php
+++ b/content/lang/checklists/checklistadminchildren.fr.php
@@ -20,7 +20,8 @@ $LANG['CREATE_EXCLUSION_LIST'] = 'Create an Exclusion child checklist';
 $LANG['PARENTS'] = 'Listes des Parents';
 $LANG['NO_PARENTS'] = "Il n'y a pas de Liste des Parents";
 $LANG['BATCH_PARSE_SP_LIST'] = "Outil de transfert et d'analyse de listes d'espèces";
-$LANG['BATCH_PARSE_DESCRIBE'] = "Utilisez l'outil suivant pour transférer, copier et découper la liste actuelle en plusieurs sous-listes de contrôle";
+$LANG['BATCH_PARSE_DESCRIBE'] = "Utilisez l'outil suivant pour transférer, copier et découper la liste actuelle en plusieurs sous-listes de contrôle.
+	L'outil ne fonctionne qu'à partir de la liste de contrôle actuelle et ne transférera ni les taxons, ni les spécimens de référence, ni les propriétés issus des listes de contrôle filles.";
 $LANG['TAXONOMICNODE'] = "Nom de la Science";
 $LANG['PARSETID'] = "Identifiant Taxonomique";
 $LANG['TARGETCHECKLIST'] = "Liste des Cibles";

--- a/content/lang/checklists/checklistadminchildren.fr.php
+++ b/content/lang/checklists/checklistadminchildren.fr.php
@@ -2,15 +2,15 @@
 /*
 ------------------
 Language: Français (French)
-Translated by: Google Translate
-Date Translated: 2024-02-20
+Translated by: Google Translate (2024-02-20)
 ------------------
 */
 
+$LANG['SELECT_FROM_LIST'] = "Vous devez sélectionner un taxon dans la liste (par ex. : l'identifiant du taxon ne doit pas être nul)";
 $LANG['CHILD_CHECKLIST'] = "Listes d'Enfants";
 $LANG['CHILD_DESCRIBE'] = "Les listes hériteront des noms scientifiques, des pièces justificatives, des notes, etc. de toutes les Listes d'Enfants.
 	L'ajout d'un nouveau taxon ou d'un bon à une liste enfant l'ajoutera automatiquement à toutes les Listes des Parents.";
-$LANG['LINK_NEW'] = 'Lier une Nouvelle Liste';
+$LANG['LINK_NEW'] = 'Lier une Liste';
 $LANG['SELECT_CHILD'] = "Sélectionner la Liste d'Enfants";
 $LANG['ADD_CHILD'] = "Ajouter une Liste d'Enfants";
 $LANG['SURE'] = 'Êtes-vous sûr de vouloir supprimer';
@@ -19,8 +19,8 @@ $LANG['NO_CHILDREN'] = "Il n'y a pas de Liste d'Enfants";
 $LANG['CREATE_EXCLUSION_LIST'] = 'Create an Exclusion child checklist';
 $LANG['PARENTS'] = 'Listes des Parents';
 $LANG['NO_PARENTS'] = "Il n'y a pas de Liste des Parents";
-$LANG['BATCH_PARSE_SP_LIST'] = 'Liste des espèces analysées par lots';
-$LANG['BATCH_PARSE_DESCRIBE'] = "Utilisez l'outil suivant pour analyser une liste en plusieurs Listes d'Enfants basées sur des nœuds taxonomiques (Liliopsida, Eudicots, Pinopsida, etc.)";
+$LANG['BATCH_PARSE_SP_LIST'] = "Outil de transfert et d'analyse de listes d'espèces";
+$LANG['BATCH_PARSE_DESCRIBE'] = "Utilisez l'outil suivant pour transférer, copier et découper la liste actuelle en plusieurs sous-listes de contrôle";
 $LANG['TAXONOMICNODE'] = "Nom de la Science";
 $LANG['PARSETID'] = "Identifiant Taxonomique";
 $LANG['TARGETCHECKLIST'] = "Liste des Cibles";
@@ -30,12 +30,13 @@ $LANG['TRANSFER_METHOD'] = 'Méthode de transfert';
 $LANG['TRANSFERTAXA'] = "Transférer des taxons";
 $LANG['COPYTAXA'] = "Copier les taxons";
 $LANG['LINK_PARENT_CHECKLIST'] = 'Lien vers la Liste des Parents';
-$LANG['NOPARENTCHECKLIST'] = "Aucune Liste Parentale";
+$LANG['CURRENT_CHECKLIST'] = 'Cette liste de contrôle';
+$LANG['NO_PARENT_CHECKLIST'] = "Aucune Liste Parentale";
 $LANG['ADD_TO_PROJECT'] = 'Ajouter au Projet';
 $LANG['NO_ACTION'] = 'aucune action';
 $LANG['NEWPROJECT'] = "Nouveau Projet";
 $LANG['COPYPERMISSIONANDGENERAL'] = "Copier les autorisations et les attributs généraux";
-$LANG['PARSE_CHECKLIST'] = "Liste d'Analyse";
+$LANG['SUBMIT_FORM'] = 'Soumettre le formulaire';
 $LANG['OPEN_TAX_THES_EXPLORE'] = "Ouvrir l'Explorateur de Thésaurus Taxonomique";
 
 ?>


### PR DESCRIPTION
- Voucher count now includes those from child checklists
- Checklist parser changes
-- Parsing taxon no longer required, thus improving copy/transfer functionality
-- Update wording to include ability to use as a copy/transfer tool
-- Improve Taxon ID (tid) updating and error handling when a taxon is selected, or not. e.g. updates tid when taxon changed or removed, block form submission if taxon is no in thesaurus, etc
-- Allow copy and transfer to child checklists
-- Add function that copies vouchers whenever "copy" is selected as the transfer method
-- Ensure that current user is allows added as a manager, even when copy permission is not select, thus avoiding the creation of orphaned checklists

Resolves issue https://github.com/Symbiota/Symbiota/issues/3524 

Please go to the `Preview` tab and double-click the appropriate sub-template link:

* [Feature or Bugfix](?expand=1&template=feature_or_bugfix.md)
* [Hotfix](?expand=1&template=hotfix.md)
* [General Release](?expand=1&template=general_release.md)