### PR TITLE
Modification to GBIF fix

### DIFF
--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -332,48 +332,48 @@ if ($SYMB_UID) {
 		if ($collid && !$collid == 0){
 			?>
 			<div class="quicksearch-container">
-			<section id="quicksearch-box" class="fieldset-like" >
-				<h3><span><?= $LANG['QUICK_SEARCH'] ?></span></h3>
-				<div id="dialogContainer" style="position: relative;">
-					<form id="quicksearch" name="quicksearch" style="display: flex; align-items:center; gap:0.5rem; flex-wrap: wrap" action="javascript:void(0);" onsubmit="directSubmitAction(event)">
-						<div class="quicksearch-input-container">
+				<section id="quicksearch-box" class="fieldset-like" >
+					<h3><span><?= $LANG['QUICK_SEARCH'] ?></span></h3>
+					<div id="dialogContainer" style="position: relative;">
+						<form id="quicksearch" name="quicksearch" style="display: flex; align-items:center; gap:0.5rem; flex-wrap: wrap" action="javascript:void(0);" onsubmit="directSubmitAction(event)">
+							<div class="quicksearch-input-container">
 								<label style="display:flex; align-items: center; position: relative; margin-right: 1.5rem" for="catalog-number"><?= $LANG['OCCURENCE_IDENTIFIER'] ?>
-						<a href="#" id="q_catalognumberinfo" style="text-decoration:none; position: absolute; right: -1.5rem">
-							<img src="../../images/info.png" style="width:1.3em;" alt="<?= $LANG['MORE_INFO_ALT']; ?>" title="<?= $LANG['MORE_INFO']; ?>" aria-label="<?= $LANG['MORE_INFO']; ?>"/>
-						</a>
+									<a href="#" id="q_catalognumberinfo" style="text-decoration:none; position: absolute; right: -1.5rem">
+										<img src="../../images/info.png" style="width:1.3em;" alt="<?= $LANG['MORE_INFO_ALT']; ?>" title="<?= $LANG['MORE_INFO']; ?>" aria-label="<?= $LANG['MORE_INFO']; ?>"/>
+									</a>
 								</label>
-						<span class="screen-reader-only">
-							<?= $LANG['IDENTIFIER_PLACEHOLDER_LIST'] . ' ' ?>
-						</span>
-						<input style="margin-bottom: 0" name="catalog-number" id="catalog-number" type="text" />
-						<dialog id="dialogEl" aria-live="polite" aria-label="Catalog number search dialog">
-							<?= $LANG['IDENTIFIER_PLACEHOLDER_LIST'] . ' ' ?>
-							<button id="closeDialog" value="search">Close</button>
-						</dialog>
-						</div>
-						<input name="collid" type="hidden" value="<?= $collid; ?>" />
-						<input name="occindex" type="hidden" value="0" />
-						<div class="quicksearch-input-container">
-						<label for="taxon-search"><?= $LANG['TAXON'] ?></label>
-						<input style="margin-bottom: 0" name="taxon-search" id="taxon-search" type="text" />
-						</div>
-						<div id="quicksearch-btn-container" style="display:flex; gap: 0.5rem; flex-grow:1">
-							<?php
-							if($editCode == 1 || $editCode == 2 || $editCode == 3){
-								?>
-								<button type="submit" id="search-by-catalog-number-admin-btn" value="edit">
-									<?= $LANG['OCCURRENCE_EDITOR'] ?>
-								</button>
+								<span class="screen-reader-only">
+									<?= $LANG['IDENTIFIER_PLACEHOLDER_LIST'] . ' ' ?>
+								</span>
+								<input style="margin-bottom: 0" name="catalog-number" id="catalog-number" type="text" />
+								<dialog id="dialogEl" aria-live="polite" aria-label="Catalog number search dialog">
+									<?= $LANG['IDENTIFIER_PLACEHOLDER_LIST'] . ' ' ?>
+									<button id="closeDialog" value="search">Close</button>
+								</dialog>
+							</div>
+							<input name="collid" type="hidden" value="<?= $collid; ?>" />
+							<input name="occindex" type="hidden" value="0" />
+							<div class="quicksearch-input-container">
+								<label for="taxon-search"><?= $LANG['TAXON'] ?></label>
+								<input style="margin-bottom: 0" name="taxon-search" id="taxon-search" type="text" />
+							</div>
+							<div id="quicksearch-btn-container" style="display:flex; gap: 0.5rem; flex-grow:1">
 								<?php
-							}
-							?>
-							<button type="submit" value='search' id="search-by-catalog-number-btn" title="<?= $LANG['IDENTIFIER_PLACEHOLDER_LIST'] ?>">
-								<?= $LANG['SEARCH'] ?>
-							</button>
-						</div>
-					</form>
-				</div>
-			</section>
+								if($editCode == 1 || $editCode == 2 || $editCode == 3){
+									?>
+									<button type="submit" id="search-by-catalog-number-admin-btn" value="edit">
+										<?= $LANG['OCCURRENCE_EDITOR'] ?>
+									</button>
+									<?php
+								}
+								?>
+								<button type="submit" value='search' id="search-by-catalog-number-btn" title="<?= $LANG['IDENTIFIER_PLACEHOLDER_LIST'] ?>">
+									<?= $LANG['SEARCH'] ?>
+								</button>
+							</div>
+						</form>
+					</div>
+				</section>
 			</div>
 		<?php
 		}
@@ -398,8 +398,8 @@ if ($SYMB_UID) {
 				<div style="margin-left: 10px; margin-bottom: 20px;">
 					<a href="https://www.gbif.org/resource/search?contentType=literature&gbifDatasetKey=<?= $datasetKey ?>" target="_blank" style="text-decoration:none;">
 						<span id="gbif-citations">
-							<img src="../../images/gbif-mark-white-logo.svg" alt="GBIF">
-							<span id="gbif-text">GBIF citations</span>
+							<img src="../../images/gbif-mark-white-logo.svg" alt="GBIF logo">
+							<span id="gbif-text"><?= $LANG['GBIF_CITATIONS'] ?></span>
 							<span id="gbif-count"></span>
 						</span>
 					</a>
@@ -1158,7 +1158,6 @@ if ($SYMB_UID) {
 		showDialogLink.addEventListener('click', (e) => {
 			e.preventDefault();
 			dialogEl.showModal();
-
 			dialogContainer.style.position = 'relative';
 			dialogContainer.appendChild(dialogEl);
 

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -210,7 +210,7 @@ if ($SYMB_UID) {
 
 		#gbif-citations{
 			display:inline-flex;
-			height:23.5px;
+			height:24px;
 			font-family:Verdana,Geneva,sans-serif;
 			font-size:13px;
 			color:#fff;

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -113,7 +113,7 @@ if ($SYMB_UID) {
 			}
 		}
 
-		document.addEventListener('DOMContentLoaded', () => {			
+		document.addEventListener('DOMContentLoaded', () => {
 			document.querySelectorAll('.accordion-header').forEach(accordionHeader => {
 				accordionHeader.addEventListener('keydown', (e) => {
 					if (e.key === 'Enter' || e.key === ' ') {
@@ -127,6 +127,32 @@ if ($SYMB_UID) {
 			});
 		});
 
+		<?php
+		if($datasetKey){
+			?>
+			async function loadGbifCount() {
+				const url = 'https://api.gbif.org/v1/literature/search?gbifDatasetKey=<?= $datasetKey ?>&limit=0';
+
+				try {
+					const response = await fetch(url);
+
+					if (!response.ok) {
+						throw new Error(`HTTP error: ${response.status}`);
+					}
+
+					const data = await response.json();
+
+					document.getElementById('gbif-count').textContent = data.count.toLocaleString();
+				} catch (error) {
+					console.error('Error retrieving GBIF count:', error);
+				}
+			}
+
+			// Run when the page loads
+			document.addEventListener('DOMContentLoaded', loadGbifCount);
+			<?php
+		}
+		?>
 	</script>
 	<style>
 		.importItem { margin-left:10px; display:none; }
@@ -180,6 +206,38 @@ if ($SYMB_UID) {
 			width: 100vw;
 			margin-left: calc(50% - 50vw);
 			z-index: 1;
+		}
+
+		#gbif-citations{
+			display:inline-flex;
+			height:23.5px;
+			font-family:Verdana,Geneva,sans-serif;
+			font-size:13px;
+			color:#fff;
+			line-height:24px;
+			border-radius:4px;
+			overflow:hidden;
+			box-shadow: inset 0 -1px 0 rgba(0,0,0,.1);
+		}
+		#gbif-citations img{
+			width:24px;
+			height:24px;
+			background:#396e36;
+			display:flex;
+			align-items:center;
+			justify-content:center;
+		}
+		#gbif-count{
+			background:#26a644;
+			padding:0 8px;
+			font-weight:200;
+			text-shadow: 0 1.25px 0 rgb(32, 129, 53);
+		}
+		#gbif-text{
+			background:#5a5a5a;
+			padding:0 8px;
+			font-weight:175;
+			text-shadow: 0 1.25px 0 rgb(66, 66, 66);
 		}
 
 		@media (max-width: 1424px) {
@@ -336,70 +394,20 @@ if ($SYMB_UID) {
 			echo '<h2 class="page-heading"><span class="screen-reader-only">' . $LANG['COLL_PROF_FOR'] . ':<br></span>' . $collData['collectionname'] . $codeStr . '</h2>';
 			// GBIF citations widget
 			if ($datasetKey) {
-				echo '<div style="margin-left: 10px; margin-bottom: 20px;">';
-				$gbifUrl = "https://api.gbif.org/v1/literature/search?gbifDatasetKey={$datasetKey}&limit=0";
-
-				$ch = curl_init($gbifUrl);
-					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-					curl_setopt($ch, CURLOPT_TIMEOUT_MS, 2500);
-					$response = curl_exec($ch);
-					curl_close($ch);
-
-					$publicationCount = 0;
-
-					if ($response) {
-						$json = json_decode($response, true);
-						$publicationCount = $json['count'] ?? 0;
-					}
-					if ($publicationCount > 0) {
-						echo '
-						<a href="https://www.gbif.org/resource/search?contentType=literature&gbifDatasetKey=' . $datasetKey . '"
-						target="_blank"
-						style="text-decoration:none;">
-							<span style="
-								display:inline-flex;
-								height:23.5px;
-								font-family:Verdana,Geneva,sans-serif;
-								font-size:13px;
-								line-height:24px;
-								border-radius:4px;
-								overflow:hidden;
-								box-shadow: inset 0 -1px 0 rgba(0,0,0,.1);
-								">
-								<span style="
-									width:28px;
-									background:#396e36;
-									display:flex;
-									align-items:center;
-									justify-content:center;
-								">
-									<img src="../../images/gbif-mark-white-logo.svg"
-									alt="GBIF"
-									style="width:22px;height:22px;">
-								</span>
-								<span style="
-									background:#5a5a5a;
-									color:#fff;
-									padding:0 8px;
-									font-weight:175;
-									text-shadow: 0 1.25px 0 rgb(66, 66, 66);
-								">
-									GBIF citations
-								</span>
-								<span style="
-									background:#26a644;
-									color:#fff;
-									padding:0 8px;
-									font-weight:200;
-									text-shadow: 0 1.25px 0 rgb(32, 129, 53);
-								">
-									' . number_format($publicationCount) . '
-								</span>
-							</span>
-						</a>';
-					}
-				echo '<a href="https://bionomia.net/dataset/' . $datasetKey . '"><img src="https://api.bionomia.net/dataset/' . $datasetKey . '/badge.svg" onerror="this.style.display=\'none\'" alt="Bionomia dataset badge" style="width:262px; height:24px; padding-left:10px;"></a>';
-				echo '</div>';
+				?>
+				<div style="margin-left: 10px; margin-bottom: 20px;">
+					<a href="https://www.gbif.org/resource/search?contentType=literature&gbifDatasetKey=<?= $datasetKey ?>" target="_blank" style="text-decoration:none;">
+						<span id="gbif-citations">
+							<img src="../../images/gbif-mark-white-logo.svg" alt="GBIF">
+							<span id="gbif-text">GBIF citations</span>
+							<span id="gbif-count"></span>
+						</span>
+					</a>
+					<a href="https://bionomia.net/dataset/<?= $datasetKey ?>">
+						<img src="https://api.bionomia.net/dataset/<?= $datasetKey ?>/badge.svg" onerror="this.style.display='none'" alt="Bionomia dataset badge" style="width:262px; height:24px; padding-left:10px;">
+					</a>
+				</div>
+				<?php
 			}
 
 			if ($editCode) {
@@ -1155,12 +1163,12 @@ if ($SYMB_UID) {
 			dialogContainer.appendChild(dialogEl);
 
 		});
+
 		document.getElementById('quicksearch').addEventListener('keypress', e => {
 			if (e.key === 'Enter') {
-			e.preventDefault();
-			const editEnabled = <?php echo ($editCode == 1 || $editCode == 2 || $editCode == 3); ?>;
-			const newSubmitObj= {submitter:{value: editEnabled ? 'edit': 'search'}};
-			directSubmitAction(newSubmitObj);
+				e.preventDefault();
+				const newSubmitObj = {submitter:{value: '<?= ($editCode ? 'edit' : 'search') ?>'}};
+				directSubmitAction(newSubmitObj);
 			}
 		});
 

--- a/content/lang/collections/misc/collprofiles.en.php
+++ b/content/lang/collections/misc/collprofiles.en.php
@@ -18,6 +18,7 @@ $LANG['DEACTIVATED'] = 'Deactivated';
 $LANG['DEACTIVATED_MESSAGE'] = 'Certain management options are only available for Live Managed Datasets. Contact portal administrator if collection needs to be reclassified.';
 $LANG['TOGGLE_MAN'] = 'Toggle Manager\'s Control Panel';
 $LANG['COLL_PROF_FOR'] = 'Collection Profile for';
+$LANG['GBIF_CITATIONS'] = 'GBIF citations';
 $LANG['DAT_EDIT'] = 'Data Editor Control Panel';
 $LANG['SUBMIT_IMAGE_V'] = 'Submit a Media Voucher (observation supported by a photo)';
 $LANG['ADD_NEW_OCCUR'] = 'Add New Occurrence Record';

--- a/content/lang/collections/misc/collprofiles.es.php
+++ b/content/lang/collections/misc/collprofiles.es.php
@@ -18,6 +18,7 @@ $LANG['DEACTIVATED'] = 'Desactivado';
 $LANG['DEACTIVATED_MESSAGE'] = 'Ciertas opciones de administración solo están disponibles para conjuntos de datos administrados en vivo. Comuníquese con el administrador del portal si es necesario reclasificar la colección.';
 $LANG['TOGGLE_MAN'] = 'Desplegar Panel de Control';
 $LANG['COLL_PROF_FOR'] = 'Perfil de Colección para';
+$LANG['GBIF_CITATIONS'] = 'Citas de GBIF';
 $LANG['DAT_EDIT'] = 'Panel de control del editor de datos';
 $LANG['SUBMIT_IMAGE_V'] = 'Presentar un Bono Medios (observación respaldada por una foto)';
 $LANG['ADD_NEW_OCCUR'] = 'Agregar nuevo registro de ocurrencias';

--- a/content/lang/collections/misc/collprofiles.fr.php
+++ b/content/lang/collections/misc/collprofiles.fr.php
@@ -18,6 +18,7 @@ $LANG['DEACTIVATED'] = 'Deactivated';
 $LANG['DEACTIVATED_MESSAGE'] = 'Certaines options de gestion ne sont disponibles que pour les ensembles de données gérés en direct. Contactez l\'administrateur du portail si la collection doit être reclassée.';
 $LANG['TOGGLE_MAN'] = 'Basculer Panneau de Configuration du Gestionnaire';
 $LANG['COLL_PROF_FOR'] = 'Profil de Collecte pour';
+$LANG['GBIF_CITATIONS'] = 'Citations du GBIF';
 $LANG['DAT_EDIT'] = 'Panneau de Configuration de l\'Éditeur de Données';
 $LANG['SUBMIT_IMAGE_V'] = 'Soumettre un coupon multimédia (observation appuyée par une photo)';
 $LANG['ADD_NEW_OCCUR'] = 'Ajouter Nouvel Échantillon d\'Occurrence';

--- a/content/lang/collections/misc/collprofiles.pt.php
+++ b/content/lang/collections/misc/collprofiles.pt.php
@@ -18,6 +18,7 @@ $LANG['DEACTIVATED'] = 'Desativado';
 $LANG['DEACTIVATED_MESSAGE'] = 'Certas opções de gerenciamento estão disponíveis apenas para conjuntos de dados gerenciados em tempo real. Entre em contato com o administrador do portal se a coleção precisar ser reclassificada.';
 $LANG['TOGGLE_MAN'] = 'Alternar painel de controle do gerenciador';
 $LANG['COLL_PROF_FOR'] = 'Perfil de coleção para';
+$LANG['GBIF_CITATIONS'] = 'Citações do GBIF';
 $LANG['DAT_EDIT'] = 'Painel de controle do editor de dados';
 $LANG['SUBMIT_IMAGE_V'] = 'Envie um Voucher Multimédia (observação apoiada por fotografia)';
 $LANG['ADD_NEW_OCCUR'] = 'Adicionar novo registro de ocorrência';


### PR DESCRIPTION
- Convert CURL to a AJAX call. The Content Security Policy (CSP) directive that was blocking the iframe method for creating the citation button are typically not applied to APIs, thus supporting an AJAX call to populate the citation count without throwing a CSP error. AJAX is preferred over CURL because it doesn't delay the page load. Whenever the API is not available button will still be displayed, but without the count. 
- Moved styling into a style block within the head to reduce complexity and improve readability of span elements
- Fix bug around line 1162 that was failing to define the editEnabled variable with a value, thus throwing an js error.

