### PR TITLE
adjust media join to have better performance on very large media tables

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -1368,7 +1368,7 @@ class Media {
 		SQL;
 
 		if($with_media) {
-			$sql .= ' LEFT JOIN media m on u.uid = m.creatorUid WHERE m.mediaID IS NOT NULL';
+			$sql .= ' LEFT JOIN media m on u.uid = m.creatorUid WHERE m.creatorUid IS NOT NULL';
 		}
 
 		$sql .= ' ORDER BY u.lastname, u.firstname';

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -1368,7 +1368,7 @@ class Media {
 		SQL;
 
 		if($with_media) {
-			$sql .= ' WHERE u.uid in (select DISTINCT creatorUid from media)';
+			$sql .= ' LEFT JOIN media m on u.uid = m.creatorUid WHERE m.mediaID IS NOT NULL';
 		}
 
 		$sql .= ' ORDER BY u.lastname, u.firstname';


### PR DESCRIPTION
# Problem
The sub query for distinct media was causing a problem due to a high amount of records and sparse data on creatorUid. Rough data was about 18 million media records with only 10 thousand with creators

# Solution
Because the data is sparse moving to the left join with a `where not null` will be sufficient in the short term. Long term solutions would be to start holding counts of media records attached to users so it is a simple lookup or caching the actual output since it does not change much.

Rough estimates of improvement with queries on the data having the issue is from about 6.5 seconds to 0.09 to 0.1 seconds.